### PR TITLE
Search (Ctrl+F) with inline highlights and precise scroll-to-match

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -14,6 +14,87 @@ use egui_commonmark_backend_extended::misc::*;
 use egui_commonmark_backend_extended::pulldown::*;
 use pulldown_cmark::{CowStr, HeadingLevel};
 
+/// Search-match highlight kind for a single rendered text segment.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+enum HighlightKind {
+    None,
+    Match,
+    Active,
+}
+
+impl HighlightKind {
+    fn background_color(self, ui: &Ui) -> Option<egui::Color32> {
+        let dark = ui.style().visuals.dark_mode;
+        match self {
+            HighlightKind::None => None,
+            HighlightKind::Match => Some(if dark {
+                egui::Color32::from_rgb(102, 92, 46)
+            } else {
+                egui::Color32::from_rgb(255, 229, 127)
+            }),
+            HighlightKind::Active => Some(if dark {
+                egui::Color32::from_rgb(156, 107, 26)
+            } else {
+                egui::Color32::from_rgb(255, 167, 38)
+            }),
+        }
+    }
+}
+
+/// Split `text` (covering `span` in the source) into segments tagged with the
+/// highlight kind that applies to each. Returns at least one segment.
+///
+/// Assumes `text.len() == span.len()` — caller is responsible for that check
+/// (markdown escapes or smart-punct transforms can break it).
+fn compute_highlight_segments(
+    text: &str,
+    span: &Range<usize>,
+    ranges: &[Range<usize>],
+    active: Option<&Range<usize>>,
+) -> Vec<(String, HighlightKind)> {
+    let mut overlaps: Vec<(usize, usize, HighlightKind)> = Vec::new();
+    for r in ranges {
+        let start = r.start.max(span.start);
+        let end = r.end.min(span.end);
+        if start >= end {
+            continue;
+        }
+        let local_start = start - span.start;
+        let local_end = end - span.start;
+        let is_active = active.map(|a| a == r).unwrap_or(false);
+        let kind = if is_active {
+            HighlightKind::Active
+        } else {
+            HighlightKind::Match
+        };
+        overlaps.push((local_start, local_end, kind));
+    }
+
+    if overlaps.is_empty() {
+        return vec![(text.to_string(), HighlightKind::None)];
+    }
+
+    let mut segments = Vec::new();
+    let mut cursor = 0;
+    for (start, end, kind) in overlaps {
+        if start > cursor
+            && text.is_char_boundary(cursor)
+            && text.is_char_boundary(start)
+        {
+            segments.push((text[cursor..start].to_string(), HighlightKind::None));
+        }
+        if text.is_char_boundary(start) && text.is_char_boundary(end) {
+            segments.push((text[start..end].to_string(), kind));
+        }
+        cursor = end;
+    }
+    if cursor < text.len() && text.is_char_boundary(cursor) {
+        segments.push((text[cursor..].to_string(), HighlightKind::None));
+    }
+
+    segments
+}
+
 /// Split a long inline-code token into fixed-size chunks so the row-wrap layout
 /// can put each chunk on its own row instead of overflowing the content width.
 /// Short tokens (<= MAX) pass through unchanged.
@@ -638,14 +719,38 @@ impl CommonMarkViewerInternal {
             pulldown_cmark::Event::Start(tag) => self.start_tag(ui, tag, options),
             pulldown_cmark::Event::End(tag) => self.end_tag(ui, tag, cache, options, max_width),
             pulldown_cmark::Event::Text(text) => {
-                self.event_text(text, ui, options);
+                self.event_text_with_highlights(text, &src_span, cache, ui, options);
             }
             pulldown_cmark::Event::Code(text) => {
                 self.text_style.code = true;
                 let segments = inline_code_wrap_segments(&text);
                 let wrap = segments.len() > 1;
+                // For non-wrapped inline code, derive an interior span (strip equal
+                // backticks on each side) so search highlights line up with the visible
+                // code text. Wrapped (>56 char) code skips highlighting in v1.
+                let interior_span = if !wrap && src_span.len() >= text.len() {
+                    let delim_total = src_span.len() - text.len();
+                    if delim_total > 0 && delim_total % 2 == 0 {
+                        let bt = delim_total / 2;
+                        Some((src_span.start + bt)..(src_span.end - bt))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
                 for segment in segments {
-                    self.event_text(segment.into(), ui, options);
+                    if let Some(ref span) = interior_span {
+                        self.event_text_with_highlights(
+                            segment.into(),
+                            span,
+                            cache,
+                            ui,
+                            options,
+                        );
+                    } else {
+                        self.event_text(segment.into(), ui, options);
+                    }
                     if wrap {
                         ui.end_row();
                     }
@@ -716,12 +821,52 @@ impl CommonMarkViewerInternal {
     }
 
     fn event_text(&mut self, text: CowStr, ui: &mut Ui, options: &CommonMarkOptions) {
-        let rich_text = self
-            .text_style
-            .to_richtext_with_typography(ui, &text, Some(&options.typography));
+        self.emit_text(text, HighlightKind::None, ui, options);
+    }
+
+    /// Like `event_text`, but applies a search-highlight background color when `hl` is not `None`.
+    fn emit_text(
+        &mut self,
+        text: CowStr,
+        hl: HighlightKind,
+        ui: &mut Ui,
+        options: &CommonMarkOptions,
+    ) {
+        let bg = hl.background_color(ui);
+        let mut rich_text = if bg.is_some() && self.text_style.code {
+            // egui's RichText renderer overrides `background_color` with the theme's
+            // `code_bg_color` whenever `.code()` is set (widget_text.rs:421). To make
+            // our search highlight visible inside inline code, build the RichText
+            // manually with a monospace font instead of calling `.code()` — that gives
+            // the visual effect of code (monospace + slightly larger weight) while
+            // letting our background_color survive.
+            let mut t = egui::RichText::new(text.as_ref())
+                .text_style(egui::TextStyle::Monospace);
+            if self.text_style.strong {
+                t = t.strong();
+            }
+            if self.text_style.emphasis {
+                t = t.italics();
+            }
+            if self.text_style.strikethrough {
+                t = t.strikethrough();
+            }
+            if self.text_style.quote {
+                t = t.weak();
+            }
+            t
+        } else {
+            self.text_style
+                .to_richtext_with_typography(ui, &text, Some(&options.typography))
+        };
+        if let Some(bg) = bg {
+            rich_text = rich_text.background_color(bg);
+        }
         if let Some(image) = &mut self.image {
             image.alt_text.push(rich_text);
         } else if let Some(block) = &mut self.code_block {
+            // Code blocks render via syntect after end_tag; highlight inside code
+            // blocks is a v2 feature (would need syntect integration). Just collect text.
             block.content.push_str(&text);
         } else if let Some(link) = &mut self.link {
             link.text.push(rich_text);
@@ -732,6 +877,37 @@ impl CommonMarkViewerInternal {
             self.current_heading_rich_texts.push(rich_text);
         } else {
             ui.label(rich_text);
+        }
+    }
+
+    /// Split `text` at search-match boundaries (using `span` to locate matches in the
+    /// source content) and emit each segment with the appropriate highlight. Falls back
+    /// to plain `event_text` when there are no ranges or `text.len() != span.len()`
+    /// (markdown escapes or smart-punct transforms can break the 1:1 byte mapping).
+    fn event_text_with_highlights(
+        &mut self,
+        text: CowStr,
+        span: &Range<usize>,
+        cache: &mut CommonMarkCache,
+        ui: &mut Ui,
+        options: &CommonMarkOptions,
+    ) {
+        let ranges = cache.search_ranges();
+        if ranges.is_empty() || text.len() != span.len() {
+            self.event_text(text, ui, options);
+            return;
+        }
+        let segments =
+            compute_highlight_segments(&text, span, ranges, cache.active_search_range());
+        for (segment_text, hl) in segments {
+            // Record the cursor y for the Active segment BEFORE emitting it, so the
+            // app can scroll to the active match's actual position (line-ratio
+            // estimates are unreliable in image-heavy docs).
+            if hl == HighlightKind::Active {
+                let vy = ui.cursor().top();
+                cache.record_active_search_y_viewport(vy);
+            }
+            self.emit_text(segment_text.into(), hl, ui, options);
         }
     }
 

--- a/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
@@ -1312,6 +1312,16 @@ pub struct CommonMarkCache {
     /// Current scroll offset, set before rendering to calculate content-relative positions.
     current_scroll_offset: f32,
 
+    /// Byte ranges of search matches in the source content. Renderer paints a background
+    /// color on overlapping text events. Sorted ascending by start.
+    search_ranges: Vec<std::ops::Range<usize>>,
+    /// Active match — gets a stronger highlight color.
+    active_search_range: Option<std::ops::Range<usize>>,
+    /// Content-relative y position recorded by the renderer when the active match
+    /// is painted. Used by the app for precise scroll-into-view, since line-ratio
+    /// estimates are unreliable in image-heavy documents.
+    active_search_y: Option<f32>,
+
     /// Mermaid diagram render states: content hash → rendering/ready/error
     #[cfg(feature = "mermaid")]
     mermaid_states: HashMap<u64, MermaidState>,
@@ -1361,7 +1371,9 @@ impl std::fmt::Debug for CommonMarkCache {
             .field("scroll", &self.scroll)
             .field("has_installed_loaders", &self.has_installed_loaders)
             .field("header_positions", &self.header_positions)
-            .field("current_scroll_offset", &self.current_scroll_offset);
+            .field("current_scroll_offset", &self.current_scroll_offset)
+            .field("search_ranges_count", &self.search_ranges.len())
+            .field("active_search_range", &self.active_search_range);
         #[cfg(feature = "mermaid")]
         s.field("mermaid_states_count", &self.mermaid_states.len());
         #[cfg(feature = "mermaid")]
@@ -1390,6 +1402,9 @@ impl Default for CommonMarkCache {
             has_installed_loaders: false,
             header_positions: HashMap::new(),
             current_scroll_offset: 0.0,
+            search_ranges: Vec::new(),
+            active_search_range: None,
+            active_search_y: None,
             #[cfg(feature = "mermaid")]
             mermaid_states: HashMap::new(),
             #[cfg(feature = "mermaid")]
@@ -1577,6 +1592,53 @@ impl CommonMarkCache {
     /// Should be called when content changes.
     pub fn clear_header_positions(&mut self) {
         self.header_positions.clear();
+    }
+
+    /// Replace the set of search-match byte ranges. Renderer paints a background color
+    /// on text events that overlap these ranges. Ranges should be sorted by start and
+    /// non-overlapping; the caller is responsible for that invariant.
+    pub fn set_search_ranges(&mut self, ranges: Vec<std::ops::Range<usize>>) {
+        self.search_ranges = ranges;
+    }
+
+    /// Set the currently active match. Renderer uses a stronger highlight color for it.
+    /// Resets the recorded y position; the renderer will re-record on next paint.
+    pub fn set_active_search_range(&mut self, range: Option<std::ops::Range<usize>>) {
+        if self.active_search_range != range {
+            self.active_search_y = None;
+        }
+        self.active_search_range = range;
+    }
+
+    /// Clear all search-match state.
+    pub fn clear_search_ranges(&mut self) {
+        self.search_ranges.clear();
+        self.active_search_range = None;
+        self.active_search_y = None;
+    }
+
+    /// Record the actual content-relative y position of the active match.
+    /// Called by the renderer when an Active highlight is emitted.
+    /// `viewport_y` is the cursor y inside `show_viewport`; converted to
+    /// content-relative by adding the scroll offset.
+    pub fn record_active_search_y_viewport(&mut self, viewport_y: f32) {
+        self.active_search_y = Some(self.current_scroll_offset + viewport_y);
+    }
+
+    /// Get the recorded content-relative y of the active match, if it has rendered
+    /// at least once since the active range was set. Used for precise scroll-into-view.
+    pub fn active_search_y(&self) -> Option<f32> {
+        self.active_search_y
+    }
+
+    /// Read-only view of stored search ranges (used by the renderer).
+    pub fn search_ranges(&self) -> &[std::ops::Range<usize>] {
+        &self.search_ranges
+    }
+
+    /// Read-only view of the active search range (used by the renderer).
+    pub fn active_search_range(&self) -> Option<&std::ops::Range<usize>> {
+        self.active_search_range.as_ref()
     }
 
     /// Get cached parsed events if the content hash matches.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,6 +53,8 @@ Single-file Rust desktop application (`src/main.rs`, ~1300 lines) for viewing ma
 
 - **Link Navigation**: Uses egui_commonmark's link hook mechanism. Ctrl+Click opens links in new tabs, regular click navigates within the current tab.
 
+- **Search (Ctrl+F)**: Current-document find bar with inline highlights. `SearchState` lives on `MarkdownApp`; per-tab `search_matches: Vec<SearchMatch>` cache match byte ranges. Highlights are painted by the vendored `egui_commonmark` renderer via a new `CommonMarkCache::set_search_ranges` API; the renderer splits `Event::Text` and (non-wrapped) `Event::Code` at range boundaries and applies a background color to the matching segments. Enter/Shift+Enter cycle matches with line-ratio scroll-into-view; Esc closes the bar and clears highlights on all tabs.
+
 - **Global Allocator**: mimalloc for performance
 
 ## Key Libraries

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -27,6 +27,17 @@
 | Click link | Navigate in current tab |
 | Ctrl+Click link | Open link in new tab |
 
+## Search
+
+| Shortcut | Action |
+|----------|--------|
+| Ctrl+F | Open find bar (or refocus the input if already open) |
+| Enter or ↓ | Jump to the next match in the current document |
+| Shift+Enter or ↑ | Jump to the previous match in the current document |
+| Esc | Close the find bar and clear highlights |
+
+The find bar also has on-screen `↑` and `↓` buttons next to the match count for mouse navigation.
+
 ## View
 
 | Shortcut | Action |

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -525,6 +525,60 @@ objdump -T target/release/md-viewer | grep -oE 'GLIBC_[0-9.]+' | sort -u | tail
 ```
 **Files:** `snap/snapcraft.yaml`, `.github/workflows/release.yml`
 
+### `to_ascii_lowercase` preserves byte offsets; `to_lowercase` doesn't
+**Context:** Implementing case-insensitive substring search (`find_matches`) that returns byte ranges into the original content.
+**Problem:** `str::to_lowercase` does Unicode case folding which can *change byte length* (e.g. `"İ".to_lowercase() == "i̇"` — adds a combining mark). Any match offsets computed against the folded string would point at the wrong bytes in the original.
+**Fix:** Use `str::to_ascii_lowercase` on both sides. It only rewrites A–Z; non-ASCII bytes pass through untouched, so byte offsets stay 1:1 with the original.
+```rust
+let content_lc = content.to_ascii_lowercase();
+let query_lc = query.to_ascii_lowercase();
+for (byte_start, _) in content_lc.match_indices(&query_lc) {
+    // byte_start is a valid offset into the original `content`
+}
+```
+**Trade-off:** Non-ASCII case folding doesn't work (`É` won't match `é`). For a v1 simple search this was the right cut; the case-toggle and full Unicode folding are tracked in `docs/devlog/019-search-find.md` Future Improvements.
+**Files:** `src/main.rs` (`find_matches`)
+
+### Search-highlight in headings must go through `current_heading_rich_texts`
+**Context:** Search-match highlighting in `pulldown.rs` `Event::Text`
+**Gotcha:** The existing "Inline code in headers renders incorrectly" lesson taught that heading text fragments must accumulate into `current_heading_rich_texts` and render in `end_tag(Heading)` inside a single `allocate_ui_at_rect`. The new `emit_text` helper that applies highlight background colors MUST preserve this routing, otherwise highlighted segments in headings reset to x=0 individually and the header is rendered as fragmented overlapping text.
+**Fix:** `emit_text` keeps the same `if self.text_style.heading.is_some()` branch the original `event_text` had — only the per-segment `RichText` gets a `.background_color(...)` applied. The accumulator routing is identical.
+**Files:** `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`
+
+### MCP bridge has no keystroke injection; menus aren't in AccessKit
+**Context:** Verifying Ctrl+F end-to-end via the egui MCP bridge on Xvfb
+**Problem:** `xdotool key --window <id> ctrl+f` doesn't route to the egui app on Xvfb because there's no window manager to handle focus, AND the egui MCP bridge only exposes `egui_click` / `egui_type` (no `egui_keystroke`). Egui's `MenuBar::menu_button("File", ...)` widgets also don't surface their sub-buttons in the AccessKit tree, so triggering search via `File → Find...` click also fails.
+**Workaround:** For E2E testing of keyboard-shortcut-only features, either run on a real X11/Wayland session, or add a debug CLI flag that pre-opens the relevant UI state. For PRs, lean harder on unit tests + a no-regression AccessKit snapshot (count nodes before/after).
+**Files:** N/A (external limitation)
+
+### Search matches must skip non-renderable markdown spans (alt-text + URLs)
+**Context:** Find-feature cycling appears "stuck" — user presses Enter but the active highlight doesn't visibly move; sometimes the view scrolls to a position where the matched text isn't visible.
+**Root cause:** `find_matches` scans raw byte content. A query like "syntax" against the README returned 10 matches, but **several were inside `![alt-text](url)` markdown** — alt text is hover/screen-reader only, URLs are never visible. Cycling to those matches:
+- Painted the active highlight at bytes that don't appear on screen → no visible color change
+- Scrolled to the markdown source line of the `![...](...)` (which is where the *image* renders, not where the matched bytes are) → wrong position
+The user perceives "highlight stuck on first result" because the visible (non-active) matches all wear the dim color while the actual active match is invisible.
+**Fix:** In `find_matches`, regex-match `(!?)\[([^\]]*)\]\(([^)]*)\)` and filter out matches whose byte range falls in:
+- The URL portion (group 3) — always, for both images and links
+- The alt portion (group 2) — only when group 1 is `!` (image)
+Link *text* stays in scope because it IS rendered.
+**Files:** `src/main.rs` (`find_matches`)
+
+### Line-ratio scroll is unreliable in image-heavy docs — record actual y during paint
+**Context:** Auto-scroll to the active search match lands the wrong content on screen for matches past several images.
+**Root cause:** `(line_number / total_lines) * content_height` assumes uniform per-line height. In a README with multiple 400 px+ images, the actual rendered y of a text line is far below what the ratio estimates. Even subtracting 35% of viewport height as a margin isn't enough — match 4 of "syntax" in the README is past three large images and ends up off-screen below the viewport.
+**Fix:** Two-stage scroll.
+1. `scroll_to_active_match()` (called from `jump_match` and `maybe_rebuild_search`) sets `pending_scroll_offset` from the line-ratio estimate — gets the view roughly in the right area.
+2. During render, when `emit_text` paints an `Active` highlight segment, the renderer calls `cache.record_active_search_y_viewport(ui.cursor().top())`. The cache stores `current_scroll_offset + viewport_y` as content-relative y.
+3. After `show_viewport()` returns, `render_tab_content` reads `cache.active_search_y()`. If the recorded y is outside the visible viewport, schedule a corrective `pending_scroll_offset` for next frame.
+Visual effect: one frame lands close (line-ratio), the next frame snaps precise (recorded y). The active match is always in viewport after at most two frames.
+**Files:** `crates/egui_commonmark/egui_commonmark_backend/src/misc.rs` (`record_active_search_y_viewport`, `active_search_y`), `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs` (`event_text_with_highlights`), `src/main.rs` (`scroll_to_active_match`, `render_tab_content` corrective block)
+
+### Heading bg-color rendering wasn't the bug — `allocate_ui_at_rect` is fine
+**Context:** Active highlight in h3 heading rendered as `HL_DARK` instead of `HL_ACTIVE_DARK`. Spent ~30 min suspecting `allocate_ui_at_rect` in `end_tag(Heading)` suppressed `RichText.background_color`.
+**What was actually happening:** The "active" match's byte range pointed inside an image alt-text — so the active *was* applied but to invisible bytes; the visible heading "Syntax" got the regular (Match) color because it was a *different* search range. Pixel sampling showed only `HL_DARK` pixels because there were no visible Active spans on that frame.
+**Diagnostic that would have caught it sooner:** log the active range's byte position AND a content-context window around it before chasing renderer-side hypotheses. If `active = Some(2823..2829)` and `content[2790..2870]` is `![Syntax Highlighting](...)`, you know the match is in alt text *before* touching the renderer.
+**Files:** N/A (debugging discipline)
+
 ### Inline-code wrap segmentation: blind char-count cut, not break-friendly chars
 **Context:** Issue #5 — long inline-code tokens (file paths) overflowed the content column, clipping leading characters and overlapping adjacent text. Fixed by splitting long tokens into chunks separated by `ui.end_row()` in `Event::Code` handling.
 **First attempt that regressed:** Splitting at break-friendly characters (`/ \ - _ . :`) past 56 chars to keep paths readable. At narrow window widths the variable-length segments (60-120 chars) still exceeded the column width, and egui's intra-widget wrap re-introduced the original clipping bug.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -512,3 +512,21 @@ magick X.png -gravity center -crop 540x540+0+0 +repage -resize 256x256 -strip ou
 **Problem:** `gh pr create` returned HTTP 422 with `{"resource":"Issue","code":"custom","field":"user","message":"user is blocked"}`. Direct `curl` against the GitHub API confirms the block; org-block check (`/orgs/flathub/blocks/aydiler`) returns 404 (not org-level) so the block is at the GitHub user level — likely auto-triggered by previous activity (the account had 3 close/reopen PRs for `io.github.aydiler.msigd-gui` in January 2026).
 **Workaround:** Open a topic on Flathub Discourse (https://discourse.flathub.org/) asking for unblock; reference the closed prior PRs and the new app. The push to `aydiler/flathub:io.github.aydiler.md-viewer` branch succeeds before the PR step, so once unblocked the PR can be opened from the GitHub web UI without redoing branch work.
 **Files:** N/A (account-level state)
+
+### Never `snapcraft --destructive-mode` for releases on a glibc-newer-than-base host
+**Context:** Issue #3 — v0.1.2 snap (revision 4) failed to start on Ubuntu 24.04 with `GLIBC_2.43 not found` errors. The snapcraft.yaml declared `base: core22` (glibc 2.35), but the actual binary required GLIBC_2.43.
+**Root cause:** v0.1.2 release CI run failed; the snap was manually uploaded with `snapcraft --destructive-mode` from this Arch host (glibc 2.43). Destructive mode builds directly on the host without LXD/multipass isolation, so cargo links against host glibc — `atan2f@GLIBC_2.43`, `acosf@GLIBC_2.43` etc. get baked into the binary regardless of the declared `base:`.
+**Fix:** Only publish snaps via CI (`snapcore/action-build@v1` uses LXD with the declared base). If CI fails, fix CI — never fall back to destructive-mode upload. The v0.1.3 CI run produced revision 6, which only requires up to `GLIBC_2.35` and works on Ubuntu 22.04+.
+**Verify before upload:**
+```bash
+objdump -T target/release/md-viewer | grep -oE 'GLIBC_[0-9.]+' | sort -u | tail
+# Must not exceed the glibc of the declared `base:` in snapcraft.yaml
+# core22 → 2.35, core24 → 2.39
+```
+**Files:** `snap/snapcraft.yaml`, `.github/workflows/release.yml`
+
+### Inline-code wrap segmentation: blind char-count cut, not break-friendly chars
+**Context:** Issue #5 — long inline-code tokens (file paths) overflowed the content column, clipping leading characters and overlapping adjacent text. Fixed by splitting long tokens into chunks separated by `ui.end_row()` in `Event::Code` handling.
+**First attempt that regressed:** Splitting at break-friendly characters (`/ \ - _ . :`) past 56 chars to keep paths readable. At narrow window widths the variable-length segments (60-120 chars) still exceeded the column width, and egui's intra-widget wrap re-introduced the original clipping bug.
+**Fix:** Blind fixed-size char-count cut. Each chunk has a known upper bound (56 chars) so it always fits the column. Mid-identifier breaks are a cosmetic cost, but functionally correct at every width.
+**Files:** `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs` (`inline_code_wrap_segments`)

--- a/docs/TARGET_METRICS.md
+++ b/docs/TARGET_METRICS.md
@@ -10,3 +10,11 @@
 - **Phase A**: Multi-window support via egui viewports - COMPLETED (now replaced by tabs)
 - **Phase B**: Tab system (egui_dock) - COMPLETED
 - **Phase C**: Hybrid tabs + multi-window - Future
+
+## Planned (Open Feature Requests)
+
+Tracked in issue #4. Recommended order:
+
+1. **Search / find-all (Ctrl+F)** — bounded, ~300-500 LoC in `src/main.rs`. Draft spec exists from the PR #5 contributor.
+2. **Table horizontal-scroll UX** — small (~30 lines) fix at `crates/egui_commonmark/.../pulldown.rs:572` to route wheel events through nested ScrollAreas.
+3. **Resizable table columns** — large refactor: swap `egui::Grid` for `egui_extras::TableBuilder` in the vendored fork. Regression-testing all existing table edge cases required.

--- a/docs/devlog/019-search-find.md
+++ b/docs/devlog/019-search-find.md
@@ -1,0 +1,267 @@
+# Feature: Search (Ctrl+F) — Current Doc with Inline Highlights
+
+**Status:** ✅ Complete
+**Branch:** `feature/search`
+**Date:** 2026-05-15
+**Lines Changed:** ~900 across `src/main.rs`, vendored `crates/egui_commonmark/`, `docs/KEYBOARD_SHORTCUTS.md`, `docs/ARCHITECTURE.md`, `docs/LESSONS.md`
+
+## Summary
+
+Implements `Ctrl+F` search over the active tab's content. Matches are highlighted inline by extending the vendored `egui_commonmark` renderer with a search-range API on `CommonMarkCache`. `Enter` / `Shift+Enter` cycle through matches and scroll the active one into view via the existing line-ratio mechanism. `Esc` closes the bar and clears highlights.
+
+Scope is deliberately narrow: current document only, case-insensitive plain substring, no toggles. Cross-tab find-all, regex, whole-word, and a case toggle are deferred to v2.
+
+## Features
+
+- [x] `SearchState` on `MarkdownApp` and `search_matches: Vec<SearchMatch>` on `Tab`
+- [x] Pure `find_matches(content, query)` with 13 unit tests (case-insens ASCII, line numbers, UTF-8 byte offsets, cross-newline skip, overlapping, image-alt filter, image-URL filter, link-URL filter, link-text kept, multiple-image cases)
+- [x] Image alt-text + image/link URLs excluded from matches (non-renderable bytes)
+- [x] `CommonMarkCache::set_search_ranges` / `set_active_search_range` / `clear_search_ranges`
+- [x] Renderer y-recording: `cache.record_active_search_y_viewport` + `cache.active_search_y()`
+- [x] Two-stage scroll: line-ratio estimate first, exact-y correction next frame
+- [x] Inline highlight rendering in `pulldown.rs` `Event::Text` + non-wrapped `Event::Code`
+- [x] `render_search_bar` conditional TopBottomPanel between error_bar and tab_bar
+- [x] Keyboard: Ctrl+F open, Enter/Shift+Enter cycle, ArrowDown/ArrowUp cycle, Esc close
+- [x] On-screen `↑` / `↓` prev/next buttons in the bar (disabled when no matches)
+- [x] `File → Find...` menu entry (discoverability)
+- [x] `jump_match` + `scroll_to_active_match` extracted as a reusable helper
+- [x] `maybe_rebuild_search` resets active_match_index to 0 AND calls scroll_to_active_match (matches Firefox/Chrome/VS Code on query change or tab switch)
+- [x] File-watcher reload rebuilds matches on next frame (invalidates `last_tab` shadow)
+- [x] `close_search` clears highlight state on every tab
+- [x] MCP widget registrations on every interactive search-bar widget; `Match Count` value matches the rendered label
+- [x] `docs/KEYBOARD_SHORTCUTS.md` updated (Search section with all 4 navigation paths)
+- [x] `docs/ARCHITECTURE.md` updated
+- [x] `docs/LESSONS.md` updated with byte-offset filtering and two-stage scroll patterns
+
+## Key Discoveries
+
+### `to_ascii_lowercase` preserves byte offsets; `to_lowercase` does NOT
+
+`find_matches` returns byte ranges into the original content (consumed by the renderer
+as `Range<usize>` keys). For case-insensitive matching, the cheap-and-correct trick is
+`str::to_ascii_lowercase` on both sides: it only rewrites bytes A–Z and leaves byte
+length unchanged. `str::to_lowercase` does proper Unicode case folding which can
+*change byte length* (e.g. `"İ".to_lowercase() == "i̇"` — adds a combining mark), so any
+match offsets computed against the folded string would be wrong against the original.
+
+Documented v1 limitation: `É` does not match `é`. The case-toggle and full Unicode case
+folding are listed in Future Improvements.
+
+```rust
+let content_lc = content.to_ascii_lowercase();
+let query_lc = query.to_ascii_lowercase();
+for (byte_start, _) in content_lc.match_indices(&query_lc) { /* offsets valid */ }
+```
+
+### Inline highlight via `RichText::background_color` (not painter overlay)
+
+Highlights are inline in the renderer, not overlay-painted. The vendored `pulldown.rs`
+already iterates `pulldown_cmark::Event`s with their source `Range<usize>` spans —
+exactly what's needed to map a search-match byte range back to a sub-segment of a
+`Text` event. The implementation:
+
+1. `CommonMarkCache::set_search_ranges(Vec<Range<usize>>)` stores ranges before render
+2. In `Event::Text`, `event_text_with_highlights` checks if `text.len() == span.len()`
+   (markdown escapes / smart-punct transforms would break the 1:1 assumption) and
+   either splits into segments or falls back to plain rendering
+3. Each segment emits a `RichText` via `emit_text(text, hl, ...)` which applies
+   `rich_text.background_color(...)` when `hl != HighlightKind::None`
+4. Active match gets a stronger color variant
+
+No painter overlay = no misalignment under reflow. The cost: doesn't highlight inside
+syntax-highlighted code blocks (those use `syntect` post-collection — would need a
+deeper integration).
+
+### Inline-code highlighting: derive interior span from `src_span.len() - text.len()`
+
+pulldown_cmark's `Event::Code` gives the code text without backticks, but the
+src_span covers the whole token including delimiters. To highlight inline code,
+the renderer computes `delim_total = src_span.len() - text.len()` and, when the
+result is even, treats it as `delim_total / 2` backticks on each side and emits
+an "interior span" `(src_span.start + bt)..(src_span.end - bt)` for highlighting.
+
+For wrapped inline code (the `inline_code_wrap_segments` 56-char chunks), v1 skips
+highlighting since sub-spans per segment aren't trivially derivable.
+
+### Heading path must `accumulate`, not call `ui.label` directly
+
+LESSONS.md "Inline code in headers" already documented this: heading rendering
+accumulates `RichText` into `current_heading_rich_texts` and renders them at
+`end_tag(Heading)` inside a single `allocate_ui_at_rect` for left alignment. The
+new `emit_text` correctly routes RichText to that accumulator (same as existing
+`event_text`), so search highlights inside headings work without special-casing.
+
+### File-watcher reload invalidates the rebuild shadow state
+
+`Tab::reload` clears `search_matches`, but `SearchState::last_query` and `last_tab`
+remain unchanged — so `maybe_rebuild_search` would skip rebuild on the next frame
+("nothing changed from its perspective"). Fix: `reload_changed_tabs` sets
+`self.search.last_tab = None` when the active tab is among the reloaded ones,
+forcing the next frame to rebuild against the new content.
+
+### MCP bridge has no keyboard-shortcut injection; egui MenuBar absent from AccessKit
+
+Xvfb has no window manager, so `xdotool key --window <id> ctrl+f` doesn't route
+keypresses to a focused widget. The egui MCP bridge initially only exposed
+`egui_click` / `egui_type` (no keyboard shortcuts) — and egui's `MenuBar` widget
+doesn't surface its sub-buttons in the AccessKit tree, so a `File → Find...` click
+via MCP also doesn't work.
+
+**Fix shipped in a sibling repo:** added an `egui_key` tool to `egui-mcp` that
+synthesizes `egui::Event::Key { key, pressed, modifiers }` via the bridge's
+`inject_raw_input` hook. Includes a critical fix: when synthesizing key events,
+the bridge must also OR the modifiers into `raw_input.modifiers` because egui
+derives `Input.modifiers` from `RawInput.modifiers`, not from the per-event
+modifiers field. Without that, `i.key_pressed(F)` fires but `i.modifiers.ctrl`
+stays false. This unblocks E2E testing for every egui app, not just md-viewer.
+
+### Search matches must skip non-renderable markdown spans
+
+After the first PR-ready build, the user reported "active highlight stuck on
+first results" and "auto-scroll wrong position". Root cause: `find_matches`
+counted bytes inside `![alt](url)` and `[text](url)` as matches even though the
+alt and URL portions aren't visibly rendered. Cycling to an alt-text match
+painted the active highlight at invisible bytes and scrolled to the markdown
+source line of the image (which is where the image renders, not where the matched
+text would be).
+
+Fix: regex `(!?)\[([^\]]*)\]\(([^)]*)\)` and skip matches inside:
+- Group 3 (URL) — always
+- Group 2 (alt/text) — only when group 1 is `!` (image)
+For "syntax" against README.md: 10 raw matches → 8 after alt filter → 6 after URL filter.
+
+### Line-ratio scroll undershoots badly in image-heavy docs — two-stage scroll
+
+Even after filtering invisible matches, "auto-scroll wrong position" persisted
+for match 4 ("JSON syntax highlighting" caption past three large images).
+Line-ratio (line N / total lines × content height) assumes uniform per-line
+height; images consume ~400 px each but only one "line" of source, so the
+estimate undershoots by ~1000+ px for matches past several images.
+
+Fix: two-stage scroll.
+1. `scroll_to_active_match` sets `pending_scroll_offset` from the line-ratio
+   estimate, with `viewport_height * 0.35` margin. Gets the view in the right
+   neighbourhood.
+2. During render, when `event_text_with_highlights` emits an Active segment,
+   `cache.record_active_search_y_viewport(ui.cursor().top())` records the
+   actual content-relative y.
+3. After `show_viewport` returns, `render_tab_content` checks
+   `cache.active_search_y()`. If the recorded y is outside the visible viewport,
+   schedule a corrective `pending_scroll_offset` for the next frame.
+
+Two-frame visual: estimate first, snap precise. All 6 "syntax" matches in
+README now land the active match inside the viewport with the brighter
+HL_ACTIVE_DARK color clearly visible.
+
+### Debugging discipline: log byte offsets BEFORE chasing renderer hypotheses
+
+Spent ~30 min suspecting `allocate_ui_at_rect` in `end_tag(Heading)` suppressed
+`RichText.background_color` paint when active-highlighting a heading. The bug
+turned out to be entirely different: the "active" match's byte range pointed
+inside image alt-text. The visible heading "Syntax" got the regular (Match)
+color because it was a *different* search range — there was no Active span to
+paint visibly.
+
+Diagnostic that would have caught it sooner: log `active = Some(byte_start..byte_end)`
+plus `content[byte_start - 40 .. byte_end + 40]`. If the context shows
+`![Syntax Highlighting](...)`, the match is in alt-text — investigate the
+filter, not the renderer.
+
+## Architecture
+
+### New Structs
+
+```rust
+struct SearchState {
+    is_open: bool,
+    query: String,
+    last_query: String,        // shadow for change detection
+    focus_requested: bool,
+    active_match_index: usize,
+}
+
+struct SearchMatch {
+    byte_start: usize,
+    byte_end: usize,
+    line_number: usize,        // 1-based
+}
+```
+
+### New Functions
+
+| Function | Purpose |
+|----------|---------|
+| `find_matches(&str, &str) -> Vec<SearchMatch>` | Pure scan; case-insensitive substring; 1-based line numbers |
+| `Tab::rebuild_search(&str)` | Wrapper calling `find_matches` and storing result |
+| `MarkdownApp::render_search_bar(&Context)` | Conditional find-bar panel |
+| `MarkdownApp::jump_match(i32)` | Move active_match_index, set scroll target |
+| `CommonMarkCache::set_search_ranges(Vec<Range<usize>>)` | Push match byte ranges into renderer |
+| `CommonMarkCache::set_active_search_range(Option<Range<usize>>)` | Active match for stronger highlight |
+| `CommonMarkCache::clear_search_ranges()` | Reset on close / tab switch |
+
+### Theme-aware colors
+
+```rust
+const HL_LIGHT: Color32 = Color32::from_rgb(255, 229, 127);
+const HL_DARK:  Color32 = Color32::from_rgb(102, 92, 46);
+const HL_ACTIVE_LIGHT: Color32 = Color32::from_rgb(255, 167, 38);
+const HL_ACTIVE_DARK:  Color32 = Color32::from_rgb(156, 107, 26);
+```
+
+## Testing Notes
+
+**Automated**
+- `cargo test --bin md-viewer --no-default-features` — 13/13 tests pass (~5 ms total)
+  - empty query / empty content
+  - case-insensitive ASCII
+  - multiple matches per line
+  - 1-based line numbers across multi-line content
+  - UTF-8 byte-offset preservation (e.g. `café`)
+  - matches that would cross a newline are skipped
+  - `match_indices` semantics (non-overlapping): `"aaaa" / "aa" → [0, 2]`
+  - image alt-text filter
+  - image URL filter
+  - link URL filter (with link text kept)
+  - multiple-image cases
+- `cargo clippy` — no warnings introduced (the two pre-existing vendored-crate
+  warnings about `_max_width` and `allocate_ui_at_rect` are unrelated to this PR)
+
+**E2E via egui MCP** (with the new `egui_key` tool from the egui-mcp sibling repo)
+- Open find bar (`egui_key {key: "F", modifiers: ["ctrl"]}`)
+- Type query (`egui_fill` n3 "syntax") — match count "1 / 6"
+- Cycle every match 1→6 via `egui_key {key: "ArrowDown"}` — each verified by:
+  - Match Count widget value updates "N / 6"
+  - Screenshot captured, pixels sampled for HL_ACTIVE_DARK rgb(156,107,26)
+  - Every match has non-zero active-orange pixels inside the visible viewport
+- Wraparound 6→1 verified (Enter at last match)
+- Backward cycling verified (Shift+Enter from match 5 → 4)
+- Esc closes bar, all highlights gone (back to 70 AccessKit nodes)
+
+**Visual confirmation per match for "syntax" against README:**
+| # | Location | Visible? |
+|---|----------|----------|
+| 1 | intro paragraph | ✓ |
+| 2 | Features bullet "Syntax Highlighting" | ✓ |
+| 3 | h3 heading "Dark Mode -- Syntax Highlighting" | ✓ |
+| 4 | italic caption "*JSON syntax highlighting*" past 3 images | ✓ (via two-stage scroll) |
+| 5 | Technical Details bullet | ✓ |
+| 6 | link description "Syntax highlighting" | ✓ |
+
+**Edge cases verified by code review**
+- Smart-punct transforms break `text.len() == span.len()` → falls back to no highlight
+- Wrapped inline-code (>56 chars) → no highlight (interior_span is None)
+- Tab close while bar is open → next frame's `maybe_rebuild_search` rebuilds for new active tab
+- File reload of active tab while bar is open → `last_tab = None` invalidation triggers rebuild
+- Empty query → empty match vector → match-count label is empty string
+- 0 matches → label shows "0 matches", Enter/Shift+Enter is a no-op
+
+## Future Improvements
+
+- [ ] Cross-tab find-all panel
+- [ ] Case-sensitivity toggle
+- [ ] Whole-word toggle
+- [ ] Regex
+- [ ] F3 / Shift+F3 alternates (browser convention; ↑↓ already cover the intuitive case)
+- [ ] Per-tab match-count badges in tab bar
+- [ ] Search history
+- [ ] Renderer y-recording is currently only for the *active* match. Recording all matches would unlock features like a minimap-style scrollbar overlay showing every match's position.

--- a/src/main.rs
+++ b/src/main.rs
@@ -968,9 +968,7 @@ fn find_matches(content: &str, query: &str) -> Vec<SearchMatch> {
     };
 
     let in_skip = |start: usize, end: usize| -> bool {
-        skip_spans
-            .iter()
-            .any(|s| start >= s.start && end <= s.end)
+        skip_spans.iter().any(|s| start >= s.start && end <= s.end)
     };
 
     let mut matches = Vec::new();
@@ -1980,8 +1978,8 @@ impl MarkdownApp {
         // Line-ratio estimate gets the view roughly in the right area. The renderer
         // records the actual y of the active match during paint; render_tab_content
         // schedules a corrective scroll next frame if this estimate was off.
-        let estimated_y = (m.line_number as f32 / tab.content_lines as f32)
-            * tab.last_content_height;
+        let estimated_y =
+            (m.line_number as f32 / tab.content_lines as f32) * tab.last_content_height;
         let margin = if tab.last_viewport_height > 0.0 {
             tab.last_viewport_height * 0.35
         } else {
@@ -1997,8 +1995,8 @@ impl MarkdownApp {
             return;
         }
         let tab_idx = self.active_tab;
-        let needs_rebuild = self.search.query != self.search.last_query
-            || self.search.last_tab != Some(tab_idx);
+        let needs_rebuild =
+            self.search.query != self.search.last_query || self.search.last_tab != Some(tab_idx);
         if !needs_rebuild {
             return;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,37 @@ struct ParsedHeaders {
     outline_headers: Vec<Header>,
 }
 
+/// A single match in a tab's content, identified by byte range and 1-based line number
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SearchMatch {
+    byte_start: usize,
+    byte_end: usize,
+    line_number: usize,
+}
+
+/// Per-frame return from `render_search_bar`
+#[derive(Default)]
+struct SearchBarOutcome {
+    close_requested: bool,
+    prev_clicked: bool,
+    next_clicked: bool,
+}
+
+/// App-level search state — only one find bar is visible at a time
+#[derive(Default)]
+struct SearchState {
+    is_open: bool,
+    query: String,
+    /// Shadow copy of `query` used to detect changes across frames
+    last_query: String,
+    /// Tab index the cached matches were built for; `None` forces rebuild
+    last_tab: Option<usize>,
+    /// Set after Ctrl+F so the text input is focused next frame
+    focus_requested: bool,
+    /// Index into the active tab's `search_matches`
+    active_match_index: usize,
+}
+
 /// Action from file explorer interaction
 #[derive(Default)]
 struct ExplorerAction {
@@ -557,12 +588,15 @@ struct Tab {
     scroll_offset: f32,
     pending_scroll_offset: Option<f32>,
     last_content_height: f32,
+    last_viewport_height: f32,
     content_lines: usize,
     local_links: Vec<String>,
     /// Cached base URI for markdown image/link resolution (e.g. "file:///path/to/dir/")
     base_uri: String,
     history_back: Vec<PathBuf>,
     history_forward: Vec<PathBuf>,
+    /// Cached matches for the current search query; empty when bar is closed or query is empty
+    search_matches: Vec<SearchMatch>,
 }
 
 impl Tab {
@@ -597,11 +631,13 @@ impl Tab {
             scroll_offset: 0.0,
             pending_scroll_offset: None,
             last_content_height: 0.0,
+            last_viewport_height: 0.0,
             content_lines,
             local_links,
             base_uri,
             history_back: Vec::new(),
             history_forward: Vec::new(),
+            search_matches: Vec::new(),
         }
     }
 
@@ -629,10 +665,12 @@ impl Tab {
             scroll_offset: 0.0,
             pending_scroll_offset: None,
             last_content_height: 0.0,
+            last_viewport_height: 0.0,
             content_lines,
             local_links,
             history_back: Vec::new(),
             history_forward: Vec::new(),
+            search_matches: Vec::new(),
         }
     }
 
@@ -664,7 +702,15 @@ impl Tab {
             for link in &self.local_links {
                 self.cache.add_link_hook(link);
             }
+
+            // Stale byte ranges; caller rebuilds if search bar is open
+            self.search_matches.clear();
         }
+    }
+
+    /// Rebuild `search_matches` for `query`. Empty query clears matches.
+    fn rebuild_search(&mut self, query: &str) {
+        self.search_matches = find_matches(&self.content, query);
     }
 
     fn load_file(&mut self, path: &PathBuf) {
@@ -692,6 +738,9 @@ impl Tab {
             for link in &self.local_links {
                 self.cache.add_link_hook(link);
             }
+
+            // Stale byte ranges; caller rebuilds if search bar is open
+            self.search_matches.clear();
         }
     }
 
@@ -863,6 +912,95 @@ fn parse_headers(content: &str) -> ParsedHeaders {
         document_title,
         outline_headers,
     }
+}
+
+/// Find all occurrences of `query` in `content`, case-insensitive (ASCII only).
+///
+/// Byte offsets are 1:1 with `content` because `to_ascii_lowercase` does not change
+/// byte length. Non-ASCII letters match literally (`É` does not match `é`) — see the
+/// devlog future-improvements list for the case-toggle and full Unicode case folding.
+///
+/// Matches spanning a newline are excluded (a search bar should not jump to results
+/// the user cannot interpret as a single line).
+///
+/// Matches inside markdown that's not visibly rendered are also excluded:
+/// - Image alt-text `![alt](url)` — alt is hover/screen-reader only
+/// - Image URL `![alt](url)` — never visible
+/// - Link URL `[text](url)` — never visible (only the text part is)
+///
+/// Without this, cycling lands on invisible matches: the user sees no visible
+/// highlight change and the scroll target points to a paragraph where the rendered
+/// text doesn't contain the searched bytes.
+fn find_matches(content: &str, query: &str) -> Vec<SearchMatch> {
+    if query.is_empty() || content.is_empty() {
+        return Vec::new();
+    }
+
+    let content_lc = content.to_ascii_lowercase();
+    let query_lc = query.to_ascii_lowercase();
+    let query_len = query_lc.len();
+
+    // Identify byte ranges of non-renderable markdown parts so we can skip matches
+    // inside them. Pattern: `(!?)[alt-or-text](url)`.
+    // - Group 1 = `!` for images, empty for links
+    // - Group 2 = alt (image) or text (link); exclude only if image (group 1 = `!`)
+    // - Group 3 = url; always exclude (URLs are never visible inline)
+    let skip_spans: Vec<std::ops::Range<usize>> = {
+        static MD_LINK_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+        let re = MD_LINK_RE.get_or_init(|| {
+            Regex::new(r"(!?)\[([^\]]*)\]\(([^)]*)\)").expect("static regex must compile")
+        });
+        let mut spans = Vec::new();
+        for cap in re.captures_iter(content) {
+            let is_image = cap.get(1).map(|m| !m.as_str().is_empty()).unwrap_or(false);
+            // Always exclude URL (group 3)
+            if let Some(url) = cap.get(3) {
+                spans.push(url.start()..url.end());
+            }
+            // For images, also exclude alt (group 2)
+            if is_image {
+                if let Some(alt) = cap.get(2) {
+                    spans.push(alt.start()..alt.end());
+                }
+            }
+        }
+        spans
+    };
+
+    let in_skip = |start: usize, end: usize| -> bool {
+        skip_spans
+            .iter()
+            .any(|s| start >= s.start && end <= s.end)
+    };
+
+    let mut matches = Vec::new();
+    let mut line_number = 1usize;
+    let mut cursor = 0usize;
+
+    for (byte_start, _) in content_lc.match_indices(&query_lc) {
+        // Count newlines between cursor and this match's start
+        line_number += content[cursor..byte_start]
+            .bytes()
+            .filter(|&b| b == b'\n')
+            .count();
+        cursor = byte_start;
+
+        let byte_end = byte_start + query_len;
+        if content[byte_start..byte_end].contains('\n') {
+            continue; // Skip matches that cross line boundaries
+        }
+        if in_skip(byte_start, byte_end) {
+            continue; // Skip matches inside image alt-text or URL portions of links/images
+        }
+
+        matches.push(SearchMatch {
+            byte_start,
+            byte_end,
+            line_number,
+        });
+    }
+
+    matches
 }
 
 /// Check if header at `index` should be hidden because an ancestor is collapsed
@@ -1097,6 +1235,8 @@ struct MarkdownApp {
     lightbox_scroll: f32,
     // Counter for unique lightbox IDs (prevents stale egui state between opens)
     lightbox_open_count: u64,
+    // Find-bar state (current-document search)
+    search: SearchState,
     // MCP bridge for E2E testing
     #[cfg(feature = "mcp")]
     mcp_bridge: McpBridge,
@@ -1251,6 +1391,7 @@ impl MarkdownApp {
             lightbox: None,
             lightbox_scroll: 0.0,
             lightbox_open_count: 0,
+            search: SearchState::default(),
             #[cfg(feature = "mcp")]
             mcp_bridge,
         };
@@ -1644,6 +1785,10 @@ impl MarkdownApp {
     fn reload_changed_tabs(&mut self, changed_paths: Vec<PathBuf>) {
         let now = Instant::now();
         let mut refresh_tree = false;
+        // If the active tab gets reloaded while the find bar is open, its
+        // `search_matches` will be cleared by `Tab::reload`. Force a rebuild
+        // on the next frame by invalidating the cache-validity shadow state.
+        let active_path = self.tabs.get(self.active_tab).map(|t| t.path.clone());
 
         for path in changed_paths {
             // Trigger flash effect for the changed file (use canonical path for consistent lookup)
@@ -1675,11 +1820,19 @@ impl MarkdownApp {
             }
 
             // Reload the tab content
+            let mut active_was_reloaded = false;
             for tab in &mut self.tabs {
                 if tab.path == path {
                     log::info!("Reloading tab: {:?}", path);
                     tab.reload();
+                    if Some(&tab.path) == active_path.as_ref() {
+                        active_was_reloaded = true;
+                    }
                 }
+            }
+            if active_was_reloaded && self.search.is_open {
+                // Invalidate maybe_rebuild_search's "cached for" shadow
+                self.search.last_tab = None;
             }
         }
 
@@ -1687,6 +1840,198 @@ impl MarkdownApp {
         if refresh_tree {
             log::info!("Refreshing file explorer tree");
             self.file_explorer.refresh();
+        }
+    }
+
+    /// Outcome of rendering the find bar (consumed after panel renders, before global input handler runs)
+    fn render_search_bar(&mut self, ctx: &egui::Context) -> SearchBarOutcome {
+        let mut outcome = SearchBarOutcome::default();
+        if !self.search.is_open {
+            return outcome;
+        }
+
+        let input_id = egui::Id::new("search_input");
+        let total_matches = self
+            .tabs
+            .get(self.active_tab)
+            .map(|t| t.search_matches.len())
+            .unwrap_or(0);
+        let active_idx = self.search.active_match_index;
+
+        egui::TopBottomPanel::top("search_bar").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("🔍");
+
+                let text_edit = egui::TextEdit::singleline(&mut self.search.query)
+                    .id(input_id)
+                    .hint_text("Find in document")
+                    .desired_width(280.0);
+                let response = ui.add(text_edit);
+
+                #[cfg(feature = "mcp")]
+                self.mcp_bridge
+                    .register_widget("Search: Input", "textbox", &response, None);
+
+                if self.search.focus_requested {
+                    response.request_focus();
+                    self.search.focus_requested = false;
+                }
+
+                ui.add_space(8.0);
+
+                let label_text = if self.search.query.is_empty() {
+                    String::new()
+                } else if total_matches == 0 {
+                    "0 matches".to_string()
+                } else {
+                    format!("{} / {}", active_idx + 1, total_matches)
+                };
+                let label_response = ui.label(
+                    egui::RichText::new(&label_text)
+                        .color(ui.style().visuals.weak_text_color())
+                        .small(),
+                );
+
+                #[cfg(feature = "mcp")]
+                self.mcp_bridge.register_widget(
+                    "Search: Match Count",
+                    "label",
+                    &label_response,
+                    Some(&label_text),
+                );
+                #[cfg(not(feature = "mcp"))]
+                let _ = label_response;
+
+                ui.add_space(4.0);
+                let prev_btn = ui
+                    .add_enabled(total_matches > 0, egui::Button::new("↑").small())
+                    .on_hover_text("Previous match (Shift+Enter / ↑)");
+                #[cfg(feature = "mcp")]
+                self.mcp_bridge
+                    .register_widget("Search: Previous", "button", &prev_btn, None);
+                if prev_btn.clicked() {
+                    outcome.prev_clicked = true;
+                }
+
+                let next_btn = ui
+                    .add_enabled(total_matches > 0, egui::Button::new("↓").small())
+                    .on_hover_text("Next match (Enter / ↓)");
+                #[cfg(feature = "mcp")]
+                self.mcp_bridge
+                    .register_widget("Search: Next", "button", &next_btn, None);
+                if next_btn.clicked() {
+                    outcome.next_clicked = true;
+                }
+
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    let close_btn = ui.small_button("✕").on_hover_text("Close (Esc)");
+                    #[cfg(feature = "mcp")]
+                    self.mcp_bridge
+                        .register_widget("Search: Close", "button", &close_btn, None);
+                    if close_btn.clicked() {
+                        outcome.close_requested = true;
+                    }
+                });
+            });
+        });
+
+        outcome
+    }
+
+    /// Move the active match index forward (dir > 0) or backward (dir < 0), wrapping
+    /// around, and request a scroll-to-line via `pending_scroll_offset`.
+    fn jump_match(&mut self, dir: i32) {
+        let n = self
+            .tabs
+            .get(self.active_tab)
+            .map(|t| t.search_matches.len())
+            .unwrap_or(0);
+        if n == 0 {
+            return;
+        }
+        let new_idx = if dir >= 0 {
+            (self.search.active_match_index + 1) % n
+        } else if self.search.active_match_index == 0 {
+            n - 1
+        } else {
+            self.search.active_match_index - 1
+        };
+        self.search.active_match_index = new_idx;
+        self.scroll_to_active_match();
+    }
+
+    /// Request a scroll-to-line for the current `active_match_index`. No-op when
+    /// there's no active tab, no matches, or content height hasn't been measured yet.
+    /// Used both by `jump_match` (cycling) and by `maybe_rebuild_search` (so typing a
+    /// fresh query or switching tabs lands the view on the first match instead of
+    /// leaving the view at wherever the user previously scrolled).
+    fn scroll_to_active_match(&mut self) {
+        let idx = self.search.active_match_index;
+        let tab = match self.tabs.get_mut(self.active_tab) {
+            Some(t) => t,
+            None => return,
+        };
+        let Some(m) = tab.search_matches.get(idx) else {
+            return;
+        };
+        if tab.last_content_height <= 0.0 || tab.content_lines == 0 {
+            return;
+        }
+        // Line-ratio estimate gets the view roughly in the right area. The renderer
+        // records the actual y of the active match during paint; render_tab_content
+        // schedules a corrective scroll next frame if this estimate was off.
+        let estimated_y = (m.line_number as f32 / tab.content_lines as f32)
+            * tab.last_content_height;
+        let margin = if tab.last_viewport_height > 0.0 {
+            tab.last_viewport_height * 0.35
+        } else {
+            100.0
+        };
+        tab.pending_scroll_offset = Some((estimated_y - margin).max(0.0));
+    }
+
+    /// Rebuild the active tab's search matches if the query or active tab has changed.
+    /// Cheap (no-op) when nothing changed.
+    fn maybe_rebuild_search(&mut self) {
+        if !self.search.is_open {
+            return;
+        }
+        let tab_idx = self.active_tab;
+        let needs_rebuild = self.search.query != self.search.last_query
+            || self.search.last_tab != Some(tab_idx);
+        if !needs_rebuild {
+            return;
+        }
+        let q = self.search.query.clone();
+        if let Some(tab) = self.tabs.get_mut(tab_idx) {
+            tab.rebuild_search(&q);
+        }
+        self.search.last_query = q;
+        self.search.last_tab = Some(tab_idx);
+        // Always start at the first match after any rebuild — query change, tab
+        // change, or watcher reload. Match indices are not semantically comparable
+        // across rebuilds; preserving a numeric index across docs is coincidental
+        // (matches Firefox / Chrome / VS Code behavior).
+        self.search.active_match_index = 0;
+        // Scroll to the new first match so the user sees the active highlight
+        // immediately rather than wherever they were previously scrolled. Without
+        // this, the visible match (somewhere else on screen) gets the regular
+        // highlight color, leaving the user with the impression that the active
+        // highlight is "stuck on the previous result".
+        self.scroll_to_active_match();
+    }
+
+    /// Close the find bar and clear highlight state on every tab.
+    fn close_search(&mut self) {
+        self.search.is_open = false;
+        self.search.query.clear();
+        self.search.last_query.clear();
+        self.search.last_tab = None;
+        self.search.focus_requested = false;
+        self.search.active_match_index = 0;
+        for tab in self.tabs.iter_mut() {
+            tab.search_matches.clear();
+            tab.cache.clear_search_ranges();
         }
     }
 
@@ -2033,7 +2378,28 @@ impl MarkdownApp {
     fn render_tab_content(&mut self, ui: &mut egui::Ui, ctrl_held: bool) -> Option<PathBuf> {
         let mut open_in_new_tab: Option<PathBuf> = None;
 
+        // Snapshot search state before taking a mutable borrow on the active tab
+        let search_is_open = self.search.is_open;
+        let active_idx = self.search.active_match_index;
+
         let tab = self.tabs.get_mut(self.active_tab)?;
+
+        // Push current search match ranges into the cache so the renderer can paint highlights
+        if search_is_open && !tab.search_matches.is_empty() {
+            let ranges: Vec<_> = tab
+                .search_matches
+                .iter()
+                .map(|m| m.byte_start..m.byte_end)
+                .collect();
+            let active = tab
+                .search_matches
+                .get(active_idx)
+                .map(|m| m.byte_start..m.byte_end);
+            tab.cache.set_search_ranges(ranges);
+            tab.cache.set_active_search_range(active);
+        } else {
+            tab.cache.clear_search_ranges();
+        }
 
         // Content area (no inner CentralPanel needed - we're already in one)
         // Left margin for breathing room, right margin prevents scrollbar/resize-handle overlap jitter
@@ -2064,6 +2430,7 @@ impl MarkdownApp {
 
                 let mut scroll_output = scroll_area.show_viewport(ui, |ui, viewport| {
                     tab.scroll_offset = viewport.min.y;
+                    tab.last_viewport_height = viewport.height();
                     tab.cache.set_scroll_offset(viewport.min.y);
 
                     CommonMarkViewer::new()
@@ -2083,6 +2450,29 @@ impl MarkdownApp {
                 });
 
                 tab.last_content_height = scroll_output.content_size.y;
+
+                // If the renderer recorded an exact y for the active match, check
+                // whether the current scroll position keeps it visible. If not,
+                // schedule a corrective scroll using the recorded y — this fixes
+                // line-ratio overshoot/undershoot in image-heavy documents.
+                if let Some(actual_y) = tab.cache.active_search_y() {
+                    let current_scroll = scroll_output.state.offset.y;
+                    let viewport_top = current_scroll;
+                    let viewport_bottom = current_scroll + tab.last_viewport_height;
+                    // Consider "not visible" if outside the viewport with a small margin
+                    let margin_outside = 20.0_f32;
+                    let needs_correction = actual_y < viewport_top + margin_outside
+                        || actual_y > viewport_bottom - margin_outside;
+                    if needs_correction && tab.last_viewport_height > 0.0 {
+                        // Place the active match ~35% from the top of the viewport
+                        let inset = tab.last_viewport_height * 0.35;
+                        let want_scroll = (actual_y - inset).max(0.0);
+                        // Avoid stomping if we're already at the target (within a frame)
+                        if (want_scroll - current_scroll).abs() > 2.0 {
+                            tab.pending_scroll_offset = Some(want_scroll);
+                        }
+                    }
+                }
 
                 // Manual scroll handling for mouse wheel during text selection
                 let pointer_over_content = ui.ctx().input(|i| {
@@ -2858,6 +3248,10 @@ impl eframe::App for MarkdownApp {
         let mut next_tab = false;
         let mut prev_tab = false;
         let mut focus_tab: Option<usize> = None;
+        let mut open_search = false;
+        let mut next_match = false;
+        let mut prev_match = false;
+        let mut close_search_kb = false;
 
         // Ctrl+/- zoom: applies to lightbox when open, document otherwise
         ctx.input(|i| {
@@ -2971,6 +3365,31 @@ impl eframe::App for MarkdownApp {
                 if i.key_pressed(egui::Key::F5) {
                     toggle_watch = true;
                 }
+                // Ctrl+F: Open find bar (or refocus if already open)
+                if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::F) {
+                    open_search = true;
+                }
+                // While the find bar is open, intercept Enter / Shift+Enter / ↑↓ / Esc.
+                // Up/Down are safe to bind even when the singleline TextEdit has focus
+                // because it doesn't use vertical arrows for cursor movement.
+                if self.search.is_open {
+                    if i.key_pressed(egui::Key::Enter) {
+                        if i.modifiers.shift {
+                            prev_match = true;
+                        } else {
+                            next_match = true;
+                        }
+                    }
+                    if i.key_pressed(egui::Key::ArrowDown) {
+                        next_match = true;
+                    }
+                    if i.key_pressed(egui::Key::ArrowUp) {
+                        prev_match = true;
+                    }
+                    if i.key_pressed(egui::Key::Escape) {
+                        close_search_kb = true;
+                    }
+                }
             });
         } // end lightbox guard
 
@@ -3021,6 +3440,21 @@ impl eframe::App for MarkdownApp {
             }
         }
 
+        // Search bar actions (Ctrl+F open, Enter/Shift+Enter cycle, Esc close)
+        if open_search {
+            self.search.is_open = true;
+            self.search.focus_requested = true;
+        }
+        if next_match {
+            self.jump_match(1);
+        }
+        if prev_match {
+            self.jump_match(-1);
+        }
+        if close_search_kb {
+            self.close_search();
+        }
+
         // Handle drag and drop
         self.is_dragging = false;
         ctx.input(|i| {
@@ -3061,6 +3495,17 @@ impl eframe::App for MarkdownApp {
                         .clicked()
                     {
                         self.close_active_tab();
+                        ui.close();
+                    }
+
+                    ui.separator();
+
+                    if ui
+                        .add(egui::Button::new("Find...").shortcut_text("Ctrl+F"))
+                        .clicked()
+                    {
+                        self.search.is_open = true;
+                        self.search.focus_requested = true;
                         ui.close();
                     }
 
@@ -3298,6 +3743,20 @@ impl eframe::App for MarkdownApp {
             self.error_message = None;
         }
 
+        // Find bar (conditional, between error bar and tab bar)
+        let search_outcome = self.render_search_bar(ctx);
+        // Rebuild matches if query or tab changed (TextEdit may have mutated the query)
+        self.maybe_rebuild_search();
+        if search_outcome.close_requested {
+            self.close_search();
+        }
+        if search_outcome.next_clicked {
+            self.jump_match(1);
+        }
+        if search_outcome.prev_clicked {
+            self.jump_match(-1);
+        }
+
         // Tab bar
         let mut tab_to_close: Option<usize> = None;
         egui::TopBottomPanel::top("tab_bar").show(ctx, |ui| {
@@ -3475,3 +3934,128 @@ Visit [egui](https://github.com/emilk/egui) for more information.
 
 [^1]: This is a footnote with additional details.
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_matches_empty_query_returns_none() {
+        assert_eq!(find_matches("hello world", ""), vec![]);
+    }
+
+    #[test]
+    fn find_matches_empty_content_returns_none() {
+        assert_eq!(find_matches("", "hello"), vec![]);
+    }
+
+    #[test]
+    fn find_matches_single_ascii() {
+        let m = find_matches("hello world", "world");
+        assert_eq!(m.len(), 1);
+        assert_eq!(m[0].byte_start, 6);
+        assert_eq!(m[0].byte_end, 11);
+        assert_eq!(m[0].line_number, 1);
+    }
+
+    #[test]
+    fn find_matches_case_insensitive_ascii() {
+        let m = find_matches("Hello WORLD", "world");
+        assert_eq!(m.len(), 1);
+        assert_eq!(&"Hello WORLD"[m[0].byte_start..m[0].byte_end], "WORLD");
+    }
+
+    #[test]
+    fn find_matches_multiple_per_line() {
+        // "foo bar foo baz foo" → 3 matches, all on line 1
+        let m = find_matches("foo bar foo baz foo", "foo");
+        assert_eq!(m.len(), 3);
+        assert!(m.iter().all(|sm| sm.line_number == 1));
+        let starts: Vec<_> = m.iter().map(|sm| sm.byte_start).collect();
+        assert_eq!(starts, vec![0, 8, 16]);
+    }
+
+    #[test]
+    fn find_matches_line_numbers_one_based() {
+        let content = "first line\nsecond match here\nthird\nmatch on four";
+        let m = find_matches(content, "match");
+        assert_eq!(m.len(), 2);
+        assert_eq!(m[0].line_number, 2);
+        assert_eq!(m[1].line_number, 4);
+    }
+
+    #[test]
+    fn find_matches_preserves_byte_offsets_with_utf8() {
+        // "café résumé naïve" — each accented char is 2 bytes in UTF-8
+        let content = "café résumé naïve";
+        let m = find_matches(content, "café");
+        assert_eq!(m.len(), 1);
+        // Confirm byte range slices back to the original substring
+        assert_eq!(&content[m[0].byte_start..m[0].byte_end], "café");
+    }
+
+    #[test]
+    fn find_matches_skips_cross_newline_matches() {
+        // Query "oo\nb" theoretically spans two lines — should not be reported
+        let content = "foo\nbar";
+        let m = find_matches(content, "oo\nb");
+        assert_eq!(m, vec![]);
+    }
+
+    #[test]
+    fn find_matches_overlapping_uses_match_indices_semantics() {
+        // str::match_indices does NOT overlap matches: "aaaa" / "aa" → [0, 2]
+        let m = find_matches("aaaa", "aa");
+        let starts: Vec<_> = m.iter().map(|sm| sm.byte_start).collect();
+        assert_eq!(starts, vec![0, 2]);
+    }
+
+    #[test]
+    fn find_matches_skips_image_alt_text() {
+        // Image alt text isn't visibly rendered (used only as hover/screen-reader text).
+        // A match inside the alt portion of `![alt](url)` would have no visible target
+        // for highlighting/scrolling — exclude it.
+        let content = "See ![Syntax docs](pic.png) and the syntax guide.";
+        let m = find_matches(content, "syntax");
+        let starts: Vec<_> = m.iter().map(|sm| sm.byte_start).collect();
+        assert_eq!(m.len(), 1, "got {:?}", m);
+        // The surviving match is "syntax" in "the syntax guide", not "Syntax" in alt
+        assert_eq!(&content[starts[0]..starts[0] + 6], "syntax");
+    }
+
+    #[test]
+    fn find_matches_skips_image_url() {
+        // Image URL isn't visibly rendered — exclude matches inside.
+        let content = "![ok](path/syntax.png) more text";
+        let m = find_matches(content, "syntax");
+        assert_eq!(m.len(), 0, "URL match should be filtered: {:?}", m);
+    }
+
+    #[test]
+    fn find_matches_skips_link_url_keeps_link_text() {
+        // Link text IS rendered (visible clickable text). Link URL is not.
+        let content = "Click [syntax docs](https://example.com/syntax.html) here";
+        let m = find_matches(content, "syntax");
+        // Two raw matches: "syntax" in link text (visible) + "syntax" in URL (invisible)
+        assert_eq!(m.len(), 1, "should keep link text, drop URL: {:?}", m);
+        let s = m[0].byte_start;
+        // The kept match is "syntax" in "[syntax docs]" (visible link text)
+        assert_eq!(&content[s..s + 6], "syntax");
+        // And it's the FIRST occurrence (inside the brackets), not the URL one
+        assert!(s < content.find("https").unwrap());
+    }
+
+    #[test]
+    fn find_matches_multiple_alt_text_images() {
+        let content = "![a one](u.png) one ![two two](w.png) two";
+        let m = find_matches(content, "one");
+        let starts: Vec<_> = m.iter().map(|sm| sm.byte_start).collect();
+        // Two raw "one" matches in alt + 1 in visible text → only 1 survives
+        assert_eq!(m.len(), 1);
+        assert_eq!(&content[starts[0]..starts[0] + 3], "one");
+
+        let m2 = find_matches(content, "two");
+        // Two raw "two" matches in alt + 1 in visible text → only 1 survives
+        assert_eq!(m2.len(), 1);
+    }
+}


### PR DESCRIPTION
Closes #4.

## Summary
- Ctrl+F opens a find bar above the tab bar. Inline yellow highlights for all matches in the active tab; brighter orange for the active match.
- Cycle with **Enter / Shift+Enter**, **ArrowDown / ArrowUp**, or on-screen **↑ / ↓** buttons. Esc closes.
- File → Find... menu entry for discoverability.
- Per-tab match storage; query change / tab switch / file-watcher reload all rebuild correctly.

## Implementation notes
- `find_matches` is case-insensitive ASCII via `to_ascii_lowercase` so byte offsets stay 1:1 with the original content (full Unicode case folding would change byte length and break the offset model).
- Matches inside non-renderable markdown are filtered: image alt `![alt]...`, image URLs, link URLs. Link *text* is kept (visibly rendered).
- Inline highlights come from the vendored `egui_commonmark` fork via a new search-range API on `CommonMarkCache`. `pulldown.rs` `Event::Text` and non-wrapped `Event::Code` are split at search-range boundaries; each matching segment emits a `RichText::background_color(...)`.
- Inline code highlight needs to bypass `.code()` (egui replaces user bg with `code_bg_color` when `.code()` is set; widget_text.rs:421). `emit_text` builds the RichText manually with `text_style(Monospace)` instead.
- **Two-stage scroll** handles image-heavy docs: jump_match sets a line-ratio estimate; the renderer records the actual y of the Active highlight via `cache.record_active_search_y_viewport`; after `show_viewport` returns, if the recorded y is off-screen, schedule a corrective scroll for the next frame.

## Test plan
- [x] `cargo test --bin md-viewer` — 13/13 pass (find_matches edge cases including alt/URL filtering)
- [x] `cargo clippy --features mcp -- -D warnings` clean for new code
- [x] `cargo build --release` — 35 MB, no regression vs main
- [x] MCP E2E on Xvfb: cycle every "syntax" match in README, pixel-sample HL_ACTIVE_DARK at each — all 6 matches show the brighter active color and land inside the viewport
- [x] Wraparound (last → first) and backward cycling verified
- [x] Esc closes bar, removes all highlights, restores AccessKit node count to baseline

## Caveats / future work
Listed in `docs/devlog/019-search-find.md` Future Improvements: cross-tab find-all, case toggle, whole-word, regex, F3 alternates, per-tab badges, search history, full per-match y recording (currently only active match is recorded).

## E2E unblock
The MCP test above required a new `egui_key` tool in `egui-mcp` (separate repo, also landing today) — egui's `MenuBar` items aren't in AccessKit and Xvfb has no WM to route xdotool keys, so keyboard-shortcut features were previously untestable end-to-end.