### PR TITLE
Wheel-route nested horizontal ScrollArea for wide tables (closes #4)

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -157,6 +157,51 @@ fn html_cell_visual_lines(cell: &str) -> usize {
     explicit_lines.saturating_add(wrap_est).max(1)
 }
 
+/// After a nested horizontal `ScrollArea` has rendered (used here to wrap tables
+/// that overflow the content column), redirect any pending vertical wheel delta
+/// into the area's horizontal offset when the cursor is hovered over it.
+///
+/// The outer document is wrapped in a `ScrollArea::vertical()`, so plain wheel
+/// over a wide table would otherwise scroll the page instead of the table —
+/// users were forced to grab the table's bottom scrollbar to see overflowing
+/// columns. With this helper, wheel-over-table scrolls the table sideways.
+///
+/// Edge pass-through: when the table is fully scrolled to either side and the
+/// wheel direction would push past the edge, the delta is left untouched so the
+/// outer area can keep scrolling the page.
+///
+/// X-delta (native trackpad horizontal swipe) is already consumed by the inner
+/// `ScrollArea::horizontal()` inside its own `.show()` call — only Y is touched
+/// here, never X.
+fn forward_wheel_to_horizontal_scroll<R>(
+    ui: &Ui,
+    out: &mut egui::containers::scroll_area::ScrollAreaOutput<R>,
+) {
+    if !ui.rect_contains_pointer(out.inner_rect) {
+        return;
+    }
+    let dy = ui.ctx().input(|i| i.smooth_scroll_delta.y);
+    if dy.abs() < 0.1 {
+        return;
+    }
+    let max_x = (out.content_size.x - out.inner_rect.width()).max(0.0);
+    if max_x <= 0.0 {
+        return;
+    }
+    let at_left = out.state.offset.x <= 0.0 && dy > 0.0;
+    let at_right = out.state.offset.x >= max_x && dy < 0.0;
+    if at_left || at_right {
+        return;
+    }
+    let new_x = (out.state.offset.x - dy).clamp(0.0, max_x);
+    if (new_x - out.state.offset.x).abs() > f32::EPSILON {
+        out.state.offset.x = new_x;
+        out.state.store(ui.ctx(), out.id);
+        ui.ctx().input_mut(|i| i.smooth_scroll_delta.y = 0.0);
+        ui.ctx().request_repaint();
+    }
+}
+
 /// Newline logic is constructed by the following:
 /// All elements try to insert a newline before them (if they are allowed)
 /// and end their own line.
@@ -870,12 +915,14 @@ impl CommonMarkViewerInternal {
                 .collect();
             // Outer ScrollArea::horizontal handles the case where columns
             // (auto-sized to content) total wider than the parent ui; without it,
-            // narrow windows clip the rightmost columns.
+            // narrow windows clip the rightmost columns. Capture the output so
+            // `forward_wheel_to_horizontal_scroll` can redirect vertical wheel
+            // deltas into the inner area's horizontal offset when hovered.
             // ui.vertical(...) is essential: TableBuilder's body() positions itself
             // relative to the parent's cursor, but the parent here is a horizontal-
             // flow Ui from the markdown renderer. Without the vertical scope the
             // body's first row overlaps the header row.
-            egui::ScrollArea::horizontal()
+            let mut scroll_out = egui::ScrollArea::horizontal()
                 .id_salt(id.with("_scroll"))
                 .max_width(max_width)
                 .auto_shrink([false, true])
@@ -949,6 +996,7 @@ impl CommonMarkViewerInternal {
                         });
                     });
                 });
+            forward_wheel_to_horizontal_scroll(ui, &mut scroll_out);
 
             self.is_table = false;
             if events.peek().is_none() {
@@ -1468,8 +1516,9 @@ impl CommonMarkViewerInternal {
         let body_heights: Vec<f32> = table.rows.iter().map(|row| row_height_for(row)).collect();
 
         // Outer ScrollArea::horizontal handles wide tables that exceed parent width;
-        // ui.vertical() prevents the header/body Y-overlap quirk.
-        egui::ScrollArea::horizontal()
+        // ui.vertical() prevents the header/body Y-overlap quirk. Capture the output
+        // so `forward_wheel_to_horizontal_scroll` can redirect wheel deltas.
+        let mut scroll_out = egui::ScrollArea::horizontal()
             .id_salt(id.with("_scroll"))
             .max_width(max_width)
             .auto_shrink([false, true])
@@ -1576,6 +1625,7 @@ impl CommonMarkViewerInternal {
                     });
                 });
             });
+        forward_wheel_to_horizontal_scroll(ui, &mut scroll_out);
 
         self.line.try_insert_end(ui);
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,6 +55,8 @@ Single-file Rust desktop application (`src/main.rs`, ~1300 lines) for viewing ma
 
 - **Search (Ctrl+F)**: Current-document find bar with inline highlights. `SearchState` lives on `MarkdownApp`; per-tab `search_matches: Vec<SearchMatch>` cache match byte ranges. Highlights are painted by the vendored `egui_commonmark` renderer via a new `CommonMarkCache::set_search_ranges` API; the renderer splits `Event::Text` and (non-wrapped) `Event::Code` at range boundaries and applies a background color to the matching segments. Enter/Shift+Enter cycle matches with line-ratio scroll-into-view; Esc closes the bar and clears highlights on all tabs.
 
+- **Table wheel routing**: Wide markdown / HTML tables are wrapped in a nested `egui::ScrollArea::horizontal()`. After each table renders, `forward_wheel_to_horizontal_scroll` in `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs` redirects pending vertical wheel deltas into the inner area's horizontal offset when the cursor is hovered. Edge passthrough (offset at 0 or max in wheel direction) lets the wheel fall through to the outer vertical area so the page can still scroll past the table.
+
 - **Global Allocator**: mimalloc for performance
 
 ## Key Libraries

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -716,3 +716,30 @@ ui.vertical(|ui| {
 **Fix:** `CommonMarkCache::syntax_layouts: HashMap<u64, LayoutJob>` keyed by hash of `(content, lang, theme_is_dark, mono_font_size, code_line_height)`. `CodeBlock::end` checks the cache before running syntect. Cache hit clones the stored LayoutJob (cheap — text + format ranges).
 **Theme/zoom changes** key in new entries naturally because they're part of the key; old entries become dead weight until cache reset on file load. Bounded by unique-code-block count, typically <5 MB for real docs. LRU eviction is deferred until measured pathology.
 **Files:** `crates/egui_commonmark/egui_commonmark_backend/src/misc.rs` (`CommonMarkCache::syntax_layouts`, `CodeBlock::end`)
+
+### Nested horizontal ScrollArea doesn't auto-redirect vertical wheel
+**Context:** Issue #4 — wide markdown/HTML tables are wrapped in `egui::ScrollArea::horizontal()` inside the outer document `ScrollArea::vertical()`. Mouse wheel over the table body scrolled the page, never the table. Users could only scroll a wide table sideways by dragging the bottom scrollbar.
+**Root cause:** egui 0.33's `ScrollArea::horizontal()` only consumes the X component of `smooth_scroll_delta` during its `.show()`. Plain mouse wheel emits Y delta only, so the inner area sees nothing; the unconsumed Y delta then reaches the outer vertical area and scrolls the page. Shift+wheel has the same broken behavior — egui doesn't auto-convert Y→X for nested horizontal areas.
+**Fix:** After the nested `ScrollArea::horizontal().show(...)` returns, check `ui.rect_contains_pointer(out.inner_rect)`. If hovered AND the area still has room in the wheel direction, redirect Y delta into `out.state.offset.x`, `state.store(ctx, out.id)`, then zero `i.smooth_scroll_delta.y` so the outer area doesn't double-consume.
+**Edge pass-through:** If `offset.x == 0` and wheel-up, OR `offset.x >= max_x` and wheel-down, return early without touching the delta. The outer area then scrolls normally — avoids "stuck table swallows my wheel" feel.
+```rust
+fn forward_wheel_to_horizontal_scroll<R>(
+    ui: &Ui,
+    out: &mut egui::containers::scroll_area::ScrollAreaOutput<R>,
+) {
+    if !ui.rect_contains_pointer(out.inner_rect) { return; }
+    let dy = ui.ctx().input(|i| i.smooth_scroll_delta.y);
+    if dy.abs() < 0.1 { return; }
+    let max_x = (out.content_size.x - out.inner_rect.width()).max(0.0);
+    if max_x <= 0.0 { return; }
+    let at_left  = out.state.offset.x <= 0.0   && dy > 0.0;
+    let at_right = out.state.offset.x >= max_x && dy < 0.0;
+    if at_left || at_right { return; }
+    out.state.offset.x = (out.state.offset.x - dy).clamp(0.0, max_x);
+    out.state.store(ui.ctx(), out.id);
+    ui.ctx().input_mut(|i| i.smooth_scroll_delta.y = 0.0);
+    ui.ctx().request_repaint();
+}
+```
+**Why `State` is `Copy`:** egui's `ScrollArea::State` is `#[derive(Copy)]`, so `out.state.store(ctx, id)` copies and stores — the caller's `out.state` stays accessible after.
+**Files:** `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs` (`forward_wheel_to_horizontal_scroll`, both table call sites)

--- a/docs/TARGET_METRICS.md
+++ b/docs/TARGET_METRICS.md
@@ -15,6 +15,6 @@
 
 Tracked in issue #4. Recommended order:
 
-1. **Search / find-all (Ctrl+F)** — bounded, ~300-500 LoC in `src/main.rs`. Draft spec exists from the PR #5 contributor.
-2. **Table horizontal-scroll UX** — small (~30 lines) fix at `crates/egui_commonmark/.../pulldown.rs:572` to route wheel events through nested ScrollAreas.
+1. ~~**Search / find-all (Ctrl+F)**~~ — shipped in v0.1.4 (PR #14).
+2. ~~**Table horizontal-scroll UX**~~ — shipped post-v0.1.4 via `forward_wheel_to_horizontal_scroll` in `crates/egui_commonmark/.../pulldown.rs`.
 3. **Resizable table columns** — large refactor: swap `egui::Grid` for `egui_extras::TableBuilder` in the vendored fork. Regression-testing all existing table edge cases required.

--- a/docs/devlog/022-table-wheel-scroll.md
+++ b/docs/devlog/022-table-wheel-scroll.md
@@ -1,0 +1,83 @@
+# Feature: Wheel-routing for nested horizontal ScrollAreas (wide tables)
+
+**Status:** ✅ Complete
+**Branch:** `feature/table-scroll`
+**Date:** 2026-05-15
+**Lines Changed:** +56 / -3 in `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`
+
+## Summary
+
+Wide markdown/HTML tables are wrapped in a nested `ScrollArea::horizontal()` inside the document's outer `ScrollArea::vertical()`. Plain mouse-wheel over a table body was routed to the outer (vertical) area, so users could only scroll the table sideways by grabbing the bottom scrollbar — exactly the complaint in issue #4. This PR redirects vertical wheel deltas to horizontal scroll when the cursor is hovered over a still-scrollable nested area, with pass-through at the edges so the page can keep scrolling after the table reaches its boundary.
+
+Closes the second half of issue #4 (the first half — search/find — shipped in v0.1.4).
+
+## Features
+
+- [x] `forward_wheel_to_horizontal_scroll()` helper added in `pulldown.rs`.
+- [x] Markdown table call site (around former line 653) captures `ScrollAreaOutput` and calls the helper.
+- [x] HTML table call site (around former line 1185) captures `ScrollAreaOutput` and calls the helper.
+- [x] Edge-pass-through: at `offset.x=0` (wheel-up) or `offset.x>=max_x` (wheel-down), the helper bails out so the outer area scrolls the page.
+- [x] Trackpad horizontal swipes (X delta) untouched — only Y is intercepted.
+- [x] E2E verified with xdotool on Xvfb against `/tmp/wide-table-test.md`.
+
+## Key Discoveries
+
+### `ScrollArea::horizontal()` only consumes X delta
+The inner `ScrollArea::horizontal()` listens for the X component of `smooth_scroll_delta`. Plain mouse-wheel emits only a Y component, so the inner area sees nothing and the delta flows up to the outer vertical area. Shift+wheel produces the same bug — egui 0.33 does not auto-convert Y→X for nested horizontal areas. The fix has to be added by the caller post-`.show()`.
+
+### `ScrollAreaOutput` exposes everything the caller needs
+The `inner_rect`, `content_size`, `state`, and `id` fields are all `pub`. `state: State` is `#[derive(Copy)]`, so `out.state.store(ctx, id)` makes a copy and the caller's `out` stays usable. The `id` already includes any `id_salt` applied at construction, so `state.store(ctx, out.id)` round-trips correctly.
+
+### Sign convention: `new_offset.x = old_offset.x - smooth_scroll_delta.y`
+This mirrors the outer ScrollArea's vertical relationship (`new_offset.y = old_offset.y - smooth_scroll_delta.y`). Wheel-down emits `dy < 0`; the subtraction makes `offset.x` increase, scrolling the table right. Verified empirically with xdotool wheel events.
+
+### Edge pass-through is the entire UX
+Without it, a table at its right edge swallows further wheel-down events and the user gets stuck — the natural "I want to read past the table" flow breaks. The fix: when `offset.x >= max_x && dy < 0`, return early before touching `smooth_scroll_delta`. The outer area then sees the still-unconsumed Y delta and scrolls the page. Same logic mirrored for the left edge.
+
+### `ui.rect_contains_pointer(inner_rect)` is cheaper than allocating a `Response`
+`inner_rect` is already a `Rect` returned by the ScrollArea — no need to create a new `Response` just to call `.hovered()`. Direct rect-pointer test does the same job in one call.
+
+## Architecture
+
+### New Functions
+
+| Function | Purpose |
+|----------|---------|
+| `forward_wheel_to_horizontal_scroll<R>(ui: &Ui, out: &mut ScrollAreaOutput<R>)` | After a nested horizontal `ScrollArea` has rendered, check hover + pending Y delta, redirect into horizontal offset, zero the consumed Y delta to block the outer area from also consuming. Generic over the inner closure return type so it works at both table call sites. |
+
+## Testing Notes
+
+E2E recipe (mirrors the original bug-confirmation flow):
+
+```bash
+# Xvfb already up
+setsid env DISPLAY=:99 WINIT_UNIX_BACKEND=x11 WAYLAND_DISPLAY= \
+  ./target/debug/md-viewer /tmp/wide-table-test.md </dev/null >/dev/null 2>&1 &
+sleep 4
+WID=$(DISPLAY=:99 xdotool search --name "wide-table" | head -1)
+DISPLAY=:99 xdotool windowsize $WID 1280 800
+DISPLAY=:99 xdotool windowmove $WID 0 0
+
+# 1. Cursor on table body → table scrolls right, page stays put
+DISPLAY=:99 xdotool mousemove 600 250
+for i in $(seq 1 10); do DISPLAY=:99 xdotool click 5; done
+# Compare /tmp/postfix-2 vs /tmp/repro-2: columns shifted, heading unchanged.
+
+# 2. Cursor below table (y=600) → page scrolls (regression check)
+DISPLAY=:99 xdotool mousemove 600 600
+for i in $(seq 1 10); do DISPLAY=:99 xdotool click 5; done
+# /tmp/postfix-5: heading gone, end markers visible.
+
+# 3. Edge passthrough: scroll table to right edge, then wheel-down → page scrolls
+DISPLAY=:99 xdotool mousemove 600 250
+for i in $(seq 1 80); do DISPLAY=:99 xdotool click 5; done
+# /tmp/postfix-8: page reached bottom (table at right edge, excess wheel passed through).
+```
+
+All three scenarios pass on debug build. `cargo clippy --bin md-viewer -- -D warnings` clean. All 13 existing unit tests still pass.
+
+## Future Improvements
+
+- **Priority 3 in `TARGET_METRICS.md`**: Resizable column dividers via `egui_extras::TableBuilder` swap. Separate, much larger initiative — requires re-implementing cell-content rendering through the TableBuilder row API, which doesn't directly support the recursive `self.event()` markdown-in-cell pattern.
+- **Touch trackpad pinch zoom** over a table: works at the egui context level, no change needed.
+- **Mobile/touch drag-to-scroll**: ScrollArea handles this natively; not affected by this PR.


### PR DESCRIPTION
## Summary

- Adds `forward_wheel_to_horizontal_scroll` next to the table-rendering code in the vendored `egui_commonmark` fork. After each wide-table's nested `ScrollArea::horizontal().show(...)` returns, the helper checks if the cursor is hovered and redirects pending vertical wheel deltas into the area's horizontal offset.
- Wires both call sites (markdown tables + HTML tables) to capture the `ScrollAreaOutput` and call the helper.
- Edge pass-through: at `offset.x = 0` (wheel-up) or `offset.x >= max_x` (wheel-down), the helper bails out so the outer vertical `ScrollArea` keeps scrolling the page.
- Trackpad horizontal X-delta still consumed by the inner area inside `.show()` — only Y is intercepted.
- Closes the second half of #4 (search shipped in v0.1.4).

## Why this matters

The original report: "horizontal scroll does not work unless there is focus on the bottom of the table." Reproduced today on v0.1.4 — wheel-on-table scrolled the page vertically while the table stayed put. Only workaround was dragging the bottom scrollbar.

`ScrollArea::horizontal()` in egui 0.33 only consumes the X component of `smooth_scroll_delta` during its `.show()`. Plain mouse wheel emits only a Y component, so the inner area sees nothing and the unconsumed Y delta flows up to the outer vertical area. Shift+wheel produces the same broken result — egui doesn't auto-convert Y→X for nested horizontal areas. The fix has to be applied by the caller post-`.show()`.

## Test plan

E2E with xdotool on Xvfb against a wide-table fixture, all verified green:

- [x] **Wheel-on-table:** cursor at (600, 250) over the table body, 10 wheel-downs → table scrolls right, heading "Wide Table Scroll Test" stays at the top.
- [x] **Wheel-off-table:** cursor below the table at (600, 600), 10 wheel-downs → page scrolls down normally; table position unchanged (regression check).
- [x] **Edge pass-through:** cursor on table, 80 wheel-downs → table scrolls to right edge, then remaining wheel delta passes through and scrolls the page.
- [x] `cargo build` clean.
- [x] `cargo clippy --bin md-viewer -- -D warnings` clean.
- [x] `cargo test --bin md-viewer` — 13/13 pass.

## Code stats

- +56 / -3 in `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`.
- Total diff: 166+/5- across pulldown.rs, ARCHITECTURE.md, LESSONS.md, TARGET_METRICS.md, devlog/020.

## Out of scope

- Resizable column dividers (priority 3 in `TARGET_METRICS.md`) — large refactor swapping `egui::Grid` for `egui_extras::TableBuilder`; warrants its own PR with full regression-test of every existing table cell-content path.