### PR TITLE
Fix Windows CJK font fallback

### DIFF
--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -142,6 +142,19 @@ fn setup_fonts(ctx: &egui::Context) {
 ```
 **Files:** `src/main.rs`
 
+### Windows CJK fallback needs Windows font paths
+**Context:** Issue #40 reported Chinese text missing on Windows 11 even though Linux Noto CJK fallback paths existed.
+**Problem:** `setup_fonts()` only loads files from paths listed in `SYSTEM_FONT_PATHS`. Linux Noto paths do nothing on Windows, so Windows builds can still miss CJK glyphs.
+**Fix:** Add common Windows CJK font files to the same fallback list, keeping the existing loader and no manual config:
+```rust
+("MicrosoftYaHei", "C:/Windows/Fonts/msyh.ttc"),
+("SimSun", "C:/Windows/Fonts/simsun.ttc"),
+("DengXian", "C:/Windows/Fonts/Deng.ttf"),
+("MicrosoftJhengHei", "C:/Windows/Fonts/msjh.ttc"),
+```
+**Scope:** This is automatic fallback only. User-configurable font paths are a separate feature because they need UI/persistence/design work.
+**Files:** `src/main.rs`
+
 ### egui 0.33 FontData requires Arc wrapper
 **Context:** Compiler error when adding fonts
 **Problem:** `fonts.font_data.insert()` expects `Arc<FontData>`, not `FontData`

--- a/docs/devlog/014-font-fallback.md
+++ b/docs/devlog/014-font-fallback.md
@@ -94,3 +94,28 @@ Test with documents containing:
 - [ ] User-configurable font paths
 - [ ] Font size scaling for different font families
 - [ ] Embed small emoji subset for systems without Noto Emoji
+
+---
+
+## 2026-07-04 Follow-up: Windows CJK fallback paths
+
+Issue #40 reported Chinese text rendering as missing glyphs on Windows 11 Home Chinese with the v0.1.13 Windows binary. The existing font fallback loader only knew common Linux Noto paths, so Windows builds had no CJK fallback unless egui's defaults happened to cover the glyphs.
+
+This follow-up extends `SYSTEM_FONT_PATHS` with common Windows CJK fonts:
+
+- Microsoft YaHei (`C:/Windows/Fonts/msyh.ttc`) for Simplified Chinese.
+- SimSun / NSimSun (`C:/Windows/Fonts/simsun.ttc`) for older Simplified Chinese installs.
+- DengXian (`C:/Windows/Fonts/Deng.ttf`) for another common Simplified Chinese UI font.
+- Microsoft JhengHei (`C:/Windows/Fonts/msjh.ttc`) for Traditional Chinese.
+- Yu Gothic (`C:/Windows/Fonts/YuGothM.ttc`) and Malgun Gothic (`C:/Windows/Fonts/malgun.ttf`) for broader CJK fallback coverage.
+
+Scope stays automatic fallback only. User-configurable font paths remain a future improvement rather than part of this bug-fix PR.
+
+Validation:
+
+- `cargo fmt --check`
+- `cargo test`
+- `cargo clippy --all-targets --all-features`
+- `git diff --check`
+
+Manual Windows rendering validation should be requested from a Windows user or maintainer because this development environment is Linux.

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ static HEADER_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(#{1,6})\s+(.
 /// Compiled regex for parsing markdown links (lazy, compiled once)
 static LINK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\[([^\]]*)\]\(([^)]+)\)").unwrap());
 
-/// System font paths for fallback (Arch Linux / common Linux paths)
+/// System font paths for fallback (Linux and Windows common paths)
 const SYSTEM_FONT_PATHS: &[(&str, &str)] = &[
     // Noto Sans for extended Latin, Greek, Cyrillic
     ("NotoSans", "/usr/share/fonts/noto/NotoSans-Regular.ttf"),
@@ -42,7 +42,7 @@ const SYSTEM_FONT_PATHS: &[(&str, &str)] = &[
         "NotoSans",
         "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
     ),
-    // CJK fonts (Chinese, Japanese, Korean)
+    // Linux CJK fonts (Chinese, Japanese, Korean)
     (
         "NotoSansCJK",
         "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
@@ -55,6 +55,15 @@ const SYSTEM_FONT_PATHS: &[(&str, &str)] = &[
         "NotoSansCJK",
         "/usr/share/fonts/google-noto-cjk/NotoSansCJK-Regular.ttc",
     ),
+    // Windows CJK fonts (Chinese, Japanese, Korean)
+    ("MicrosoftYaHei", "C:/Windows/Fonts/msyh.ttc"),
+    ("MicrosoftYaHeiUI", "C:/Windows/Fonts/msyh.ttc"),
+    ("SimSun", "C:/Windows/Fonts/simsun.ttc"),
+    ("NSimSun", "C:/Windows/Fonts/simsun.ttc"),
+    ("DengXian", "C:/Windows/Fonts/Deng.ttf"),
+    ("MicrosoftJhengHei", "C:/Windows/Fonts/msjh.ttc"),
+    ("YuGothic", "C:/Windows/Fonts/YuGothM.ttc"),
+    ("MalgunGothic", "C:/Windows/Fonts/malgun.ttf"),
     // Arabic
     (
         "NotoSansArabic",


### PR DESCRIPTION
## Summary
- Add common Windows CJK font paths to the existing fallback loader so Chinese text can render on Windows builds.
- Keep the fix automatic only: no new settings UI, config, dependencies, or manual font path support.
- Document the Windows fallback scope and Linux-only validation caveat in the devlog and lessons.

Fixes aydiler/md-viewer#40

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test` — 29 passed
- [x] `cargo clippy --all-targets --all-features` — passed with existing vendored warnings
- [x] `git diff --check`
- [x] Independent verification agent PARTIAL: Linux checks passed and Microsoft Windows 11 font list confirms filenames; Windows GUI rendering still needs confirmation on Windows 11.