### PR TITLE
Drop macOS Intel from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,6 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             asset_name: linux-x86_64
-          - os: macos-13
-            target: x86_64-apple-darwin
-            asset_name: macos-x86_64
           - os: macos-14
             target: aarch64-apple-darwin
             asset_name: macos-arm64

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Downloads the prebuilt binary for your platform, verifies its SHA256, and instal
 curl -fsSL https://raw.githubusercontent.com/aydiler/md-viewer/main/scripts/install.sh | sh
 ```
 
-Supports Linux x86_64, macOS x86_64, and macOS arm64. Set `INSTALL_DIR=/usr/local/bin` to install elsewhere.
+Supports Linux x86_64 and macOS arm64 (Apple Silicon). Set `INSTALL_DIR=/usr/local/bin` to install elsewhere. Intel Macs need to build from source via `cargo install md-viewer`.
 
 > **macOS Gatekeeper note:** binaries are not yet signed/notarized. If macOS refuses to run the app, run:
 > `xattr -d com.apple.quarantine ~/.local/bin/md-viewer`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,7 +49,7 @@ case "$OS" in
     Darwin)
         case "$ARCH" in
             arm64|aarch64) ASSET_NAME="macos-arm64" ;;
-            x86_64) ASSET_NAME="macos-x86_64" ;;
+            x86_64) err "Intel Macs are not currently built. Build from source: cargo install md-viewer" ;;
             *) err "unsupported macOS architecture: $ARCH" ;;
         esac
         ;;


### PR DESCRIPTION
Hotfix to unblock v0.1.3 release. GitHub macos-13 runners are heavily contended; the previous run sat queued for 24+ min. Apple Silicon is the modern macOS target; Intel Mac users can build from source via cargo. See commit for details.