### PR TITLE
Fix code blocks inside list items

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -1444,6 +1444,11 @@ impl CommonMarkViewerInternal {
                 self.is_blockquote = true;
             }
             pulldown_cmark::Tag::CodeBlock(c) => {
+                // List items render in one horizontal_wrapped row; end it before a block widget.
+                if self.list.is_inside_a_list() {
+                    ui.end_row();
+                }
+
                 match c {
                     pulldown_cmark::CodeBlockKind::Fenced(lang) => {
                         self.code_block = Some(crate::CodeBlock {
@@ -1632,6 +1637,11 @@ impl CommonMarkViewerInternal {
             pulldown_cmark::TagEnd::BlockQuote(_) => {}
             pulldown_cmark::TagEnd::CodeBlock => {
                 self.end_code_block(ui, cache, options, max_width);
+
+                // Keep any following list-item text below the completed block widget.
+                if self.list.is_inside_a_list() {
+                    ui.end_row();
+                }
             }
 
             pulldown_cmark::TagEnd::List(_) => {

--- a/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
+++ b/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
@@ -3,28 +3,85 @@
 //! overlapped surrounding text at narrow widths. See pulldown.rs
 //! `inline_code_wrap_segments`.
 
-use egui::{Context, Rect, TextStyle};
+use egui::{Context, Rect, Shape, TextStyle};
 use egui_commonmark_extended::{CommonMarkCache, CommonMarkViewer};
 
-fn render(markdown: &str, width: f32) -> (Rect, f32) {
-    let ctx = Context::default();
-    let mut body_rect = Rect::NOTHING;
+#[derive(Debug)]
+struct PaintedText {
+    text: String,
+    rect: Rect,
+}
 
-    // Two passes: egui caches font/layout state on the first pass.
-    for _ in 0..2 {
+fn collect_painted_text(shape: &Shape, painted: &mut Vec<PaintedText>) {
+    // Text can be emitted directly or nested in a grouped Shape::Vec.
+    match shape {
+        Shape::Text(text) => painted.push(PaintedText {
+            text: text.galley.job.text.clone(),
+            rect: text.galley.rect.translate(text.pos.to_vec2()),
+        }),
+        Shape::Vec(shapes) => {
+            for shape in shapes {
+                collect_painted_text(shape, painted);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn render_geometry(markdown: &str, width: f32) -> (Rect, f32, Vec<PaintedText>) {
+    let ctx = Context::default();
+    let mut cache = CommonMarkCache::default();
+    let mut body_rect = Rect::NOTHING;
+    let mut painted = Vec::new();
+
+    // Two passes let egui settle font/layout caches before geometry is asserted.
+    for pass in 0..2 {
         ctx.begin_pass(Default::default());
         egui::CentralPanel::default().show(&ctx, |ui| {
             ui.set_width(width);
-            let mut cache = CommonMarkCache::default();
             let response = CommonMarkViewer::new().show(ui, &mut cache, markdown);
             body_rect = response.response.rect;
         });
-        let _ = ctx.end_pass();
+        let output = ctx.end_pass();
+
+        // Only final-pass positions represent the settled layout.
+        if pass == 1 {
+            for clipped in output.shapes {
+                collect_painted_text(&clipped.shape, &mut painted);
+            }
+        }
     }
 
     let body_id = TextStyle::Body.resolve(&ctx.style());
-    let row_height = ctx.fonts_mut(|f| f.row_height(&body_id));
+    let row_height = ctx.fonts_mut(|fonts| fonts.row_height(&body_id));
+    (body_rect, row_height, painted)
+}
+
+fn render(markdown: &str, width: f32) -> (Rect, f32) {
+    let (body_rect, row_height, _) = render_geometry(markdown, width);
     (body_rect, row_height)
+}
+
+fn text_rect(painted: &[PaintedText], marker: &str) -> Rect {
+    painted
+        .iter()
+        .find(|entry| entry.text.contains(marker))
+        .unwrap_or_else(|| panic!("missing painted marker {marker:?}: {painted:#?}"))
+        .rect
+}
+
+fn assert_vertical_order(painted: &[PaintedText], markers: &[&str]) {
+    // Strict top-to-bottom order detects same-row overlap at either block edge.
+    for pair in markers.windows(2) {
+        let upper = text_rect(painted, pair[0]);
+        let lower = text_rect(painted, pair[1]);
+        assert!(
+            upper.bottom() <= lower.top(),
+            "expected {:?} above {:?}, got upper={upper:?} lower={lower:?}",
+            pair[0],
+            pair[1]
+        );
+    }
 }
 
 #[test]
@@ -150,4 +207,94 @@ fn deeply_nested_list_renders() {
     assert!(rect.height() > 0.0, "deeply nested list rect was empty: {rect:?}");
     let rect2 = render_scrollable(md, 540.0, 200.0, None);
     assert!(rect2.height() > 0.0, "deeply nested via scrollable empty: {rect2:?}");
+}
+
+#[test]
+fn list_code_block_uses_separate_rows() {
+    let markdown = "- ISSUE44_BEFORE\n  ```sh\n  ISSUE44_CODE\n  ```\n  ISSUE44_AFTER";
+    let (_, _, painted) = render_geometry(markdown, 540.0);
+
+    // The issue #44 block and trailing text must each occupy later rows.
+    assert_vertical_order(
+        &painted,
+        &["ISSUE44_BEFORE", "ISSUE44_CODE", "ISSUE44_AFTER"],
+    );
+}
+
+#[test]
+fn ordered_list_code_block_uses_separate_rows() {
+    let markdown = "1. ORDERED_BEFORE\n   ```text\n   ORDERED_CODE\n   ```\n   ORDERED_AFTER";
+    let (_, _, painted) = render_geometry(markdown, 540.0);
+
+    // Ordered-list markers use the same list runtime state as bullets.
+    assert_vertical_order(
+        &painted,
+        &["ORDERED_BEFORE", "ORDERED_CODE", "ORDERED_AFTER"],
+    );
+}
+
+#[test]
+fn code_only_list_item_renders_without_overlap_or_panic() {
+    let markdown = "- ```text\n  CODE_ONLY_MARKER\n  ```";
+    let (_, _, painted) = render_geometry(markdown, 540.0);
+
+    // Successful rendering and a visible marker cover the no-panic contract.
+    let code = text_rect(&painted, "CODE_ONLY_MARKER");
+    assert!(
+        code.is_positive(),
+        "code-only block has no painted area: {code:?}"
+    );
+}
+
+#[test]
+fn multiple_code_blocks_in_one_item_keep_row_order() {
+    let markdown = "- MULTI_BEFORE\n  ```text\n  MULTI_CODE_ONE\n  ```\n  MULTI_BETWEEN\n  ```text\n  MULTI_CODE_TWO\n  ```\n  MULTI_AFTER";
+    let (_, _, painted) = render_geometry(markdown, 540.0);
+
+    // Each block has independent before/after boundaries inside one item.
+    assert_vertical_order(
+        &painted,
+        &[
+            "MULTI_BEFORE",
+            "MULTI_CODE_ONE",
+            "MULTI_BETWEEN",
+            "MULTI_CODE_TWO",
+            "MULTI_AFTER",
+        ],
+    );
+}
+
+#[test]
+fn nested_list_code_blocks_keep_order_and_deeper_indentation() {
+    let markdown = "- OUTER_BEFORE\n  ```text\n  OUTER_CODE\n  ```\n  - NESTED_BEFORE\n    ```text\n    NESTED_CODE\n    ```\n    NESTED_AFTER\n- OUTER_AFTER";
+    let (_, _, painted) = render_geometry(markdown, 540.0);
+
+    // Nested list processing must remain balanced and vertically ordered.
+    assert_vertical_order(
+        &painted,
+        &[
+            "OUTER_BEFORE",
+            "OUTER_CODE",
+            "NESTED_BEFORE",
+            "NESTED_CODE",
+            "NESTED_AFTER",
+            "OUTER_AFTER",
+        ],
+    );
+
+    let outer_code = text_rect(&painted, "OUTER_CODE");
+    let nested_code = text_rect(&painted, "NESTED_CODE");
+    assert!(
+        nested_code.left() > outer_code.left(),
+        "nested code lost list indentation: outer={outer_code:?} nested={nested_code:?}"
+    );
+}
+
+#[test]
+fn top_level_code_block_layout_remains_separate() {
+    let markdown = "TOP_BEFORE\n\n```text\nTOP_CODE\n```\n\nTOP_AFTER";
+    let (_, _, painted) = render_geometry(markdown, 540.0);
+
+    // This control is already green before the fix and protects the list-only gate.
+    assert_vertical_order(&painted, &["TOP_BEFORE", "TOP_CODE", "TOP_AFTER"]);
 }

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1050,3 +1050,26 @@ Smooth ≤ ~3k events; borderline ~5–10k; laggy ~20k; near-unusable at 100k. A
 **General lesson:** when a "side path" caches values mid-render for downstream consumers (here, `active_search_y` for the corrective scroll), audit ALL the code paths that *populate* the cache when you change rendering behavior. The disable-virtualization fix in `21d43c5` was correctness-first for paint, but it silently changed the semantics of `active_search_y` from "valid while visible" to "valid forever," and the corrective block was implicitly assuming the old semantics.
 
 **Files:** `src/main.rs` (`Tab.correct_active_search_pending`, `scroll_to_active_match`, `render_tab_content` corrective block), `docs/devlog/031-search-scroll-lock.md`
+
+### List-item block widgets need explicit wrapped-row boundaries
+**Context:** Issue #44 — fenced code blocks inside unordered, ordered, and nested list items overlapped text immediately before or after the block.
+
+**Root cause:** List-item content renders in an egui horizontal wrapped row. A fenced code block is a block widget, but entering and leaving `Tag::CodeBlock` did not end that active row. Adjacent text and the block could therefore occupy the same layout row.
+
+**Fix:** Call `ui.end_row()` immediately before starting and after finishing a code block, gated by `self.list.is_inside_a_list()`. The gate leaves top-level code-block layout unchanged.
+
+**Fixture gotcha:** Markdown indentation does not guarantee a sibling block. This ending:
+```markdown
+    NESTED_AFTER
+  OUTER_AFTER
+```
+parses as one nested paragraph with a `SoftBreak`, so same-row placement is valid. To test return to outer list depth, use an actual outer sibling item:
+```markdown
+    NESTED_AFTER
+- OUTER_AFTER
+```
+Do not change renderer soft-break behavior to satisfy a fixture whose syntax expresses one paragraph.
+
+**Testing technique:** Inspect final-pass painted `Shape::Text` rectangles and assert strict top-to-bottom ordering. Response height alone can miss overlap. Keep one `CommonMarkCache` across render passes so tests match production cache lifetime and egui layout can settle.
+
+**Files:** `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`, `crates/egui_commonmark/egui_commonmark/tests/wrapping.rs`, `docs/devlog/043-list-code-block-layout.md`

--- a/docs/devlog/043-list-code-block-layout.md
+++ b/docs/devlog/043-list-code-block-layout.md
@@ -1,0 +1,64 @@
+# Fix: List-item fenced code block layout
+
+**Status:** Complete
+**Branch:** `fix/44-list-blocks`
+**Date:** 2026-07-12
+**Files Changed:** renderer row boundaries, geometry regression tests, and documentation
+
+## Summary
+
+Issue #44 exposed fenced code blocks overlapping adjacent text when rendered inside list items. List-item content uses egui horizontal wrapped rows, while fenced code renders as a block widget. Without explicit row boundaries, text before the fence, the code block, or text after the fence could share layout space.
+
+The renderer now ends the active list row immediately before and after each fenced code block. Top-level code blocks retain their existing path because row boundaries are conditional on active list state.
+
+## Implementation
+
+- End list-item row before starting a code block.
+- Render the code block through the existing `end_code_block` path.
+- End list-item row after the block so following item text starts below it.
+- Add painted-shape geometry assertions covering unordered, ordered, code-only, repeated, nested, and top-level-control cases.
+
+## Key Discovery
+
+Markdown indentation alone does not always create a new semantic block. This fixture ending:
+
+```markdown
+    NESTED_AFTER
+  OUTER_AFTER
+```
+
+parses both lines as one nested paragraph separated by a soft break. Equal Y placement is therefore valid. Making `OUTER_AFTER` an outer sibling list item:
+
+```markdown
+    NESTED_AFTER
+- OUTER_AFTER
+```
+
+expresses the intended block transition without forcing soft breaks apart in renderer code.
+
+## Coding Style And Technique Rationale
+
+The fix stays inside existing immediate-mode list state and uses `ui.end_row()` at the two block boundaries. This is smaller and clearer than introducing special paragraph parsing or post-layout correction. Conditional checks preserve top-level behavior and avoid changing soft-break semantics.
+
+Geometry tests inspect final-pass painted text rectangles rather than only response height. Strict top-to-bottom comparisons directly detect overlap at both code-block edges. Reusing one persistent `CommonMarkCache` across two passes matches production behavior and lets egui settle font/layout caches before assertions.
+
+## RED / GREEN Evidence
+
+- Baseline renderer with corrected fixture: `list_code_block_uses_separate_rows` RED because `OUTER_BEFORE` overlaps `OUTER_CODE`.
+- Focused corrected nested test: GREEN, 1 passed.
+- Full wrapping suite: GREEN, 12 passed.
+
+## Validation
+
+Run from vendored workspace via explicit manifest path:
+
+```bash
+cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --test wrapping nested_list_code_blocks_keep_order_and_deeper_indentation
+cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --test wrapping
+```
+
+Root formatting, root tests, clippy, and diff checks were run before completion. Vendored `cargo fmt --all --check` also ran but reported repository-wide pre-existing formatting drift across untouched files; no unrelated mass formatting was applied.
+
+## Impact
+
+Fenced code blocks inside list items now occupy dedicated rows, preserving order and nested indentation. Markdown soft breaks remain unchanged. No public API or persisted-state changes.


### PR DESCRIPTION
## Summary
- End egui wrapped rows before and after fenced code blocks inside list items so block content no longer overlaps adjacent text.
- Keep top-level code-block behavior unchanged by gating row boundaries on active list state.
- Add geometry regressions for unordered, ordered, code-only, nested, repeated-block, and trailing-text cases.

Fixes aydiler/md-viewer#44

## Test plan
- [x] `cargo test -p egui_commonmark_extended --test wrapping -- --nocapture` — 12 passed
- [x] `cargo test` — 29 passed
- [x] `cargo clippy --all-targets --all-features` — passed with existing vendored warnings
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] Spec compliance review PASS
- [x] Code-quality review PASS
- [x] Independent verification PASS