### PR TITLE
fix: stop table scroll wheel nudging

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -157,51 +157,6 @@ fn html_cell_visual_lines(cell: &str) -> usize {
     explicit_lines.saturating_add(wrap_est).max(1)
 }
 
-/// After a nested horizontal `ScrollArea` has rendered (used here to wrap tables
-/// that overflow the content column), redirect any pending vertical wheel delta
-/// into the area's horizontal offset when the cursor is hovered over it.
-///
-/// The outer document is wrapped in a `ScrollArea::vertical()`, so plain wheel
-/// over a wide table would otherwise scroll the page instead of the table —
-/// users were forced to grab the table's bottom scrollbar to see overflowing
-/// columns. With this helper, wheel-over-table scrolls the table sideways.
-///
-/// Edge pass-through: when the table is fully scrolled to either side and the
-/// wheel direction would push past the edge, the delta is left untouched so the
-/// outer area can keep scrolling the page.
-///
-/// X-delta (native trackpad horizontal swipe) is already consumed by the inner
-/// `ScrollArea::horizontal()` inside its own `.show()` call — only Y is touched
-/// here, never X.
-fn forward_wheel_to_horizontal_scroll<R>(
-    ui: &Ui,
-    out: &mut egui::containers::scroll_area::ScrollAreaOutput<R>,
-) {
-    if !ui.rect_contains_pointer(out.inner_rect) {
-        return;
-    }
-    let dy = ui.ctx().input(|i| i.smooth_scroll_delta.y);
-    if dy.abs() < 0.1 {
-        return;
-    }
-    let max_x = (out.content_size.x - out.inner_rect.width()).max(0.0);
-    if max_x <= 0.0 {
-        return;
-    }
-    let at_left = out.state.offset.x <= 0.0 && dy > 0.0;
-    let at_right = out.state.offset.x >= max_x && dy < 0.0;
-    if at_left || at_right {
-        return;
-    }
-    let new_x = (out.state.offset.x - dy).clamp(0.0, max_x);
-    if (new_x - out.state.offset.x).abs() > f32::EPSILON {
-        out.state.offset.x = new_x;
-        out.state.store(ui.ctx(), out.id);
-        ui.ctx().input_mut(|i| i.smooth_scroll_delta.y = 0.0);
-        ui.ctx().request_repaint();
-    }
-}
-
 /// Newline logic is constructed by the following:
 /// All elements try to insert a newline before them (if they are allowed)
 /// and end their own line.
@@ -1080,14 +1035,14 @@ impl CommonMarkViewerInternal {
                 .collect();
             // Outer ScrollArea::horizontal handles the case where columns
             // (auto-sized to content) total wider than the parent ui; without it,
-            // narrow windows clip the rightmost columns. Capture the output so
-            // `forward_wheel_to_horizontal_scroll` can redirect vertical wheel
-            // deltas into the inner area's horizontal offset when hovered.
+            // narrow windows clip the rightmost columns. Vertical wheel input stays
+            // with the outer document scroller so scrolling past wide tables does
+            // not nudge their horizontal offset.
             // ui.vertical(...) is essential: TableBuilder's body() positions itself
             // relative to the parent's cursor, but the parent here is a horizontal-
             // flow Ui from the markdown renderer. Without the vertical scope the
             // body's first row overlaps the header row.
-            let mut scroll_out = egui::ScrollArea::horizontal()
+            egui::ScrollArea::horizontal()
                 .id_salt(id.with("_scroll"))
                 .max_width(max_width)
                 .auto_shrink([false, true])
@@ -1161,8 +1116,6 @@ impl CommonMarkViewerInternal {
                         });
                     });
                 });
-            forward_wheel_to_horizontal_scroll(ui, &mut scroll_out);
-
             self.is_table = false;
             if events.peek().is_none() {
                 self.line.should_end_newline_forced = false;
@@ -1730,9 +1683,10 @@ impl CommonMarkViewerInternal {
         let body_heights: Vec<f32> = table.rows.iter().map(|row| row_height_for(row)).collect();
 
         // Outer ScrollArea::horizontal handles wide tables that exceed parent width;
-        // ui.vertical() prevents the header/body Y-overlap quirk. Capture the output
-        // so `forward_wheel_to_horizontal_scroll` can redirect wheel deltas.
-        let mut scroll_out = egui::ScrollArea::horizontal()
+        // ui.vertical() prevents the header/body Y-overlap quirk. Vertical wheel
+        // input stays with the outer document scroller so scrolling past wide tables
+        // does not nudge their horizontal offset.
+        egui::ScrollArea::horizontal()
             .id_salt(id.with("_scroll"))
             .max_width(max_width)
             .auto_shrink([false, true])
@@ -1839,8 +1793,6 @@ impl CommonMarkViewerInternal {
                     });
                 });
             });
-        forward_wheel_to_horizontal_scroll(ui, &mut scroll_out);
-
         self.line.try_insert_end(ui);
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,7 +55,7 @@ Single-file Rust desktop application (`src/main.rs`, ~1300 lines) for viewing ma
 
 - **Search (Ctrl+F)**: Current-document find bar with inline highlights. `SearchState` lives on `MarkdownApp`; per-tab `search_matches: Vec<SearchMatch>` cache match byte ranges. Highlights are painted by the vendored `egui_commonmark` renderer via a new `CommonMarkCache::set_search_ranges` API; the renderer splits `Event::Text` and (non-wrapped) `Event::Code` at range boundaries and applies a background color to the matching segments. Enter/Shift+Enter cycle matches with line-ratio scroll-into-view; Esc closes the bar and clears highlights on all tabs.
 
-- **Table wheel routing**: Wide markdown / HTML tables are wrapped in a nested `egui::ScrollArea::horizontal()`. After each table renders, `forward_wheel_to_horizontal_scroll` in `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs` redirects pending vertical wheel deltas into the inner area's horizontal offset when the cursor is hovered. Edge passthrough (offset at 0 or max in wheel direction) lets the wheel fall through to the outer vertical area so the page can still scroll past the table.
+- **Wide table scrolling**: Wide markdown / HTML tables are wrapped in a nested `egui::ScrollArea::horizontal()` so columns wider than the content area can still be reached. Vertical wheel input remains owned by the outer document scroller; table horizontal movement uses the bottom scrollbar or native horizontal input so scrolling past a table does not change its horizontal offset.
 
 - **Global Allocator**: mimalloc for performance
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -767,32 +767,12 @@ Belt-and-suspenders: keep `cargo publish --allow-dirty` in `scripts/publish-crat
 **Theme/zoom changes** key in new entries naturally because they're part of the key; old entries become dead weight until cache reset on file load. Bounded by unique-code-block count, typically <5 MB for real docs. LRU eviction is deferred until measured pathology.
 **Files:** `crates/egui_commonmark/egui_commonmark_backend/src/misc.rs` (`CommonMarkCache::syntax_layouts`, `CodeBlock::end`)
 
-### Nested horizontal ScrollArea doesn't auto-redirect vertical wheel
-**Context:** Issue #4 — wide markdown/HTML tables are wrapped in `egui::ScrollArea::horizontal()` inside the outer document `ScrollArea::vertical()`. Mouse wheel over the table body scrolled the page, never the table. Users could only scroll a wide table sideways by dragging the bottom scrollbar.
-**Root cause:** egui 0.33's `ScrollArea::horizontal()` only consumes the X component of `smooth_scroll_delta` during its `.show()`. Plain mouse wheel emits Y delta only, so the inner area sees nothing; the unconsumed Y delta then reaches the outer vertical area and scrolls the page. Shift+wheel has the same broken behavior — egui doesn't auto-convert Y→X for nested horizontal areas.
-**Fix:** After the nested `ScrollArea::horizontal().show(...)` returns, check `ui.rect_contains_pointer(out.inner_rect)`. If hovered AND the area still has room in the wheel direction, redirect Y delta into `out.state.offset.x`, `state.store(ctx, out.id)`, then zero `i.smooth_scroll_delta.y` so the outer area doesn't double-consume.
-**Edge pass-through:** If `offset.x == 0` and wheel-up, OR `offset.x >= max_x` and wheel-down, return early without touching the delta. The outer area then scrolls normally — avoids "stuck table swallows my wheel" feel.
-```rust
-fn forward_wheel_to_horizontal_scroll<R>(
-    ui: &Ui,
-    out: &mut egui::containers::scroll_area::ScrollAreaOutput<R>,
-) {
-    if !ui.rect_contains_pointer(out.inner_rect) { return; }
-    let dy = ui.ctx().input(|i| i.smooth_scroll_delta.y);
-    if dy.abs() < 0.1 { return; }
-    let max_x = (out.content_size.x - out.inner_rect.width()).max(0.0);
-    if max_x <= 0.0 { return; }
-    let at_left  = out.state.offset.x <= 0.0   && dy > 0.0;
-    let at_right = out.state.offset.x >= max_x && dy < 0.0;
-    if at_left || at_right { return; }
-    out.state.offset.x = (out.state.offset.x - dy).clamp(0.0, max_x);
-    out.state.store(ui.ctx(), out.id);
-    ui.ctx().input_mut(|i| i.smooth_scroll_delta.y = 0.0);
-    ui.ctx().request_repaint();
-}
-```
-**Why `State` is `Copy`:** egui's `ScrollArea::State` is `#[derive(Copy)]`, so `out.state.store(ctx, id)` copies and stores — the caller's `out.state` stays accessible after.
-**Files:** `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs` (`forward_wheel_to_horizontal_scroll`, both table call sites)
+### Reverted: nested horizontal ScrollArea vertical-wheel forwarding
+**Context:** Issue #4 — wide markdown/HTML tables are wrapped in `egui::ScrollArea::horizontal()` inside the outer document `ScrollArea::vertical()`. Mouse wheel over the table body originally scrolled the page, while sideways table access required dragging the bottom scrollbar or using native horizontal input.
+**Historical attempt:** A helper named `forward_wheel_to_horizontal_scroll` converted hovered-table `smooth_scroll_delta.y` into `out.state.offset.x`, stored the inner table state, and consumed the Y delta so the outer document scroller would not also scroll.
+**Why it was reverted:** Converting vertical wheel into horizontal table offset made ordinary document scrolling nudge wide tables left/right whenever the cursor crossed them. Edge pass-through reduced but did not remove the surprising behavior.
+**Current guidance:** Do not convert vertical wheel input into horizontal table offset inside the document scroller. Let the outer document `ScrollArea::vertical()` own vertical wheel input. Keep table horizontal access through the bottom scrollbar and native horizontal input handled by `ScrollArea::horizontal()`.
+**Files:** Historical helper/call sites were in `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`; the helper and call sites should stay removed unless product behavior is intentionally changed again.
 
 ### `delayed_events_list_item` must depth-track nested items
 **Context:** v0.1.8 — `panicked at lib.rs:566 unreachable!()` in `List::start_item` when scrolling past a nested list in `show_scrollable`. Reproduced on `Recent-Changes.md` (7481 lines, 272 nested-list items).

--- a/docs/TARGET_METRICS.md
+++ b/docs/TARGET_METRICS.md
@@ -16,5 +16,5 @@
 Tracked in issue #4. Recommended order:
 
 1. ~~**Search / find-all (Ctrl+F)**~~ — shipped in v0.1.4 (PR #14).
-2. ~~**Table horizontal-scroll UX**~~ — shipped post-v0.1.4 via `forward_wheel_to_horizontal_scroll` in `crates/egui_commonmark/.../pulldown.rs`.
+2. ~~**Table horizontal-scroll UX**~~ — wide-table overflow remains reachable through the nested `egui::ScrollArea::horizontal()` bottom scrollbar and native horizontal input. The former `forward_wheel_to_horizontal_scroll` wheel-routing helper was removed because it made normal document scrolling nudge wide tables horizontally.
 3. **Resizable table columns** — large refactor: swap `egui::Grid` for `egui_extras::TableBuilder` in the vendored fork. Regression-testing all existing table edge cases required.

--- a/docs/devlog/032-table-scroll-wheel.md
+++ b/docs/devlog/032-table-scroll-wheel.md
@@ -1,0 +1,31 @@
+# Table Scroll Wheel Fix
+
+**Date:** 2026-05-23
+**Branch:** fix/table-scroll-wheel
+**Status:** Implemented
+
+## Scope
+
+Fix issue #22 where wide tables shifted horizontally when vertical wheel scrolling past them.
+
+## Root Cause
+
+Wide markdown and HTML tables used a nested horizontal `ScrollArea` plus `forward_wheel_to_horizontal_scroll`. The helper read `smooth_scroll_delta.y`, applied it to the inner table `offset.x`, stored the state, and consumed vertical delta. That made ordinary document scrolling change table horizontal position whenever the cursor crossed a wide table.
+
+## Change
+
+Removed custom vertical-wheel forwarding. Wide tables still use `ScrollArea::horizontal()` for bottom scrollbar and native horizontal input, but vertical wheel remains document scroll.
+
+## Testing Notes
+
+- Pre-fix static guard found `forward_wheel_to_horizontal_scroll`, `smooth_scroll_delta.y`, `out.state.offset.x`, and helper call sites in `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`.
+- Post-fix static guard clean: `! grep -n "forward_wheel_to_horizontal_scroll\|smooth_scroll_delta.y\|out.state.offset.x" crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`.
+- `cargo fmt --check` exit 0.
+- `cargo check` exit 0 with existing warnings.
+- `cargo clippy --all-targets --all-features` exit 0 with existing warnings.
+- Manual: `cargo run -- /tmp/md-viewer-wide-table.md --no-watch` launched.
+- Manual: confirmed by user on real display with `docs/DEVELOPMENT_PLAN.md`. Reported "fixed."
+
+## Impact
+
+Verified behavior: normal mouse wheel over tables scrolls the document instead of horizontally nudging wide tables. Horizontal table access remains available via bottom scrollbar/native horizontal input.


### PR DESCRIPTION
Remove vertical-wheel forwarding from wide table scroll areas so page scrolling no longer shifts tables sideways, while preserving horizontal access through the table scrollbar/native horizontal input. This stemmed from this open issue: https://github.com/aydiler/md-viewer/issues/22

I see it was intended to do that originally, so wondering if we want to keep this behavior? @aydiler I did test this, and scrolling now is smooth without nudging or shifting of the tables left and right. Horizontal bar still works perfectly. Thoughts? 

Video below of before and after. Left is Before, Right is After. 


https://github.com/user-attachments/assets/76ef642f-09fc-4f80-bc79-57b10597fb28

