### PR TITLE
Prep Flatpak manifest for Flathub submission

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -106,8 +106,9 @@ A Flatpak manifest lives at `flatpak/io.github.aydiler.md-viewer.yaml`. Submitti
 
 ### Pre-submission requirements
 
-- **Replace the placeholder icon** at `data/io.github.aydiler.md-viewer.png` with a designed 256×256 PNG. Flathub reviewers will reject submissions whose icon is a generic placeholder.
-- **Regenerate Cargo sources** when `Cargo.lock` changes (Flathub builds offline):
+- **Replace the placeholder icon** at `data/io.github.aydiler.md-viewer.png` with a designed 256×256 PNG (or scalable SVG). Flathub reviewers will reject submissions whose icon is a generic placeholder.
+- **Bump `tag:` and `commit:` in the manifest** to the latest release before opening the PR. The `x-checker-data` block will auto-bump them on subsequent releases *after* the first submission is accepted.
+- **Regenerate Cargo sources** when `Cargo.lock` changes its transitive deps (Flathub builds offline):
   ```bash
   # one-time tool setup
   git clone https://github.com/flatpak/flatpak-builder-tools.git /tmp/fbt
@@ -115,15 +116,26 @@ A Flatpak manifest lives at `flatpak/io.github.aydiler.md-viewer.yaml`. Submitti
       /tmp/fbt/cargo/flatpak-cargo-generator.py Cargo.lock \
       -o flatpak/cargo-sources.json
   ```
-  Commit the updated `flatpak/cargo-sources.json`.
+  Commit the updated `flatpak/cargo-sources.json`. Pure version bumps (without dep changes) don't require regeneration.
+- **Run the Flathub linter and fix all error-level findings**:
+  ```bash
+  # one-time tool install (Arch Linux):
+  sudo pacman -S flatpak-builder
+  flatpak install --user flathub org.flatpak.Builder
+
+  # then:
+  flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest \
+      flatpak/io.github.aydiler.md-viewer.yaml
+  ```
+  Warnings are non-fatal but worth addressing.
 
 ### Local smoke test before submitting
 
 ```bash
 flatpak install --user flathub \
-    org.freedesktop.Platform//23.08 \
-    org.freedesktop.Sdk//23.08 \
-    org.freedesktop.Sdk.Extension.rust-stable//23.08
+    org.freedesktop.Platform//24.08 \
+    org.freedesktop.Sdk//24.08 \
+    org.freedesktop.Sdk.Extension.rust-stable//24.08
 
 flatpak-builder --user --install --force-clean build-dir \
     flatpak/io.github.aydiler.md-viewer.yaml

--- a/docs/devlog/017-flathub-prep.md
+++ b/docs/devlog/017-flathub-prep.md
@@ -1,0 +1,85 @@
+# Feature: Flathub Submission Prep
+
+**Status:** 🚧 In Progress
+**Branch:** `feature/flathub-prep`
+**Date:** 2026-05-15
+**Lines Changed:** TBD
+
+## Summary
+
+Brings the Flatpak manifest from "exists" to "ready for Flathub PR review" by addressing items flagged in the post-v0.1.3 audit against Flathub's published rules (https://docs.flathub.org/docs/for-app-authors/requirements + linter rules). The placeholder icon and the Flathub PR itself stay manual user actions; everything else automatable is done here.
+
+The original manifest in devlog 016 was a first-pass scaffold — runtime was 23.08 (newer cycle exists), sandbox permissions were too broad for a viewer (`--filesystem=home`), and network access was missing (breaks remote-image rendering documented in README).
+
+## Features
+
+- [x] Bump `runtime-version` from 23.08 → 24.08 (latest stable freedesktop cycle on Flathub at time of writing)
+- [x] Replace `--filesystem=home` with `--filesystem=host:ro` (read-only, covers CLI args + live reload + ad-hoc files)
+- [x] Add `--share=network` so HTTP image URLs in markdown render in the sandbox
+- [x] Bump `sources.git.tag` to `v0.1.3` and add `commit:` SHA pin (Flathub linter recommendation)
+- [x] Add `x-checker-data` block keyed off Git tags for automatic version detection on Flathub
+- [x] Update `PUBLISHING.md` Flathub section with lint command, icon-replacement reminder, and tag/commit bump procedure
+- [ ] Replace placeholder icon at `data/io.github.aydiler.md-viewer.png` — **user task**, can't be automated
+- [ ] Run `flatpak-builder-lint` locally before submission — **requires `sudo pacman -S flatpak-builder`**, user must opt in
+- [ ] Open Flathub PR — **user task** (fork flathub/flathub, push manifest + cargo-sources.json, open PR against `new-pr` branch)
+
+## Key Discoveries
+
+### `host:ro` vs `home` is a different shape of broadness, not strictly narrower
+
+`--filesystem=home` is rw access to `$HOME`. `--filesystem=host:ro` is read-only access to the *entire* host filesystem. For a markdown viewer:
+
+- Read-only fits the use case (no writes to user files)
+- Covers CLI invocation `md-viewer ~/notes/foo.md` (path could be anywhere)
+- Covers live reload (file watcher needs read access to the watched path)
+- Covers `xdg-open` style file pickers that may return paths outside `xdg-documents`
+
+Trade-off: `host:ro` exposes `/etc`, `/usr`, etc. to read access — broader *scope* but no write *capability*. Flathub reviewers may push back; defense is "live reload requires open read access to the file path the user picks, and viewers don't mutate user files." Precedent: several markdown editors on Flathub use `--filesystem=host` or `host:ro`.
+
+### `cargo-sources.json` was NOT regenerated for v0.1.3
+
+The version bump 0.1.2 → 0.1.3 only changed `md-viewer`'s own version in `Cargo.lock`. The transitive dependency tree is identical, and `cargo-sources.json` lists only transitive crates (md-viewer itself isn't in there — Flathub fetches it via the git source). No regeneration needed.
+
+If Cargo.lock changes transitive deps in a future release, run:
+
+```bash
+git clone https://github.com/flatpak/flatpak-builder-tools.git /tmp/fbt
+uv run --with aiohttp --with PyYAML --with tomlkit \
+    /tmp/fbt/cargo/flatpak-cargo-generator.py Cargo.lock \
+    -o flatpak/cargo-sources.json
+```
+
+### `x-checker-data` only helps *after* the Flathub PR is accepted
+
+The `x-checker-data` block tells Flathub's update bot to watch for new git tags matching `^v([\d.]+)$`. It does nothing during initial submission — Flathub maintainers still review the first PR manually. After acceptance, future tag pushes auto-create update PRs to the Flathub repo.
+
+## Architecture
+
+### Modified files
+
+| Path | Change |
+|------|--------|
+| `flatpak/io.github.aydiler.md-viewer.yaml` | Runtime bump, finish-args tightened, source pinned to v0.1.3 + SHA, x-checker-data added |
+| `PUBLISHING.md` | Three new bullets in the Flathub submission section |
+
+### No code changes
+
+This is a packaging/metadata change only. No `src/` modifications. No Cargo.toml changes.
+
+## Testing Notes
+
+**Required (done):**
+- `python3 -c "import yaml; yaml.safe_load(open('flatpak/io.github.aydiler.md-viewer.yaml'))"` — parses
+- `appstreamcli validate data/io.github.aydiler.md-viewer.metainfo.xml` — passes (unchanged)
+
+**Optional (requires user to install flatpak-builder via pacman):**
+- `flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest flatpak/io.github.aydiler.md-viewer.yaml` — should be clean (no error-level findings)
+- `flatpak-builder --user --install --force-clean build-dir flatpak/io.github.aydiler.md-viewer.yaml` — should build the app
+- `flatpak run io.github.aydiler.md-viewer README.md` — should open with the placeholder icon visible in the taskbar
+
+## Future Improvements
+
+- [ ] Replace the placeholder icon with a designed PNG/SVG
+- [ ] Once the Flathub PR is accepted, the `x-checker-data` block will auto-bump tag references on each new release — verify it actually fires on the next tag push
+- [ ] Consider tightening `--filesystem=host:ro` to `--filesystem=xdg-documents:ro --filesystem=xdg-download:ro` if Flathub reviewers push back — would break CLI invocation from arbitrary paths and live-reload of files outside those directories
+- [ ] Drop the `cargo-sources.json` regeneration step from the maintainer flow once we have a CI check that compares the file's hash against a re-generation from Cargo.lock

--- a/flatpak/io.github.aydiler.md-viewer.yaml
+++ b/flatpak/io.github.aydiler.md-viewer.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.aydiler.md-viewer
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
@@ -12,10 +12,16 @@ finish-args:
   - --socket=fallback-x11
   - --share=ipc
   - --device=dri
-  # File access (markdown files live in the user's home tree).
-  # Tighten to xdg-documents only if you'd rather have a stricter sandbox,
-  # but most users keep notes outside ~/Documents.
-  - --filesystem=home
+  # Network is needed so HTTP image URLs in markdown render in the sandbox
+  # (the README documents remote-image support, and shields.io badges, etc.).
+  - --share=network
+  # Read-only host access. A viewer never writes to user files, but it must
+  # read files at arbitrary paths: CLI invocation (`md-viewer ~/notes/foo.md`),
+  # live reload via the notify watcher, and files dropped from outside
+  # xdg-documents. Narrower than --filesystem=home in capability (no writes),
+  # broader in scope (also exposes /etc, /usr as readable) — defensible for a
+  # markdown viewer.
+  - --filesystem=host:ro
   - --filesystem=xdg-documents
   # Native file dialogs via portals
   - --talk-name=org.freedesktop.portal.FileChooser
@@ -55,8 +61,15 @@ modules:
     sources:
       - type: git
         url: https://github.com/aydiler/md-viewer.git
-        tag: v0.1.2
+        tag: v0.1.3
+        # Pinning to the tag's commit SHA satisfies Flathub linter and
+        # prevents tag-rewrite drift from changing the build inputs.
+        commit: 43d5efa8b68027df28124401839e86d13b4d1ee2
+        # Tells Flathub's update bot to watch for new tags after merge.
+        x-checker-data:
+          type: git
+          tag-pattern: '^v([\d.]+)$'
       # Pre-resolved Cargo sources (generated with flatpak-cargo-generator.py).
-      # Regenerate when Cargo.lock changes:
+      # Regenerate when Cargo.lock changes its transitive deps:
       #   python3 flatpak-cargo-generator.py Cargo.lock -o flatpak/cargo-sources.json
       - cargo-sources.json


### PR DESCRIPTION
Addresses items from the post-v0.1.3 Flathub-rules audit. See commit body and docs/devlog/017-flathub-prep.md for full rationale. Manifest+docs only, no Rust build affected.