### PR TITLE
Release 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "md-viewer"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-viewer"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.80"
 description = "Fast, lightweight markdown viewer for Linux with tabs, file explorer, and live reload"

--- a/data/io.github.aydiler.md-viewer.metainfo.xml
+++ b/data/io.github.aydiler.md-viewer.metainfo.xml
@@ -80,6 +80,18 @@
   </provides>
 
   <releases>
+    <release version="0.1.3" date="2026-05-15">
+      <description>
+        <p>Distribution improvements:</p>
+        <ul>
+          <li>Cross-platform prebuilt binaries (Linux, macOS Intel/arm64, Windows)</li>
+          <li>One-line installer script for Linux and macOS</li>
+          <li>SHA256 checksums on every release artifact</li>
+          <li>AUR package now auto-published from CI</li>
+          <li>Flatpak manifest ready for Flathub submission</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.1.2" date="2026-03-04">
       <description>
         <p>Bug fixes and performance improvements.</p>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: md-viewer
 base: core22
-version: '0.1.2'
+version: '0.1.3'
 summary: Fast, lightweight markdown viewer for Linux
 description: |
   A fast, lightweight markdown viewer built with Rust and egui.


### PR DESCRIPTION
Version bump 0.1.2 → 0.1.3 for the distribution-improvements release (PR #6 just merged).

Touches:
- Cargo.toml + Cargo.lock
- snap/snapcraft.yaml
- data/io.github.aydiler.md-viewer.metainfo.xml (new \<release\> entry)

Once CI is green and this is merged, tagging \`v0.1.3\` from main will fire the full release pipeline: cross-platform binaries, crates.io publish, Snap stable, AUR push, GitHub Release with checksums.