### PR TITLE
Tighten Flatpak finish-args for Flathub linter

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -127,7 +127,7 @@ A Flatpak manifest lives at `flatpak/io.github.aydiler.md-viewer.yaml`. Submitti
   flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest \
       flatpak/io.github.aydiler.md-viewer.yaml
   ```
-  Warnings are non-fatal but worth addressing.
+  Warnings are non-fatal but worth addressing. **One known lint error is intentional**: `finish-args-home-ro-filesystem-access` flags the `--filesystem=home:ro` permission. The viewer needs this to read markdown files at arbitrary paths under `$HOME` for CLI invocation (`md-viewer ~/anywhere/foo.md`) and live reload via the notify watcher. Flathub permits read-only home access with reviewer justification — include a note in the PR description explaining the use case. If reviewers reject it, fall back to `--filesystem=xdg-documents` only and document the CLI/live-reload limitation in the README.
 
 ### Local smoke test before submitting
 

--- a/flatpak/io.github.aydiler.md-viewer.yaml
+++ b/flatpak/io.github.aydiler.md-viewer.yaml
@@ -15,17 +15,16 @@ finish-args:
   # Network is needed so HTTP image URLs in markdown render in the sandbox
   # (the README documents remote-image support, and shields.io badges, etc.).
   - --share=network
-  # Read-only host access. A viewer never writes to user files, but it must
-  # read files at arbitrary paths: CLI invocation (`md-viewer ~/notes/foo.md`),
-  # live reload via the notify watcher, and files dropped from outside
-  # xdg-documents. Narrower than --filesystem=home in capability (no writes),
-  # broader in scope (also exposes /etc, /usr as readable) — defensible for a
-  # markdown viewer.
-  - --filesystem=host:ro
+  # Read-only home access. A viewer never writes user files; it just needs
+  # to read at arbitrary paths under $HOME for CLI invocation
+  # (`md-viewer ~/notes/foo.md`), live reload via the notify watcher, and
+  # files outside xdg-documents. Narrower than --filesystem=host:ro (no
+  # /etc, /usr exposure) which the Flathub linter rejects.
+  - --filesystem=home:ro
   - --filesystem=xdg-documents
-  # Native file dialogs via portals
-  - --talk-name=org.freedesktop.portal.FileChooser
-  - --talk-name=org.freedesktop.portal.Desktop
+  # No --talk-name for XDG portals — Flatpak apps reach FileChooser and
+  # Desktop portals through the standard sandbox mechanism without an
+  # explicit D-Bus talk-name (the linter flags those as unnecessary).
 
 build-options:
   append-path: /usr/lib/sdk/rust-stable/bin


### PR DESCRIPTION
Addresses two flatpak-builder-lint errors uncovered after the flathub-prep PR merged. host:ro narrowed to home:ro; portal talk-name entries removed. One lint error remains intentional (home:ro itself) — Flathub-exception pattern, documented in PUBLISHING.md.