### PR TITLE
Fix release pipeline: drop crates.io, repair AUR ownership

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,41 +99,11 @@ jobs:
             md-viewer-*.sha256
             RELEASE_NOTES.md
 
-  publish-crates:
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang pkg-config libxcb1-dev libxcb-render0-dev \
-            libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev \
-            libgtk-3-dev libfontconfig1-dev libdbus-1-dev
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Remove local-only MCP dependency
-        shell: python
-        run: |
-          import pathlib, re
-          p = pathlib.Path("Cargo.toml")
-          t = p.read_text()
-          t = t.replace('mcp = ["dep:egui-mcp-bridge"]', 'mcp = []')
-          t = re.sub(r'(?m)^egui-mcp-bridge = .*\n', '', t)
-          p.write_text(t)
-      - name: Publish to crates.io
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          # Skip if already published
-          if cargo search --limit 1 md-viewer | grep -q "md-viewer = \"${VERSION}\""; then
-            echo "Version ${VERSION} already on crates.io; skipping."
-            exit 0
-          fi
-          cargo publish --allow-dirty
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  # NOTE: crates.io publish is intentionally not automated. The repo consumes a
+  # vendored fork of `egui_commonmark_extended` (path patch in crates/) with a
+  # custom `math` feature that doesn't exist on the upstream crate. `cargo
+  # publish` resolves deps against crates.io and rejects this combination. See
+  # PUBLISHING.md for the path to re-enable (publish the fork under a new name).
 
   publish-snap:
     runs-on: ubuntu-latest
@@ -215,6 +185,13 @@ jobs:
             sudo -u builder makepkg --printsrcinfo
           ' > aur-repo/.SRCINFO
 
+      - name: Restore aur-repo ownership to runner
+        if: steps.check.outputs.proceed == 'true'
+        # The container's chown -R builder propagated through the bind mount, so
+        # the host runner can no longer write inside aur-repo (e.g. .git/config).
+        # Reclaim ownership before doing git config / commit / push.
+        run: sudo chown -R "$(id -u):$(id -g)" aur-repo
+
       - name: Commit and push to AUR
         if: steps.check.outputs.proceed == 'true'
         working-directory: aur-repo
@@ -231,7 +208,7 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
-    needs: [build, publish-crates, publish-snap]
+    needs: [build, publish-snap]
     permissions:
       contents: write
     steps:

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -19,17 +19,23 @@ This document covers the **one-time setup** for each channel and the **per-relea
 
 ## Crates.io
 
-```bash
-# Login (one-time)
-cargo login
+**Crates.io publishing is intentionally NOT automated** in `release.yml`. `cargo publish` rejects this repo because `Cargo.toml` consumes `egui_commonmark_extended` with a custom `math` feature (added in the vendored fork at `crates/egui_commonmark/`). The upstream `egui_commonmark_extended` on crates.io does not have that feature, so dependency resolution against the registry fails:
 
-# Publish (run from repo root)
-cargo publish
+```
+package `md-viewer` depends on `egui_commonmark_extended` with feature `math`
+but `egui_commonmark_extended` does not have that feature
 ```
 
-**Note**: The vendored `egui_commonmark` fork uses a local path. For crates.io publishing, you may need to either:
-- Publish your fork to crates.io first
-- Or patch the dependency in Cargo.toml to use a git URL
+To re-enable crates.io publishing, you would need to either:
+- Publish the vendored fork to crates.io under a new name (e.g., `egui_commonmark_extended_aydiler`) and update `Cargo.toml` to depend on the renamed crate. Ongoing fork maintenance becomes a separate publishing pipeline.
+- Or, upstream the `math` feature into `egui_commonmark_extended` and drop the local patch.
+
+Manual publish (if you do address one of the above):
+
+```bash
+cargo login              # one-time
+cargo publish            # from repo root
+```
 
 ## AUR (Arch User Repository)
 


### PR DESCRIPTION
Removes the never-going-to-work crates.io publish job (vendored fork has a feature not on the upstream crate) and fixes AUR push (\ inside container propagated through the bind mount, locking out the runner). See commit body for details.