### PR TITLE
Add keyboard document scrolling

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,7 +24,7 @@ Single-file Rust desktop application (`src/main.rs`, ~1300 lines) for viewing ma
   - `cache: CommonMarkCache` - **must persist across frames** (never recreate per-frame, only reset on file load)
   - `document_title: Option<String>` - first h1 used as sidebar title
   - `outline_headers: Vec<Header>` - parsed headers for outline
-  - `scroll_offset`, `pending_scroll_offset`, `last_content_height` - scroll state
+  - `scroll_offset`, `pending_scroll_offset`, `last_content_height`, `last_viewport_height` - scroll state
   - `local_links: Vec<String>` - cached local markdown links
   - `history_back`, `history_forward: Vec<PathBuf>` - per-tab navigation history
 
@@ -54,6 +54,8 @@ Single-file Rust desktop application (`src/main.rs`, ~1300 lines) for viewing ma
 - **Link Navigation**: Uses egui_commonmark's link hook mechanism. Ctrl+Click opens links in new tabs, regular click navigates within the current tab.
 
 - **Search (Ctrl+F)**: Current-document find bar with inline highlights. `SearchState` lives on `MarkdownApp`; per-tab `search_matches: Vec<SearchMatch>` cache match byte ranges. Highlights are painted by the vendored `egui_commonmark` renderer via a new `CommonMarkCache::set_search_ranges` API; the renderer splits `Event::Text` and (non-wrapped) `Event::Code` at range boundaries and applies a background color to the matching segments. Enter/Shift+Enter cycle matches with line-ratio scroll-into-view; Esc closes the bar and clears highlights on all tabs.
+
+- **Keyboard document scrolling**: Plain document scroll keys are handled in `MarkdownApp::update` after mode-specific shortcuts are checked. `KeyboardScrollAction` maps Up/Down to fixed line steps and Page Up/Page Down to viewport-relative page steps through `keyboard_scroll_target`, which clamps against the active tab's `last_content_height`. The chosen target is assigned to the tab's `pending_scroll_offset`, so keyboard scrolling uses the same renderer-owned `ScrollArea` pipeline as outline and search jumps. Arrow keys are reserved for search-result navigation while the find bar is open, and document scrolling ignores Ctrl/Alt/Command-modified keypresses so it does not steal existing shortcuts.
 
 - **Wide table scrolling**: Wide markdown / HTML tables are wrapped in a nested `egui::ScrollArea::horizontal()` so columns wider than the content area can still be reached. Plain vertical wheel stays with the outer document scroller; table horizontal movement uses the bottom scrollbar, native horizontal input, or `Shift+vertical-wheel` (routed via `forward_shift_wheel_to_horizontal_scroll` in `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`) so the cursor crossing a wide table during normal scrolling does not change its horizontal offset.
 

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -48,5 +48,7 @@ The find bar also has on-screen `↑` and `↓` buttons next to the match count 
 | Ctrl++ / Ctrl+= | Zoom in |
 | Ctrl+- | Zoom out |
 | Ctrl+0 | Reset zoom to 100% |
+| ↑ / ↓ (when find bar is closed) | Scroll document up/down by line |
+| Page Up / Page Down | Scroll document up/down by page |
 | Ctrl+Scroll | Zoom in/out with mouse wheel |
 | Shift+Scroll over a wide table | Scroll the table horizontally |

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -217,7 +217,7 @@ if raw_scroll.abs() > 0.0 {
 **Context:** Issue #29 keyboard document scrolling added Up/Down and Page Up/Page Down document movement.
 **Problem:** Arrow keys already have a mode-specific meaning in the find bar: Up/Down cycle search matches. A global document-scroll handler that consumes the same keys unconditionally would make focused/mode shortcuts feel broken.
 **Fix:** Gate document-level shortcut handling on UI state and modifiers. Let search consume arrows while the find bar is open, and ignore Ctrl/Alt/Command-modified keypresses so existing app and system shortcuts keep priority. Defer the chosen scroll action through `pending_scroll_offset` rather than mutating renderer-owned scroll state directly.
-**Files:** `src/main.rs`, `docs/devlog/034-keyboard-scroll-keys.md`
+**Files:** `src/main.rs`, `docs/devlog/035-keyboard-scroll-keys.md`
 
 ### Resize handle and scrollbar overlap causes jitter
 **Context:** Resizing outline panel caused mouse jitter when near content scrollbar

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -213,6 +213,12 @@ if raw_scroll.abs() > 0.0 {
 **Gotcha:** Avoid `state.store()` at scroll boundaries (offset near 0 or max) - can still break selection
 **Files:** `src/main.rs`
 
+### Document-level keyboard shortcuts must not steal mode-specific keys
+**Context:** Issue #29 keyboard document scrolling added Up/Down and Page Up/Page Down document movement.
+**Problem:** Arrow keys already have a mode-specific meaning in the find bar: Up/Down cycle search matches. A global document-scroll handler that consumes the same keys unconditionally would make focused/mode shortcuts feel broken.
+**Fix:** Gate document-level shortcut handling on UI state and modifiers. Let search consume arrows while the find bar is open, and ignore Ctrl/Alt/Command-modified keypresses so existing app and system shortcuts keep priority. Defer the chosen scroll action through `pending_scroll_offset` rather than mutating renderer-owned scroll state directly.
+**Files:** `src/main.rs`, `docs/devlog/034-keyboard-scroll-keys.md`
+
 ### Resize handle and scrollbar overlap causes jitter
 **Context:** Resizing outline panel caused mouse jitter when near content scrollbar
 **Problem:** The SidePanel resize handle sensing area overlaps with the adjacent ScrollArea scrollbar, causing rapid switching between resize and scroll modes.

--- a/docs/devlog/034-keyboard-scroll-keys.md
+++ b/docs/devlog/034-keyboard-scroll-keys.md
@@ -1,0 +1,60 @@
+# Feature: Keyboard document scroll keys
+
+**Status:** Implemented; validation recorded
+**Branch:** `feature/issue-29-keyboard-scroll`
+**Date:** 2026-06-03
+**Issue:** aydiler/md-viewer#29
+
+## Summary
+
+Keyboard document scrolling has been implemented in `src/main.rs` so users can move the active markdown document without the mouse. This docs task records the behavior, implementation flow, and latest validation evidence only; it does not mark the PR as complete.
+
+## User-Facing Behavior
+
+- Up/Down scroll the document by a fixed line step when the find bar is closed.
+- Page Up/Page Down scroll the document by a viewport-relative page step.
+- Search keeps its existing arrow-key behavior while the find bar is open.
+- Ctrl/Alt/Command-modified keypresses remain reserved for existing shortcuts instead of document scrolling.
+
+## Chronology
+
+- Task 1: Code implementation added keyboard document scrolling in `src/main.rs`.
+- Task 2: Review validated formatting, focused keyboard-scroll tests, full tests, build, clippy, and source diff whitespace.
+- Task 3: Repo-local docs updated for shortcuts, architecture flow, devlog status, and one durable lesson.
+
+## Architecture Notes
+
+Keyboard shortcuts are collected in `MarkdownApp::update` as deferred actions. Document scroll keys set a `KeyboardScrollAction`; after input collection, the active tab's current `scroll_offset`, `last_viewport_height`, and `last_content_height` are passed to `keyboard_scroll_target`. The resulting clamped y offset is stored in `pending_scroll_offset`, letting the existing renderer-owned `ScrollArea` apply the movement on the next render pass.
+
+The shortcut handling is intentionally gated by UI state and modifiers: the find bar keeps arrow keys for match navigation, and Ctrl/Alt/Command-modified keypresses stay available to existing app/system shortcuts.
+
+## Validation Evidence
+
+Fresh closeout validation on 2026-06-03:
+
+- `cargo fmt --check --manifest-path /home/akiro/Coding/md-viewer-keyboard-scroll/Cargo.toml` — PASS no output.
+- `git -C /home/akiro/Coding/md-viewer-keyboard-scroll diff --check` — PASS no output.
+- `cargo test --manifest-path /home/akiro/Coding/md-viewer-keyboard-scroll/Cargo.toml` — PASS 19 passed; pre-existing vendored warnings observed.
+- `cargo clippy --manifest-path /home/akiro/Coding/md-viewer-keyboard-scroll/Cargo.toml --all-targets --all-features` — PASS; pre-existing vendored warnings observed.
+- `cargo build --manifest-path /home/akiro/Coding/md-viewer-keyboard-scroll/Cargo.toml` — PASS; pre-existing vendored warnings observed.
+
+Earlier targeted validation from Task 2 review:
+
+- `cargo test --manifest-path "/home/akiro/Coding/md-viewer-keyboard-scroll/Cargo.toml" keyboard_scroll_target -- --nocapture` — PASS 4 passed.
+
+Manual UI validation on 2026-06-04:
+
+- Launched `/home/akiro/Coding/md-viewer-keyboard-scroll/target/debug/md-viewer /home/akiro/Coding/md-viewer-keyboard-scroll/docs/LESSONS.md` from this session; process exited cleanly after user closed it.
+- User confirmed keyboard scrolling behavior: "perfect, works great."
+
+## Files Updated In This Docs Task
+
+- `docs/KEYBOARD_SHORTCUTS.md`
+- `docs/ARCHITECTURE.md`
+- `docs/devlog/034-keyboard-scroll-keys.md`
+- `docs/LESSONS.md`
+
+## Future Improvements
+
+- Add automated E2E UI evidence if project scope later requires it.
+- Consider documenting Home/End only if they are implemented in a future keyboard-scroll expansion.

--- a/docs/devlog/035-keyboard-scroll-keys.md
+++ b/docs/devlog/035-keyboard-scroll-keys.md
@@ -51,7 +51,7 @@ Manual UI validation on 2026-06-04:
 
 - `docs/KEYBOARD_SHORTCUTS.md`
 - `docs/ARCHITECTURE.md`
-- `docs/devlog/034-keyboard-scroll-keys.md`
+- `docs/devlog/035-keyboard-scroll-keys.md`
 - `docs/LESSONS.md`
 
 ## Future Improvements

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,40 @@ const OUTLINE_DEFAULT_WIDTH: f32 = 208.0; // 200 + 8 margins
 const PANEL_SEPARATORS: f32 = 16.0;
 const OPTIMAL_WINDOW_HEIGHT: f32 = 750.0;
 
+// Keyboard document scroll deltas are centralized so shortcut wiring and tests
+// share the same line/page behavior.
+const KEYBOARD_LINE_SCROLL_STEP: f32 = 48.0;
+const KEYBOARD_PAGE_SCROLL_RATIO: f32 = 0.9;
+
+// App-level keyboard scroll actions; kept private until shortcut wiring needs
+// to pass them through `MarkdownApp::update`.
+#[derive(Clone, Copy, Debug)]
+enum KeyboardScrollAction {
+    LineUp,
+    LineDown,
+    PageUp,
+    PageDown,
+}
+
+// Compute the next clamped document scroll offset without touching egui state.
+fn keyboard_scroll_target(
+    current_offset: f32,
+    viewport_height: f32,
+    content_height: f32,
+    action: KeyboardScrollAction,
+) -> f32 {
+    let page_step = viewport_height * KEYBOARD_PAGE_SCROLL_RATIO;
+    let delta = match action {
+        KeyboardScrollAction::LineUp => -KEYBOARD_LINE_SCROLL_STEP,
+        KeyboardScrollAction::LineDown => KEYBOARD_LINE_SCROLL_STEP,
+        KeyboardScrollAction::PageUp => -page_step,
+        KeyboardScrollAction::PageDown => page_step,
+    };
+    let max_scroll = (content_height - viewport_height).max(0.0);
+
+    (current_offset + delta).clamp(0.0, max_scroll)
+}
+
 fn content_default_width(full_width_content: bool) -> Option<usize> {
     if full_width_content {
         None
@@ -3380,6 +3414,7 @@ impl eframe::App for MarkdownApp {
         let mut next_match = false;
         let mut prev_match = false;
         let mut close_search_kb = false;
+        let mut keyboard_scroll_action: Option<KeyboardScrollAction> = None;
 
         // Ctrl+/- zoom: applies to lightbox when open, document otherwise
         ctx.input(|i| {
@@ -3518,6 +3553,26 @@ impl eframe::App for MarkdownApp {
                         close_search_kb = true;
                     }
                 }
+                // Plain document scroll keys reuse the existing pending-scroll pipeline.
+                // Arrow keys stay available for search navigation while the find bar is open.
+                let no_scroll_modifier =
+                    !i.modifiers.ctrl && !i.modifiers.alt && !i.modifiers.command;
+                if no_scroll_modifier {
+                    if !self.search.is_open {
+                        if i.key_pressed(egui::Key::ArrowUp) {
+                            keyboard_scroll_action = Some(KeyboardScrollAction::LineUp);
+                        }
+                        if i.key_pressed(egui::Key::ArrowDown) {
+                            keyboard_scroll_action = Some(KeyboardScrollAction::LineDown);
+                        }
+                    }
+                    if i.key_pressed(egui::Key::PageUp) {
+                        keyboard_scroll_action = Some(KeyboardScrollAction::PageUp);
+                    }
+                    if i.key_pressed(egui::Key::PageDown) {
+                        keyboard_scroll_action = Some(KeyboardScrollAction::PageDown);
+                    }
+                }
             });
         } // end lightbox guard
 
@@ -3581,6 +3636,17 @@ impl eframe::App for MarkdownApp {
         }
         if close_search_kb {
             self.close_search();
+        }
+        if let Some(action) = keyboard_scroll_action {
+            if let Some(tab) = self.tabs.get_mut(self.active_tab) {
+                let target = keyboard_scroll_target(
+                    tab.scroll_offset,
+                    tab.last_viewport_height,
+                    tab.last_content_height,
+                    action,
+                );
+                tab.pending_scroll_offset = Some(target);
+            }
         }
 
         // Handle drag and drop
@@ -4261,5 +4327,49 @@ mod tests {
         let m2 = find_matches(content, "two");
         // Two raw "two" matches in alt + 1 in visible text → only 1 survives
         assert_eq!(m2.len(), 1);
+    }
+
+    #[test]
+    fn keyboard_scroll_target_moves_by_line_step() {
+        assert_eq!(
+            keyboard_scroll_target(100.0, 500.0, 2_000.0, KeyboardScrollAction::LineDown),
+            148.0
+        );
+        assert_eq!(
+            keyboard_scroll_target(100.0, 500.0, 2_000.0, KeyboardScrollAction::LineUp),
+            52.0
+        );
+    }
+
+    #[test]
+    fn keyboard_scroll_target_moves_by_page_step() {
+        assert_eq!(
+            keyboard_scroll_target(1_000.0, 500.0, 3_000.0, KeyboardScrollAction::PageDown),
+            1_450.0
+        );
+        assert_eq!(
+            keyboard_scroll_target(1_000.0, 500.0, 3_000.0, KeyboardScrollAction::PageUp),
+            550.0
+        );
+    }
+
+    #[test]
+    fn keyboard_scroll_target_clamps_to_document_bounds() {
+        assert_eq!(
+            keyboard_scroll_target(10.0, 500.0, 2_000.0, KeyboardScrollAction::PageUp),
+            0.0
+        );
+        assert_eq!(
+            keyboard_scroll_target(1_490.0, 500.0, 2_000.0, KeyboardScrollAction::PageDown),
+            1_500.0
+        );
+    }
+
+    #[test]
+    fn keyboard_scroll_target_handles_short_documents() {
+        assert_eq!(
+            keyboard_scroll_target(25.0, 500.0, 300.0, KeyboardScrollAction::LineDown),
+            0.0
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add Up/Down and Page Up/Page Down document scrolling through the existing pending-scroll pipeline.
- Preserve find-bar Up/Down search navigation while search is open.
- Document shortcut behavior, implementation notes, devlog, and reusable shortcut-gating lesson.

Fixes aydiler/md-viewer#29

## Test plan
- [x] `cargo fmt --check --manifest-path /home/akiro/Coding/md-viewer-keyboard-scroll/Cargo.toml`
- [x] `cargo test --manifest-path /home/akiro/Coding/md-viewer-keyboard-scroll/Cargo.toml` — 19 passed
- [x] `cargo clippy --manifest-path /home/akiro/Coding/md-viewer-keyboard-scroll/Cargo.toml --all-targets --all-features` — passed with pre-existing vendored warnings
- [x] `cargo build --manifest-path /home/akiro/Coding/md-viewer-keyboard-scroll/Cargo.toml` — passed with pre-existing vendored warnings
- [x] `git -C /home/akiro/Coding/md-viewer-keyboard-scroll diff --check`
- [x] Manual UI check: opened `docs/LESSONS.md`; Up/Down and Page Up/Page Down scrolling worked as expected