### PR TITLE
ci: fix snap push-metadata (drop --from-yaml, removed in snapcraft 8.x)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,16 +229,22 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
 
-      # Push the store-listing description / summary from snapcraft.yaml.
-      # `snapcraft upload` only ships the .snap artifact; the Snap Store
-      # listing description is curated separately and won't pick up changes to
-      # the yaml unless we explicitly push-metadata. --force overwrites any
-      # web-UI edits with the yaml as source of truth.
+      # Push the store-listing description / summary embedded in the snap.
+      # snapcore/action-publish above only ships the .snap artifact to a
+      # channel; the Snap Store listing description is curated separately and
+      # won't pick up changes unless we explicitly push-metadata. --force
+      # overwrites any web-UI edits, treating snap/snapcraft.yaml in the repo
+      # as source of truth.
+      #
+      # Note: snapcraft 8.x removed `--from-yaml`. Metadata is read from the
+      # .snap file's embedded yaml (which came from snap/snapcraft.yaml at
+      # build time), so the freshly-built snap from steps.build already
+      # carries the current description.
       - name: Push snap store listing metadata
         if: steps.check.outputs.proceed == 'true'
         run: |
           sudo snap install snapcraft --classic
-          snapcraft push-metadata "${SNAP_FILE}" --from-yaml --force
+          snapcraft push-metadata "${SNAP_FILE}" --force
         env:
           SNAP_FILE: ${{ steps.build.outputs.snap }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.github/workflows/snap-push-metadata.yml
+++ b/.github/workflows/snap-push-metadata.yml
@@ -1,12 +1,18 @@
 name: Push Snap Store Metadata
 
-# Manual-only workflow that pushes the snap/snapcraft.yaml description and
+# Manual-only workflow that pushes snap/snapcraft.yaml's description and
 # summary to the Snap Store listing. The release.yml publish-snap job does
 # this automatically on every release tag from v0.1.12 onward; this workflow
 # exists for one-off resyncs (e.g. v0.1.11 shipped before that auto-push
 # step was wired in, so the store description lagged the yaml).
 #
 # Trigger via: gh workflow run snap-push-metadata.yml
+#
+# Note: snapcraft 8.x removed `--from-yaml`. Metadata is read from the
+# .snap file's embedded yaml, so we must build a fresh snap with the
+# current snap/snapcraft.yaml before push-metadata can pick up the
+# new description. The freshly-built snap is NOT released to a channel —
+# only the metadata it embeds is pushed to the store listing.
 
 on:
   workflow_dispatch:
@@ -15,7 +21,7 @@ jobs:
   push-metadata:
     name: Push snap metadata
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       contents: read
     env:
@@ -31,20 +37,13 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install snapcraft + snap CLI
+      - uses: snapcore/action-build@v1
+        id: build
+
+      - name: Push metadata from fresh snap
         run: |
           sudo snap install snapcraft --classic
-          # `snap download` is part of snapd on the runner
-
-      - name: Download latest published snap
-        run: |
-          snap download md-viewer --channel=stable
-          ls -lh md-viewer_*.snap
-
-      - name: Push metadata from snapcraft.yaml
-        run: |
-          SNAP_FILE=$(ls md-viewer_*.snap | head -1)
-          echo "Pushing metadata from snap file: $SNAP_FILE"
-          snapcraft push-metadata "$SNAP_FILE" --from-yaml --force
+          snapcraft push-metadata "${SNAP_FILE}" --force
         env:
+          SNAP_FILE: ${{ steps.build.outputs.snap }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}


### PR DESCRIPTION
The snap-push-metadata workflow dispatched after PR #26 failed:

\`\`\`
Error: No such option: --from-yaml
\`\`\`

snapcraft 8.x dropped --from-yaml. Metadata is now read from the .snap file's embedded yaml. So we need to:

1. Build a fresh snap (with the new snap/snapcraft.yaml embedded)
2. Run \`snapcraft push-metadata <snap> --force\` — no --from-yaml

This PR:
- Updates \`.github/workflows/snap-push-metadata.yml\` to build a fresh snap via \`snapcore/action-build@v1\` instead of downloading the published one. The downloaded snap embeds the OLD yaml (since v0.1.11 shipped with the short description), so push-metadata on it wouldn't update anything useful.
- Updates the corresponding step in \`.github/workflows/release.yml\` to also drop --from-yaml. The build is already happening there for the publish step, so only the flag needed fixing.

After merge: \`gh workflow run snap-push-metadata.yml\` to dispatch the corrected one-shot.