### PR TITLE
v0.1.7 follow-ups: duplicate-headers + image-lightbox + bootstrap scroll fix

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -614,10 +614,14 @@ impl CommonMarkViewerInternal {
         let page_size_opt = scroll_cache(cache, &source_id).page_size;
         let Some(page_size) = page_size_opt else {
             let out = make_scroll_area().show(ui, |ui| {
-                // The inner show() runs in normal ScrollArea content space
-                // (no viewport translation), so 0.0 is the right baseline
-                // for record_header_position / record_active_search_y.
-                cache.set_scroll_offset(0.0);
+                // The inner show() runs inside a scrolled ScrollArea. The
+                // cursor is viewport-relative, so we add the *current scroll
+                // offset* — not 0 — to convert to content-relative y when
+                // recording header / active-search positions. A non-zero
+                // pending_scroll_offset means the caller jumped to that
+                // position this frame; without this, the bootstrap records
+                // every position shifted by -pending, corrupting the cache.
+                cache.set_scroll_offset(pending_scroll_offset.unwrap_or(0.0));
                 self.show(ui, cache, options, text, Some(source_id));
             });
             // Prevent repopulating points twice at startup

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -1444,7 +1444,7 @@ impl CommonMarkViewerInternal {
             }
             pulldown_cmark::TagEnd::Image => {
                 if let Some(image) = self.image.take() {
-                    image.end(ui, options);
+                    image.end(ui, cache, options);
                 }
             }
             pulldown_cmark::TagEnd::HtmlBlock => {

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -281,6 +281,11 @@ pub struct CommonMarkViewerInternal {
     current_heading_text: String,
     /// Accumulate heading RichText fragments for single render at end
     current_heading_rich_texts: Vec<egui::RichText>,
+    /// Per-render-pass counter: number of headings seen so far with each
+    /// normalized title. Used to build composite cache keys that
+    /// disambiguate duplicate-titled headers (e.g. multiple `## Installation`).
+    /// Reset at the start of each `show*` call so the count restarts at 0.
+    heading_occurrence_counts: std::collections::HashMap<String, usize>,
 }
 
 pub(crate) struct CheckboxClickEvent {
@@ -308,6 +313,7 @@ impl CommonMarkViewerInternal {
             current_heading_y: None,
             current_heading_text: String::new(),
             current_heading_rich_texts: Vec::new(),
+            heading_occurrence_counts: std::collections::HashMap::new(),
         }
     }
 }
@@ -1364,11 +1370,25 @@ impl CommonMarkViewerInternal {
                         }
                     });
                 }
-                // Record header position for scroll navigation (use normalized key)
+                // Record header position for scroll navigation. Composite key
+                // is `normalized_title` for the 0th occurrence and
+                // `normalized_title#N` for the Nth duplicate (matches the key
+                // built by the app's `header_position_key` helper), so multiple
+                // headings with the same title get distinct cache entries.
                 if let Some(y) = self.current_heading_y.take() {
                     if !self.current_heading_text.is_empty() {
                         let normalized = self.current_heading_text.trim().to_lowercase();
-                        cache.record_header_position(&normalized, y);
+                        let nth = self
+                            .heading_occurrence_counts
+                            .entry(normalized.clone())
+                            .or_insert(0);
+                        let key = if *nth == 0 {
+                            normalized.clone()
+                        } else {
+                            format!("{normalized}#{nth}")
+                        };
+                        *nth += 1;
+                        cache.record_header_position(&key, y);
                     }
                 }
                 self.current_heading_text.clear();

--- a/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
@@ -307,12 +307,28 @@ impl Image {
         }
     }
 
-    pub fn end(self, ui: &mut Ui, options: &CommonMarkOptions) {
+    pub fn end(self, ui: &mut Ui, cache: &mut CommonMarkCache, options: &CommonMarkOptions) {
         let response = ui.add(
             egui::Image::from_uri(&self.uri)
                 .fit_to_original_size(1.0)
-                .max_width(options.max_width(ui)),
+                .max_width(options.max_width(ui))
+                .sense(egui::Sense::click()),
         );
+
+        if response.hovered() {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+        }
+
+        if response.clicked() {
+            let load = ui.ctx().try_load_texture(
+                &self.uri,
+                egui::TextureOptions::default(),
+                egui::load::SizeHint::default(),
+            );
+            if let Ok(egui::load::TexturePoll::Ready { texture }) = load {
+                cache.clicked_image = Some((texture.id, texture.size));
+            }
+        }
 
         if !self.alt_text.is_empty() && options.show_alt_text_on_hover {
             response.on_hover_ui_at_pointer(|ui| {
@@ -1380,6 +1396,10 @@ pub struct CommonMarkCache {
     #[cfg(feature = "mermaid")]
     clicked_mermaid: Option<(egui::TextureHandle, egui::Vec2)>,
 
+    /// Set when a regular image is clicked (texture id + intrinsic size for lightbox).
+    /// Texture lifetime is owned by egui's loader, so we only carry the id.
+    clicked_image: Option<(egui::TextureId, egui::Vec2)>,
+
     /// Hash of the diagram that currently has an active background thread.
     /// Only one diagram renders at a time so they appear top-to-bottom.
     #[cfg(feature = "mermaid")]
@@ -1416,6 +1436,7 @@ impl std::fmt::Debug for CommonMarkCache {
         s.field("mermaid_states_count", &self.mermaid_states.len());
         #[cfg(feature = "mermaid")]
         s.field("clicked_mermaid", &self.clicked_mermaid.is_some());
+        s.field("clicked_image", &self.clicked_image.is_some());
         #[cfg(feature = "math")]
         s.field("math_states_count", &self.math_states.len());
         s.finish()
@@ -1460,6 +1481,7 @@ impl Default for CommonMarkCache {
                 })),
             #[cfg(feature = "mermaid")]
             clicked_mermaid: None,
+            clicked_image: None,
             #[cfg(feature = "mermaid")]
             mermaid_rendering: None,
             #[cfg(feature = "math")]
@@ -1523,6 +1545,12 @@ impl CommonMarkCache {
     #[cfg(feature = "mermaid")]
     pub fn take_clicked_mermaid(&mut self) -> Option<(egui::TextureHandle, egui::Vec2)> {
         self.clicked_mermaid.take()
+    }
+
+    /// Take the clicked image texture id and size (if any). Returns `Some` once per click.
+    /// The texture is owned by egui's loader; the id is valid for as long as it stays loaded.
+    pub fn take_clicked_image(&mut self) -> Option<(egui::TextureId, egui::Vec2)> {
+        self.clicked_image.take()
     }
 
     /// Clear the cache for all scrollable elements

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,20 @@ struct PersistedState {
     explorer_sort_order: Option<SortOrder>,
 }
 
+/// Build the composite cache key for a header position lookup. Combines the
+/// normalized (lowercased) title with the occurrence index so duplicate-titled
+/// headers map to distinct entries in `CommonMarkCache::header_positions`.
+/// Both the parser (which assigns `nth_with_same_text` to each `Header`) and
+/// the renderer (which records positions while painting) use this function so
+/// keys agree across the read/write boundary.
+pub fn header_position_key(normalized_title: &str, nth_with_same_text: usize) -> String {
+    if nth_with_same_text == 0 {
+        normalized_title.to_string()
+    } else {
+        format!("{normalized_title}#{nth_with_same_text}")
+    }
+}
+
 /// Represents a markdown header for the outline
 #[derive(Clone)]
 struct Header {
@@ -156,6 +170,11 @@ struct Header {
     display_title: String,
     /// Pre-computed lowercase key for header position cache lookups
     normalized_title: String,
+    /// Occurrence index among headers with the same `normalized_title`.
+    /// The first `## Installation` is 0, the second is 1, etc. Combined
+    /// with `normalized_title` into the composite cache key so duplicates
+    /// scroll to the correct (different) y positions.
+    nth_with_same_text: usize,
     line_number: usize,
 }
 
@@ -596,6 +615,12 @@ struct Tab {
     collapsed_headers: HashSet<usize>,
     scroll_offset: f32,
     pending_scroll_offset: Option<f32>,
+    /// Composite header-position key (see `header_position_key`) waiting for
+    /// a corrective scroll. Set when the outline-click handler used the
+    /// line-ratio fallback because the cache didn't yet have the precise y
+    /// for this key. Cleared once the post-render corrective step has
+    /// snapped the viewport to the recorded position.
+    pending_header_click_key: Option<String>,
     last_content_height: f32,
     last_viewport_height: f32,
     content_lines: usize,
@@ -644,6 +669,7 @@ impl Tab {
             collapsed_headers: HashSet::new(),
             scroll_offset: 0.0,
             pending_scroll_offset: None,
+            pending_header_click_key: None,
             last_content_height: 0.0,
             last_viewport_height: 0.0,
             content_lines,
@@ -679,6 +705,7 @@ impl Tab {
             collapsed_headers: HashSet::new(),
             scroll_offset: 0.0,
             pending_scroll_offset: None,
+            pending_header_click_key: None,
             last_content_height: 0.0,
             last_viewport_height: 0.0,
             content_lines,
@@ -893,7 +920,7 @@ fn truncate_display_name(s: &str, max_len: usize) -> String {
 /// Parse markdown headers from content, skipping code blocks.
 fn parse_headers(content: &str) -> ParsedHeaders {
     let re = &*HEADER_RE;
-    let mut all_headers = Vec::new();
+    let mut all_headers: Vec<Header> = Vec::new();
     let mut in_code_block = false;
 
     for (line_number, line) in content.lines().enumerate() {
@@ -910,11 +937,18 @@ fn parse_headers(content: &str) -> ParsedHeaders {
             let title = caps[2].trim().to_string();
             let normalized_title = title.to_lowercase();
             let display_title = truncate_display_name(&title, 35);
+            // Count prior headers with the same normalized title so each
+            // duplicate gets a distinct composite cache key.
+            let nth_with_same_text = all_headers
+                .iter()
+                .filter(|h| h.normalized_title == normalized_title)
+                .count();
             all_headers.push(Header {
                 level: caps[1].len() as u8,
                 title,
                 display_title,
                 normalized_title,
+                nth_with_same_text,
                 line_number,
             });
         }
@@ -2389,17 +2423,27 @@ impl MarkdownApp {
         // Calculate scroll target if header was clicked
         if let Some(idx) = clicked_header_index {
             if let Some(header) = tab.outline_headers.get(idx) {
-                // Try to get actual rendered position from cache first
-                if let Some(y_pos) = tab.cache.get_header_position(&header.normalized_title) {
-                    // Use exact position if available (header has been rendered)
+                // Composite key disambiguates duplicate-titled headers (e.g. two
+                // `## Installation` sections). Each occurrence has its own
+                // `nth_with_same_text` index assigned at parse time, and the
+                // renderer records positions under the same composite scheme.
+                let key = header_position_key(&header.normalized_title, header.nth_with_same_text);
+                // Try to get actual rendered position from cache first.
+                // With virtualization, the cache may hold a stale value from a
+                // partial render — record the key for the post-render
+                // corrective step which re-checks after the bootstrap full paint.
+                if let Some(y_pos) = tab.cache.get_header_position(&key) {
                     tab.pending_scroll_offset = Some((y_pos - 50.0).max(0.0));
                 } else if tab.last_content_height > 0.0 && tab.content_lines > 0 {
                     // Fallback: estimate position based on line number ratio
-                    // This works for headers that haven't been rendered yet
                     let estimated_y = (header.line_number as f32 / tab.content_lines as f32)
                         * tab.last_content_height;
                     tab.pending_scroll_offset = Some((estimated_y - 50.0).max(0.0));
                 }
+                // Remember the click target — once the bootstrap full paint
+                // triggered by `pending_scroll_offset` populates the cache, the
+                // corrective step in `render_tab_content` snaps to the precise y.
+                tab.pending_header_click_key = Some(key);
             }
         }
     }
@@ -2494,6 +2538,23 @@ impl MarkdownApp {
                         let inset = tab.last_viewport_height * 0.35;
                         let want_scroll = (actual_y - inset).max(0.0);
                         // Avoid stomping if we're already at the target (within a frame)
+                        if (want_scroll - current_scroll).abs() > 2.0 {
+                            tab.pending_scroll_offset = Some(want_scroll);
+                        }
+                    }
+                }
+
+                // Corrective scroll for outline-click. The bootstrap full paint
+                // triggered above by `pending_scroll_offset` recorded every
+                // heading's precise y under its composite cache key. If the
+                // line-ratio first-frame estimate left the target outside the
+                // viewport (common in image-heavy docs and the failure mode for
+                // duplicate-titled headers before this), snap the next frame to
+                // the recorded y. Mirrors the search-match corrective above.
+                if let Some(key) = tab.pending_header_click_key.take() {
+                    if let Some(actual_y) = tab.cache.get_header_position(&key) {
+                        let current_scroll = scroll_output.state.offset.y;
+                        let want_scroll = (actual_y - 50.0).max(0.0);
                         if (want_scroll - current_scroll).abs() > 2.0 {
                             tab.pending_scroll_offset = Some(want_scroll);
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1198,9 +1198,26 @@ fn main() -> eframe::Result<()> {
     )
 }
 
+/// Source of a lightbox texture. Mermaid pre-rasterizes its own texture so we
+/// own the handle to keep it alive; loader-managed images (egui_extras) just
+/// give us an id whose lifetime is governed by the loader.
+enum LightboxTexture {
+    Owned(egui::TextureHandle),
+    Loaded(egui::TextureId),
+}
+
+impl LightboxTexture {
+    fn id(&self) -> egui::TextureId {
+        match self {
+            Self::Owned(handle) => handle.id(),
+            Self::Loaded(id) => *id,
+        }
+    }
+}
+
 struct LightboxState {
-    /// Pre-rasterized texture (GPU-resident). Zoom just scales this — instant.
-    texture: egui::TextureHandle,
+    /// GPU-resident texture (mermaid-owned or loader-owned). Zoom scales it — instant.
+    texture: LightboxTexture,
     /// Original rasterized pixel dimensions (before any zoom)
     base_size: egui::Vec2,
     zoom: f32,
@@ -1210,9 +1227,6 @@ struct LightboxState {
     /// egui's ScrollArea may clamp the old offset when content size changes mid-zoom)
     scroll_offset: egui::Vec2,
 }
-
-// LightboxState is constructed directly from pre-rasterized mermaid textures
-// (see take_clicked_mermaid in CommonMarkCache)
 
 /// Check if a path is on a GVFS FUSE mount (e.g., SFTP via Thunar/Nautilus).
 fn is_gvfs_path(path: &Path) -> bool {
@@ -3949,7 +3963,17 @@ impl eframe::App for MarkdownApp {
             if let Some((texture, base_size)) = tab.cache.take_clicked_mermaid() {
                 self.lightbox_open_count += 1;
                 self.lightbox = Some(LightboxState {
-                    texture,
+                    texture: LightboxTexture::Owned(texture),
+                    base_size,
+                    zoom: 1.0,
+                    open_id: self.lightbox_open_count,
+                    scroll_offset: egui::Vec2::ZERO,
+                });
+            }
+            if let Some((tex_id, base_size)) = tab.cache.take_clicked_image() {
+                self.lightbox_open_count += 1;
+                self.lightbox = Some(LightboxState {
+                    texture: LightboxTexture::Loaded(tex_id),
                     base_size,
                     zoom: 1.0,
                     open_id: self.lightbox_open_count,
@@ -3958,7 +3982,7 @@ impl eframe::App for MarkdownApp {
             }
         }
 
-        // Lightbox overlay for enlarged mermaid diagrams
+        // Lightbox overlay for enlarged diagrams or images
         self.render_lightbox(ctx);
 
         // Drag and drop overlay


### PR DESCRIPTION
## Summary

Three small fixes ready for v0.1.7. Each is its own commit; all three verified end-to-end via egui-MCP on a synthetic test doc (\`/tmp/md-screens/bug-test.md\`).

### 1. \`Fix: disambiguate duplicate outline headers\`

Two outline entries with identical normalized titles (e.g. multiple \`## Installation\` sections) both scrolled to the same y. Root cause: \`CommonMarkCache::header_positions\` is keyed by \`String\`, so the second occurrence's \`insert()\` clobbered the first.

Fix: composite key \`(normalized_title, nth_with_same_text)\` rendered as \`\"installation\"\` for the 0th occurrence and \`\"installation#N\"\` for the Nth duplicate. \`Header\` struct gains \`nth_with_same_text: usize\` assigned at parse time; renderer maintains a per-render-pass counter that records each heading position under the same scheme; click handler uses \`header_position_key\` helper to look up.

Includes a corrective two-stage scroll (\`pending_header_click_key\`) that mirrors the existing search-jump corrective — handles the case where the bootstrap full paint produces precise positions only after the first scroll.

### 2. \`feat: extend lightbox to regular images\` (rebased from \`feature/image-lightbox\`)

\`Image::end\` in the vendored fork was rendered without \`Sense::click()\` — clicks went nowhere. Only mermaid diagrams opened the lightbox; regular \`![alt](url)\` images were dead.

Fix: add \`.sense(Sense::click())\`, capture \`response.clicked()\`, store the texture handle on \`CommonMarkCache::clicked_image\`. Main app consumes it the same way as \`take_clicked_mermaid\`.

### 3. \`Fix: bootstrap branch must use pending_scroll_offset for set_scroll_offset\`

Discovered while testing #1 above. The bootstrap full-paint branch in \`show_scrollable\` called \`cache.set_scroll_offset(0.0)\` unconditionally. When triggered by a non-zero \`pending_scroll_offset\` (e.g. clicking an outline entry deep in the doc), every \`record_header_position\` got shifted by the negative scroll offset, corrupting the cache for that frame. The corrective scroll then snapped to the wrong values.

Fix: pass \`pending_scroll_offset.unwrap_or(0.0)\` instead. Cold-launch case unchanged; click-driven case now resolves to correct content-y values.

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --bin md-viewer -- -D warnings\` clean (pre-existing vendored-crate warnings only)
- [x] MCP: doc with two \`## Installation\` sections → click first → scrolls to first; click second → scrolls to second
- [x] MCP: doc with \`![alt](url)\` → click image → lightbox opens with X close button (matches mermaid lightbox behavior)
- [x] Existing search-jump and outline-click flows still work (no regression in the \`active_search_y\` corrective)