### PR TITLE
docs: refresh listings descriptions (snap, README, binary size)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,20 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
 
+      # Push the store-listing description / summary from snapcraft.yaml.
+      # `snapcraft upload` only ships the .snap artifact; the Snap Store
+      # listing description is curated separately and won't pick up changes to
+      # the yaml unless we explicitly push-metadata. --force overwrites any
+      # web-UI edits with the yaml as source of truth.
+      - name: Push snap store listing metadata
+        if: steps.check.outputs.proceed == 'true'
+        run: |
+          sudo snap install snapcraft --classic
+          snapcraft push-metadata "${SNAP_FILE}" --from-yaml --force
+        env:
+          SNAP_FILE: ${{ steps.build.outputs.snap }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
   publish-aur:
     name: Publish to AUR
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 | CLI | clap |
 | Allocator | mimalloc |
 
-**Binary:** ~8.7MB (includes syntax highlighting, image support, Wayland+X11)
+**Binary:** ~35 MB release build (includes syntect, mermaid renderer, math rendering, image support, Wayland+X11). ~7 MB compressed as snap.
 
 ## Before You Code
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ A fast, lightweight markdown viewer for Linux built with Rust and egui. Designed
 | Ctrl+- | Zoom out |
 | Ctrl+0 | Reset zoom to 100% |
 | Ctrl+Scroll | Zoom with mouse wheel |
+| Shift+Scroll over a wide table | Scroll the table horizontally |
 
 ### File Operations
 

--- a/docs/TARGET_METRICS.md
+++ b/docs/TARGET_METRICS.md
@@ -1,6 +1,6 @@
 # Target Metrics
 
-- Binary size: ~8.7MB (includes full syntax highlighting via syntect, image support, Wayland+X11)
+- Binary size: ~35 MB release build (includes full syntax highlighting via syntect, mermaid renderer, math rendering, image support, Wayland+X11). ~7 MB compressed as snap.
 - Startup time: < 200ms
 - Render: 60 FPS with viewport-based lazy rendering
 - Platform: Linux X11 and Wayland

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,16 +3,40 @@ base: core22
 version: '0.1.11'
 summary: Fast, lightweight markdown viewer for Linux
 description: |
-  A fast, lightweight markdown viewer built with Rust and egui.
+  A fast, lightweight markdown viewer for Linux built with Rust and egui.
+  Designed for distraction-free reading with excellent typography and syntax highlighting.
 
-  Features:
-  - GitHub Flavored Markdown with syntax highlighting (200+ languages)
-  - Tab system for multiple documents
-  - File explorer sidebar
-  - Outline/table of contents sidebar
-  - Dark and light themes
-  - Live reload on file changes
-  - Session persistence
+  Rendering:
+  - GitHub Flavored Markdown (tables, task lists, footnotes)
+  - Syntax highlighting for 200+ languages
+  - Mermaid diagrams (flowcharts, sequence diagrams) rendered natively, click to enlarge
+  - Math rendering (LaTeX via typst)
+  - Resizable table columns - drag dividers to fit content
+  - HTML tables with proper cell padding
+  - Images and SVG support (PNG, JPEG, GIF, SVG, HTTP URLs) - click images to enlarge
+  - Unicode support with system font fallbacks (emojis, CJK, non-Latin scripts)
+  - 60 FPS rendering with viewport-based lazy rendering
+  - WCAG 2.1 compliant typography (1.5x line height)
+
+  Navigation:
+  - Tab system for multiple documents (Ctrl+Click links to open in new tab)
+  - In-document search (Ctrl+F) with inline highlights and Enter/Shift+Enter to cycle
+  - File explorer sidebar with hierarchical directory tree
+  - Outline sidebar with click-to-navigate table of contents
+  - Per-tab back/forward history (Alt+Left/Right)
+  - Internal links between markdown files
+
+  View:
+  - Dark and light themes (Ctrl+D)
+  - Zoom 50%-300% (Ctrl++/-/0 or Ctrl+Scroll)
+  - Full-width content toggle (View menu) to use the entire content pane
+  - Shift+Scroll over a wide table scrolls it horizontally
+  - Live reload on file changes (enabled by default)
+
+  Usability:
+  - Drag and drop files to open
+  - Native file dialogs
+  - Session persistence (tabs, theme, zoom, sidebar state)
   - Native X11 and Wayland support
 
 grade: stable


### PR DESCRIPTION
## Summary

- **README.md** — adds Shift+Scroll-over-table row to view shortcuts table (v0.1.11 was missing).
- **snap/snapcraft.yaml** — description was last touched around v0.1.3; missing Ctrl+F search (v0.1.4), resizable table columns (v0.1.5), full-width content toggle (v0.1.6), click-to-enlarge images/diagrams (v0.1.7), math rendering, and Shift+wheel table horizontal scroll (v0.1.11). Now matches the structure of the existing hand-curated store listing description, with the new features added.
- **CLAUDE.md / docs/TARGET_METRICS.md** — corrects stale `~8.7MB` binary size to `~35 MB release` / `~7 MB snap`. README.md was already accurate; the two internal docs lagged.
- **.github/workflows/release.yml** — adds `snapcraft push-metadata --from-yaml --force` after the snap publish step. The Snap Store listing description is curated separately from the snap upload; without push-metadata, yaml description edits don't propagate. With this step, future releases sync the store description automatically.

## One-time manual step still needed

The v0.1.11 release CI run is in flight as I write this and won't pick up the new push-metadata step (workflow code is read from the tag commit, which predates this PR). After this PR merges, the snap store listing will still show the old short description until the next release ships, OR until a manual one-time push:

```bash
snapcraft login   # or set SNAPCRAFT_STORE_CREDENTIALS
snapcraft push-metadata md-viewer_0.1.11_amd64.snap --from-yaml --force
```

From v0.1.12 onwards CI handles it.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('snap/snapcraft.yaml'))"` parses cleanly
- [ ] Next release (or one-time manual push) flips the snap store description to the expanded version
- [ ] `snapcraft push-metadata` step succeeds in CI on the next release