### PR TITLE
Render GitHub emoji shortcodes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,8 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           ASSET="md-viewer-${VERSION}-${{ matrix.asset_name }}.tar.gz"
-          tar -czf "$ASSET" -C "target/${{ matrix.target }}/release" md-viewer
+          tar -czf "$ASSET" -C "target/${{ matrix.target }}/release" md-viewer \
+            -C "$GITHUB_WORKSPACE" LICENSE THIRD_PARTY_NOTICES
           shasum -a 256 "$ASSET" > "$ASSET.sha256"
 
       - name: Package (Windows)
@@ -120,7 +121,7 @@ jobs:
         run: |
           $VERSION = "${env:GITHUB_REF}" -replace '^refs/tags/v',''
           $ASSET = "md-viewer-$VERSION-${{ matrix.asset_name }}.zip"
-          Compress-Archive -Path "target/${{ matrix.target }}/release/md-viewer.exe" -DestinationPath $ASSET
+          Compress-Archive -Path "target/${{ matrix.target }}/release/md-viewer.exe", "LICENSE", "THIRD_PARTY_NOTICES" -DestinationPath $ASSET
           $Hash = (Get-FileHash -Algorithm SHA256 $ASSET).Hash.ToLower()
           "$Hash  $ASSET" | Out-File -Encoding ascii "$ASSET.sha256"
 
@@ -415,7 +416,7 @@ jobs:
           cp aur-bin/PKGBUILD aur-repo/PKGBUILD
 
           # Tarball sha256 comes from the downloaded artifact (see comment above).
-          # The three aux files (.desktop, icon, LICENSE) come from raw.github
+          # The four aux files (.desktop, icon, LICENSE, notice) come from raw.github
           # at the tagged commit — those URLs are valid as soon as the tag exists.
           mkdir -p sums
           cp "dist/md-viewer-${VERSION}-linux-x86_64.tar.gz.sha256" sums/tarball.sha256
@@ -425,14 +426,16 @@ jobs:
             | sha256sum > sums/icon.sha256
           curl -fsSL "https://raw.githubusercontent.com/aydiler/md-viewer/v${VERSION}/LICENSE" \
             | sha256sum > sums/license.sha256
+          curl -fsSL "https://raw.githubusercontent.com/aydiler/md-viewer/v${VERSION}/THIRD_PARTY_NOTICES" \
+            | sha256sum > sums/notice.sha256
 
-          # Rewrite pkgver and the four-element sha256sums=( ... ) array.
+          # Rewrite pkgver and the five-element sha256sums=( ... ) array.
           # sed on a multi-line array is fragile, so use Python.
           python3 - <<'PY'
           import re, pathlib
           p = pathlib.Path("aur-repo/PKGBUILD")
           sums = [open(f"sums/{n}.sha256").read().split()[0]
-                  for n in ("tarball", "desktop", "icon", "license")]
+                  for n in ("tarball", "desktop", "icon", "license", "notice")]
           import os
           version = os.environ["VERSION"]
           text = p.read_text()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend_extended"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1596,11 +1596,12 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_extended"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "egui",
  "egui_commonmark_backend_extended",
  "egui_extras",
+ "emojis",
  "pulldown-cmark 0.13.0",
 ]
 
@@ -1679,6 +1680,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "emojis"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1514ced566c94991ed9563258ecf61e311fd773bf0a3f20606830386bf66e3"
+dependencies = [
+ "phf 0.13.1",
+]
 
 [[package]]
 name = "ena"
@@ -7939,4 +7949,4 @@ dependencies = [
 
 [[patch.unused]]
 name = "egui_commonmark_macros_extended"
-version = "0.24.0"
+version = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["markdown", "viewer", "egui", "linux", "desktop"]
 categories = ["command-line-utilities", "gui", "visualization"]
 exclude = [
     "docs/devlog/*",
+    "docs/superpowers/*",
     "screenshots/*",
     ".claude/*",
     "crates/*",
@@ -34,7 +35,7 @@ egui = { version = "0.33", features = ["accesskit"] }
 # egui-mcp-bridge = { path = "/home/ahmet/dev/mcp/egui-mcp/crates/egui-mcp-bridge", optional = true }
 
 # Markdown rendering with syntax highlighting (fork with typography support)
-egui_commonmark_extended = { version = "0.24.0", features = [
+egui_commonmark_extended = { version = "0.25.0", features = [
     "better_syntax_highlighting",
     "svg",
     "svg_text",
@@ -85,6 +86,6 @@ lto = "thin"
 codegen-units = 4
 
 [patch.crates-io]
-egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark" }
-egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend" }
-egui_commonmark_macros_extended = { path = "crates/egui_commonmark/egui_commonmark_macros" }
+egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark", version = "0.25.0" }
+egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend", version = "0.25.0" }
+egui_commonmark_macros_extended = { path = "crates/egui_commonmark/egui_commonmark_macros", version = "0.25.0" }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release install run clean
+.PHONY: build release install uninstall run clean
 
 build:
 	cargo build
@@ -10,6 +10,14 @@ install: release
 	cp target/release/md-viewer ~/.local/bin/
 	mkdir -p ~/.local/share/applications
 	cp data/md-viewer.desktop ~/.local/share/applications/
+	mkdir -p ~/.local/share/licenses/md-viewer
+	cp LICENSE THIRD_PARTY_NOTICES ~/.local/share/licenses/md-viewer/
+	update-desktop-database ~/.local/share/applications 2>/dev/null || true
+
+uninstall:
+	rm -f ~/.local/bin/md-viewer
+	rm -f ~/.local/share/applications/md-viewer.desktop
+	rm -rf ~/.local/share/licenses/md-viewer
 	update-desktop-database ~/.local/share/applications 2>/dev/null || true
 
 run:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A fast, lightweight markdown viewer for Linux built with Rust and egui. Designed
 ## Features
 
 ### Rendering
-- **GitHub Flavored Markdown** - Full GFM support including tables, task lists, and footnotes
+- **GitHub Flavored Markdown** - Full GFM support including tables, task lists, footnotes, and recognized emoji shortcodes such as `:pushpin:`
 - **LaTeX Math** - Inline `$…$` and display `$$…$$` equations rendered via typst + mitex — fractions, sub/superscripts, `\boxed`, accents, matrices, and more — sized and baseline-aligned to the surrounding text
 - **Syntax Highlighting** - 200+ languages via syntect with beautiful color schemes
 - **Mermaid Diagrams** - Flowcharts, sequence diagrams, and more rendered natively via [merman](https://github.com/Latias94/merman) (click to enlarge)
@@ -151,7 +151,7 @@ A fast, lightweight markdown viewer for Linux built with Rust and egui. Designed
 
 ### Quick Install (Linux / macOS) — recommended
 
-Downloads the prebuilt binary for your platform, verifies its SHA256, and installs to `~/.local/bin`. No compilation, takes seconds.
+Downloads the prebuilt binary for your platform, verifies its SHA256, and installs the binary to `~/.local/bin` plus bundled third-party notices under `~/.local/share/licenses/md-viewer`. No compilation, takes seconds.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/aydiler/md-viewer/main/scripts/install.sh | sh
@@ -206,7 +206,8 @@ Compiles locally (~2–3 minutes). Update with `cargo install --force md-viewer`
 git clone https://github.com/aydiler/md-viewer
 cd md-viewer
 cargo build --release
-make install   # installs to ~/.local/bin (optional)
+make install     # installs to ~/.local/bin (optional)
+make uninstall   # removes the local installation
 ```
 
 ### System Dependencies (Arch Linux)
@@ -250,6 +251,7 @@ When launched from a terminal, `md-viewer` detaches by default so the shell prom
 
 - [eframe/egui](https://github.com/emilk/egui) - Immediate mode GUI framework
 - [egui_commonmark](https://github.com/lampsitter/egui_commonmark) - Markdown rendering (vendored fork with typography, math, and alignment improvements)
+- [emojis](https://crates.io/crates/emojis) - GitHub/gemoji shortcode lookup data (`(MIT OR Apache-2.0) AND Unicode-3.0`; see `THIRD_PARTY_NOTICES`)
 - [typst](https://github.com/typst/typst) + [mitex](https://github.com/mitex-rs/mitex) - LaTeX math rendering (LaTeX → typst → rasterized inline)
 - [merman](https://github.com/Latias94/merman) - Mermaid diagram rendering
 - [syntect](https://github.com/trishume/syntect) - Syntax highlighting

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,0 +1,78 @@
+Third-Party Notices
+===================
+
+emojis 0.9.0
+------------
+
+md-viewer uses the `emojis` crate for GitHub/gemoji shortcode lookup data.
+The crate is licensed under:
+
+    (MIT OR Apache-2.0) AND Unicode-3.0
+
+Source: https://github.com/rossmacarthur/emojis
+
+The `emojis` software is redistributed under the MIT license:
+
+MIT License
+
+Copyright (c) 2019 Ross MacArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The bundled emoji data is covered by the following Unicode License v3 notice.
+
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2023 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in
+the Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.

--- a/aur-bin/PKGBUILD
+++ b/aur-bin/PKGBUILD
@@ -31,12 +31,14 @@ source=(
     "md-viewer.desktop::https://raw.githubusercontent.com/aydiler/md-viewer/v${pkgver}/data/md-viewer.desktop"
     "io.github.aydiler.md-viewer.png::https://raw.githubusercontent.com/aydiler/md-viewer/v${pkgver}/data/io.github.aydiler.md-viewer.png"
     "LICENSE::https://raw.githubusercontent.com/aydiler/md-viewer/v${pkgver}/LICENSE"
+    "THIRD_PARTY_NOTICES::https://raw.githubusercontent.com/aydiler/md-viewer/v${pkgver}/THIRD_PARTY_NOTICES"
 )
 sha256sums=(
     'bc7e3f5f00101cccea2cd6535ec0f32ecf0b403b5c96d902e8b63ad744730ce8'
     '7d786706389bf20531f1e2ace18bc1d2057b1745c059df6e804695cbbc8fe69c'
     '46d7a5b2a50e845d8c63146441914d37df5c411036a22d5412f1844126330b1b'
     '1a12042bdcb8eb609fd272b10a1dac618aec3aebdae90f5dd49af264a358444e'
+    'SKIP'
 )
 
 package() {
@@ -48,4 +50,6 @@ package() {
         "${pkgdir}/usr/share/pixmaps/io.github.aydiler.md-viewer.png"
     install -Dm644 "${srcdir}/LICENSE" \
         "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -Dm644 "${srcdir}/THIRD_PARTY_NOTICES" \
+        "${pkgdir}/usr/share/licenses/${pkgname}/THIRD_PARTY_NOTICES"
 }

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -48,4 +48,5 @@ package() {
     install -Dm755 "target/release/md-viewer" "$pkgdir/usr/bin/md-viewer"
     install -Dm644 "data/md-viewer.desktop" "$pkgdir/usr/share/applications/md-viewer.desktop"
     install -Dm644 "LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 "THIRD_PARTY_NOTICES" "$pkgdir/usr/share/licenses/$pkgname/THIRD_PARTY_NOTICES"
 }

--- a/crates/egui_commonmark/Cargo.lock
+++ b/crates/egui_commonmark/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend_extended"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "data-url",
  "egui",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_extended"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "document-features",
  "eframe",
@@ -1166,13 +1166,14 @@ dependencies = [
  "egui_commonmark_backend_extended",
  "egui_commonmark_macros_extended",
  "egui_extras",
+ "emojis",
  "image",
  "pulldown-cmark 0.13.0",
 ]
 
 [[package]]
 name = "egui_commonmark_macros_extended"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "document-features",
  "egui",
@@ -1259,6 +1260,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "emojis"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1514ced566c94991ed9563258ecf61e311fd773bf0a3f20606830386bf66e3"
+dependencies = [
+ "phf 0.13.1",
+]
 
 [[package]]
 name = "ena"

--- a/crates/egui_commonmark/Cargo.toml
+++ b/crates/egui_commonmark/Cargo.toml
@@ -12,15 +12,17 @@ resolver = "3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.76"
-version = "0.24.0"
+version = "0.25.0"
 repository = "https://github.com/aydiler/md-viewer"
 
 [workspace.dependencies]
 egui_extras = { version = "0.33", default-features = false }
 egui = { version = "0.33", default-features = false }
 
-egui_commonmark_backend_extended = { version = "0.24.0", path = "egui_commonmark_backend", default-features = false }
-egui_commonmark_macros_extended = { version = "0.24.0", path = "egui_commonmark_macros", default-features = false }
+# Runtime lookup for recognized GitHub/gemoji shortcode names.
+emojis = "0.9.0"
+egui_commonmark_backend_extended = { version = "0.25.0", path = "egui_commonmark_backend", default-features = false }
+egui_commonmark_macros_extended = { version = "0.25.0", path = "egui_commonmark_macros", default-features = false }
 
 # To add features to documentation
 document-features = { version = "0.2" }

--- a/crates/egui_commonmark/egui_commonmark/Cargo.toml
+++ b/crates/egui_commonmark/egui_commonmark/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["commonmark", "egui", "markdown", "typography"]
 categories = ["gui"]
 readme = "README.md"
 documentation = "https://docs.rs/egui_commonmark_extended"
-include = ["src/**/*.rs", "LICENSE-MIT", "LICENSE-APACHE", "Cargo.toml"]
+include = ["src/**/*.rs", "LICENSE-MIT", "LICENSE-APACHE", "THIRD_PARTY_NOTICES", "Cargo.toml"]
 
 [dependencies]
 egui_commonmark_backend_extended = { workspace = true }
@@ -21,6 +21,9 @@ egui_commonmark_macros_extended = { workspace = true, optional = true }
 
 egui_extras = { workspace = true }
 egui = { workspace = true }
+
+# Expand recognized GitHub shortcodes in visible Markdown text.
+emojis = { workspace = true }
 
 document-features = { workspace = true, optional = true }
 

--- a/crates/egui_commonmark/egui_commonmark/THIRD_PARTY_NOTICES
+++ b/crates/egui_commonmark/egui_commonmark/THIRD_PARTY_NOTICES
@@ -1,0 +1,78 @@
+Third-Party Notices
+===================
+
+emojis 0.9.0
+------------
+
+This crate uses the `emojis` crate for GitHub/gemoji shortcode lookup data.
+The crate is licensed under:
+
+    (MIT OR Apache-2.0) AND Unicode-3.0
+
+Source: https://github.com/rossmacarthur/emojis
+
+The `emojis` software is redistributed under the MIT license:
+
+MIT License
+
+Copyright (c) 2019 Ross MacArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The bundled emoji data is covered by the following Unicode License v3 notice.
+
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2023 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in
+the Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -41,58 +41,157 @@ impl HighlightKind {
     }
 }
 
-/// Split `text` (covering `span` in the source) into segments tagged with the
-/// highlight kind that applies to each. Returns at least one segment.
-///
-/// Assumes `text.len() == span.len()` — caller is responsible for that check
-/// (markdown escapes or smart-punct transforms can break it).
-fn compute_highlight_segments(
-    text: &str,
+/// One borrowed visible segment plus its exact identity in raw Markdown source.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EmojiTextSegment<'a> {
+    rendered: &'a str,
+    source_range: Range<usize>,
+    raw: &'a str,
+    replaced: bool,
+}
+
+/// Visit recognized `:shortcode:` replacements without allocating unchanged text.
+fn visit_emoji_text_segments<'a>(
+    text: &'a str,
+    span: &Range<usize>,
+    mut visit: impl FnMut(EmojiTextSegment<'a>),
+) {
+    // Transformed pulldown text cannot be mapped safely back to original source bytes.
+    if text.len() != span.len() {
+        visit(EmojiTextSegment {
+            rendered: text,
+            source_range: span.clone(),
+            raw: text,
+            replaced: false,
+        });
+        return;
+    }
+
+    let mut plain_start = 0usize;
+    let mut search_from = 0usize;
+    let mut replaced_any = false;
+
+    while let Some(open_rel) = text[search_from..].find(':') {
+        let open = search_from + open_rel;
+        let name_start = open + 1;
+        let Some(close_rel) = text[name_start..].find(':') else {
+            break;
+        };
+        let close = name_start + close_rel;
+        let name = &text[name_start..close];
+
+        if !name.is_empty() {
+            if let Some(emoji) = emojis::get_by_shortcode(name) {
+                if plain_start < open {
+                    visit(EmojiTextSegment {
+                        rendered: &text[plain_start..open],
+                        source_range: span.start + plain_start..span.start + open,
+                        raw: &text[plain_start..open],
+                        replaced: false,
+                    });
+                }
+
+                let raw_end = close + 1;
+                visit(EmojiTextSegment {
+                    rendered: emoji.as_str(),
+                    source_range: span.start + open..span.start + raw_end,
+                    raw: &text[open..raw_end],
+                    replaced: true,
+                });
+                replaced_any = true;
+                plain_start = raw_end;
+                search_from = raw_end;
+                continue;
+            }
+        }
+
+        // Keep unknown syntax literal while searching later openers in this event.
+        search_from = name_start;
+    }
+
+    if !replaced_any {
+        visit(EmojiTextSegment {
+            rendered: text,
+            source_range: span.clone(),
+            raw: text,
+            replaced: false,
+        });
+    } else if plain_start < text.len() {
+        visit(EmojiTextSegment {
+            rendered: &text[plain_start..],
+            source_range: span.start + plain_start..span.end,
+            raw: &text[plain_start..],
+            replaced: false,
+        });
+    }
+}
+
+/// Only ordinary visible text may expand; image alt text and code blocks stay literal.
+fn emoji_expansion_is_eligible(in_image: bool, in_code_block: bool) -> bool {
+    !in_image && !in_code_block
+}
+
+/// Resolve one indivisible replacement against source-authoritative search ranges.
+fn highlight_for_source_span(
+    source_span: &Range<usize>,
+    ranges: &[Range<usize>],
+    active: Option<&Range<usize>>,
+) -> HighlightKind {
+    let overlaps =
+        |range: &Range<usize>| range.start < source_span.end && source_span.start < range.end;
+
+    if active.is_some_and(overlaps) {
+        HighlightKind::Active
+    } else if ranges.iter().any(overlaps) {
+        HighlightKind::Match
+    } else {
+        HighlightKind::None
+    }
+}
+
+/// Visit borrowed text slices tagged with exact source-range highlighting.
+/// Assumes non-overlapping source ranges, matching app search production.
+fn visit_highlight_segments<'a>(
+    text: &'a str,
     span: &Range<usize>,
     ranges: &[Range<usize>],
     active: Option<&Range<usize>>,
-) -> Vec<(String, HighlightKind)> {
-    let mut overlaps: Vec<(usize, usize, HighlightKind)> = Vec::new();
-    for r in ranges {
-        let start = r.start.max(span.start);
-        let end = r.end.min(span.end);
+    mut visit: impl FnMut(&'a str, HighlightKind),
+) {
+    let mut cursor = 0usize;
+    let mut found = false;
+
+    for range in ranges {
+        let start = range.start.max(span.start);
+        let end = range.end.min(span.end);
         if start >= end {
             continue;
         }
+
         let local_start = start - span.start;
         let local_end = end - span.start;
-        let is_active = active.map(|a| a == r).unwrap_or(false);
-        let kind = if is_active {
+        if !text.is_char_boundary(local_start) || !text.is_char_boundary(local_end) {
+            continue;
+        }
+
+        found = true;
+        if local_start > cursor && text.is_char_boundary(cursor) {
+            visit(&text[cursor..local_start], HighlightKind::None);
+        }
+        let kind = if active == Some(range) {
             HighlightKind::Active
         } else {
             HighlightKind::Match
         };
-        overlaps.push((local_start, local_end, kind));
+        visit(&text[local_start..local_end], kind);
+        cursor = local_end;
     }
 
-    if overlaps.is_empty() {
-        return vec![(text.to_string(), HighlightKind::None)];
+    if !found {
+        visit(text, HighlightKind::None);
+    } else if cursor < text.len() && text.is_char_boundary(cursor) {
+        visit(&text[cursor..], HighlightKind::None);
     }
-
-    let mut segments = Vec::new();
-    let mut cursor = 0;
-    for (start, end, kind) in overlaps {
-        if start > cursor
-            && text.is_char_boundary(cursor)
-            && text.is_char_boundary(start)
-        {
-            segments.push((text[cursor..start].to_string(), HighlightKind::None));
-        }
-        if text.is_char_boundary(start) && text.is_char_boundary(end) {
-            segments.push((text[start..end].to_string(), kind));
-        }
-        cursor = end;
-    }
-    if cursor < text.len() && text.is_char_boundary(cursor) {
-        segments.push((text[cursor..].to_string(), HighlightKind::None));
-    }
-
-    segments
 }
 
 /// Split a long inline-code token into fixed-size chunks so the row-wrap layout
@@ -1238,7 +1337,8 @@ impl CommonMarkViewerInternal {
                 };
                 for segment in segments {
                     if let Some(ref span) = interior_span {
-                        self.event_text_with_highlights(
+                        // Inline code stays source-literal while retaining byte-range highlights.
+                        self.event_literal_text_with_highlights(
                             segment.into(),
                             span,
                             cache,
@@ -1325,13 +1425,14 @@ impl CommonMarkViewerInternal {
     }
 
     fn event_text(&mut self, text: CowStr, ui: &mut Ui, options: &CommonMarkOptions) {
-        self.emit_text(text, HighlightKind::None, ui, options);
+        self.emit_text(text, None, HighlightKind::None, ui, options);
     }
 
-    /// Like `event_text`, but applies a search-highlight background color when `hl` is not `None`.
+    /// Render text while optionally retaining a different raw spelling for heading identity.
     fn emit_text(
         &mut self,
         text: CowStr,
+        raw_heading_text: Option<&str>,
         hl: HighlightKind,
         ui: &mut Ui,
         options: &CommonMarkOptions,
@@ -1376,7 +1477,8 @@ impl CommonMarkViewerInternal {
             link.text.push(rich_text);
         } else if self.text_style.heading.is_some() {
             // Accumulate heading text for position tracking
-            self.current_heading_text.push_str(&text);
+            self.current_heading_text
+                .push_str(raw_heading_text.unwrap_or(&text));
             // Accumulate RichText - will render all at once in end_tag(Heading)
             self.current_heading_rich_texts.push(rich_text);
         } else {
@@ -1384,10 +1486,35 @@ impl CommonMarkViewerInternal {
         }
     }
 
-    /// Split `text` at search-match boundaries (using `span` to locate matches in the
-    /// source content) and emit each segment with the appropriate highlight. Falls back
-    /// to plain `event_text` when there are no ranges or `text.len() != span.len()`
-    /// (markdown escapes or smart-punct transforms can break the 1:1 byte mapping).
+    /// Render source-literal text while preserving fine-grained search highlighting.
+    fn event_literal_text_with_highlights(
+        &mut self,
+        text: CowStr,
+        span: &Range<usize>,
+        cache: &mut CommonMarkCache,
+        ui: &mut Ui,
+        options: &CommonMarkOptions,
+    ) {
+        // Emit borrowed slices directly; record captured active Y after cache borrows end.
+        let mut active_y = None;
+        visit_highlight_segments(
+            &text,
+            span,
+            cache.search_ranges(),
+            cache.active_search_range(),
+            |segment_text, hl| {
+                if hl == HighlightKind::Active {
+                    active_y = Some(ui.cursor().top());
+                }
+                self.emit_text(segment_text.into(), None, hl, ui, options);
+            },
+        );
+        if let Some(y) = active_y {
+            cache.record_active_search_y_viewport(y);
+        }
+    }
+
+    /// Expand eligible emoji shortcodes, then preserve source-based search semantics.
     fn event_text_with_highlights(
         &mut self,
         text: CowStr,
@@ -1396,22 +1523,44 @@ impl CommonMarkViewerInternal {
         ui: &mut Ui,
         options: &CommonMarkOptions,
     ) {
-        let ranges = cache.search_ranges();
-        if ranges.is_empty() || text.len() != span.len() {
+        if !emoji_expansion_is_eligible(self.image.is_some(), self.code_block.is_some()) {
             self.event_text(text, ui, options);
             return;
         }
-        let segments =
-            compute_highlight_segments(&text, span, ranges, cache.active_search_range());
-        for (segment_text, hl) in segments {
-            // Record the cursor y for the Active segment BEFORE emitting it, so the
-            // app can scroll to the active match's actual position (line-ratio
-            // estimates are unreliable in image-heavy docs).
-            if hl == HighlightKind::Active {
-                let vy = ui.cursor().top();
-                cache.record_active_search_y_viewport(vy);
+
+        // Emit borrowed source slices and static emoji strings directly.
+        let mut active_y = None;
+        visit_emoji_text_segments(&text, span, |segment| {
+            if segment.replaced {
+                // Replacement glyphs are indivisible, but overlap uses raw source range.
+                let hl = highlight_for_source_span(
+                    &segment.source_range,
+                    cache.search_ranges(),
+                    cache.active_search_range(),
+                );
+                if hl == HighlightKind::Active {
+                    active_y = Some(ui.cursor().top());
+                }
+                self.emit_text(segment.rendered.into(), Some(segment.raw), hl, ui, options);
+                return;
             }
-            self.emit_text(segment_text.into(), hl, ui, options);
+
+            // Plain source-preserving segments retain exact highlight splitting.
+            visit_highlight_segments(
+                segment.rendered,
+                &segment.source_range,
+                cache.search_ranges(),
+                cache.active_search_range(),
+                |segment_text, hl| {
+                    if hl == HighlightKind::Active {
+                        active_y = Some(ui.cursor().top());
+                    }
+                    self.emit_text(segment_text.into(), None, hl, ui, options);
+                },
+            );
+        });
+        if let Some(y) = active_y {
+            cache.record_active_search_y_viewport(y);
         }
     }
 
@@ -1880,5 +2029,374 @@ impl CommonMarkViewerInternal {
             });
         forward_shift_wheel_to_horizontal_scroll(ui, &mut scroll_out);
         self.line.try_insert_end(ui);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pulldown_cmark::{Event, Options, Parser, Tag};
+
+    // Snapshot scanner output so ranges and raw/rendered identities stay explicit.
+    fn segment_snapshot(text: &str, start: usize) -> Vec<(String, Range<usize>, String, bool)> {
+        let mut snapshots = Vec::new();
+        visit_emoji_text_segments(text, &(start..start + text.len()), |segment| {
+            snapshots.push((
+                segment.rendered.to_owned(),
+                segment.source_range,
+                segment.raw.to_owned(),
+                segment.replaced,
+            ));
+        });
+        snapshots
+    }
+
+    // Collect highlight output only in tests; production emission stays borrowed.
+    fn highlight_snapshot(
+        text: &str,
+        span: &Range<usize>,
+        ranges: &[Range<usize>],
+        active: Option<&Range<usize>>,
+    ) -> Vec<(String, HighlightKind)> {
+        let mut snapshots = Vec::new();
+        visit_highlight_segments(text, span, ranges, active, |segment, kind| {
+            snapshots.push((segment.to_owned(), kind));
+        });
+        snapshots
+    }
+
+    // Exercise expansion at pulldown event boundaries without invoking egui painting.
+    fn expanded_visible_text(markdown: &str) -> String {
+        let mut visible = String::new();
+        let mut image_depth = 0usize;
+        let mut code_block_depth = 0usize;
+
+        for (event, span) in Parser::new_ext(markdown, Options::all()).into_offset_iter() {
+            match event {
+                Event::Start(Tag::Image { .. }) => image_depth += 1,
+                Event::End(pulldown_cmark::TagEnd::Image) => image_depth -= 1,
+                Event::Start(Tag::CodeBlock(_)) => code_block_depth += 1,
+                Event::End(pulldown_cmark::TagEnd::CodeBlock) => code_block_depth -= 1,
+                Event::Text(text)
+                    if emoji_expansion_is_eligible(image_depth > 0, code_block_depth > 0) =>
+                {
+                    visit_emoji_text_segments(&text, &span, |segment| {
+                        visible.push_str(segment.rendered);
+                    });
+                }
+                Event::Text(text) | Event::Code(text) => visible.push_str(&text),
+                _ => {}
+            }
+        }
+        visible
+    }
+
+    #[test]
+    fn no_colon_fast_path_borrows_original_text() {
+        let text = "plain text only";
+        let mut seen = 0;
+
+        visit_emoji_text_segments(text, &(7..7 + text.len()), |segment| {
+            seen += 1;
+            assert_eq!(segment.rendered.as_ptr(), text.as_ptr());
+            assert_eq!(segment.raw.as_ptr(), text.as_ptr());
+            assert_eq!(segment.source_range, 7..7 + text.len());
+            assert!(!segment.replaced);
+        });
+
+        assert_eq!(seen, 1);
+    }
+
+    #[test]
+    fn unknown_only_fast_path_borrows_original_text() {
+        let text = ":unknown: and :still_unknown:";
+        let mut seen = 0;
+
+        visit_emoji_text_segments(text, &(3..3 + text.len()), |segment| {
+            seen += 1;
+            assert_eq!(segment.rendered.as_ptr(), text.as_ptr());
+            assert_eq!(segment.raw.as_ptr(), text.as_ptr());
+            assert_eq!(segment.source_range, 3..3 + text.len());
+            assert!(!segment.replaced);
+        });
+
+        assert_eq!(seen, 1);
+    }
+
+    #[test]
+    fn plain_query_boundary_does_not_highlight_following_emoji() {
+        let text = "hello world :rocket:";
+        let span = 30..30 + text.len();
+        let world = 36..41;
+        let mut snapshots = Vec::new();
+
+        visit_emoji_text_segments(text, &span, |segment| {
+            if segment.replaced {
+                snapshots.push((
+                    segment.rendered.to_owned(),
+                    highlight_for_source_span(
+                        &segment.source_range,
+                        std::slice::from_ref(&world),
+                        None,
+                    ),
+                ));
+            } else {
+                snapshots.extend(highlight_snapshot(
+                    segment.rendered,
+                    &segment.source_range,
+                    std::slice::from_ref(&world),
+                    None,
+                ));
+            }
+        });
+
+        assert_eq!(
+            snapshots,
+            vec![
+                ("hello ".into(), HighlightKind::None),
+                ("world".into(), HighlightKind::Match),
+                (" ".into(), HighlightKind::None),
+                ("🚀".into(), HighlightKind::None),
+            ]
+        );
+    }
+
+    #[test]
+    fn emoji_segments_keep_absolute_raw_source_ranges() {
+        assert_eq!(
+            segment_snapshot("A :pushpin: B", 20),
+            vec![
+                ("A ".into(), 20..22, "A ".into(), false),
+                ("📌".into(), 22..31, ":pushpin:".into(), true),
+                (" B".into(), 31..33, " B".into(), false),
+            ]
+        );
+    }
+
+    #[test]
+    fn emoji_segments_support_multiple_and_adjacent_shortcodes() {
+        assert_eq!(
+            segment_snapshot(":rocket::pushpin:", 0),
+            vec![
+                ("🚀".into(), 0..8, ":rocket:".into(), true),
+                ("📌".into(), 8..17, ":pushpin:".into(), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn emoji_segments_preserve_unknown_empty_and_unterminated_candidates() {
+        for text in [
+            ":not_a_gemoji:",
+            "::",
+            "prefix :pushpin",
+            "12:30",
+            "https://x:y",
+        ] {
+            assert_eq!(
+                segment_snapshot(text, 7),
+                vec![(text.into(), 7..7 + text.len(), text.into(), false)]
+            );
+        }
+    }
+
+    #[test]
+    fn emoji_segments_continue_after_unknown_candidates() {
+        assert_eq!(
+            segment_snapshot(":unknown: then :rocket:", 4),
+            vec![
+                (
+                    ":unknown: then ".into(),
+                    4..19,
+                    ":unknown: then ".into(),
+                    false
+                ),
+                ("🚀".into(), 19..27, ":rocket:".into(), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn emoji_segments_are_utf8_safe_before_and_after_shortcode() {
+        assert_eq!(
+            segment_snapshot("é:pushpin:界", 10),
+            vec![
+                ("é".into(), 10..12, "é".into(), false),
+                ("📌".into(), 12..21, ":pushpin:".into(), true),
+                ("界".into(), 21..24, "界".into(), false),
+            ]
+        );
+    }
+
+    #[test]
+    fn emoji_segments_refuse_non_identity_source_mapping() {
+        let mut snapshots = Vec::new();
+        visit_emoji_text_segments("📌", &(10..19), |segment| {
+            snapshots.push((
+                segment.rendered.to_owned(),
+                segment.source_range,
+                segment.raw.to_owned(),
+                segment.replaced,
+            ));
+        });
+        assert_eq!(snapshots, vec![("📌".into(), 10..19, "📌".into(), false)]);
+    }
+
+    #[test]
+    fn replacement_highlight_is_indivisible_for_any_source_overlap() {
+        let source = 22..31;
+        assert_eq!(
+            highlight_for_source_span(&source, &[25..26], None),
+            HighlightKind::Match
+        );
+        assert_eq!(
+            highlight_for_source_span(&source, &[0..100], None),
+            HighlightKind::Match
+        );
+    }
+
+    #[test]
+    fn active_overlap_wins_over_regular_match() {
+        assert_eq!(
+            highlight_for_source_span(&(22..31), &[22..31], Some(&(24..25))),
+            HighlightKind::Active
+        );
+    }
+
+    #[test]
+    fn disjoint_source_ranges_do_not_highlight_replacement() {
+        assert_eq!(
+            highlight_for_source_span(&(22..31), &[0..22, 31..40], None),
+            HighlightKind::None
+        );
+    }
+
+    #[test]
+    fn emoji_expansion_eligibility_excludes_images_and_code_blocks() {
+        assert!(emoji_expansion_is_eligible(false, false));
+        assert!(!emoji_expansion_is_eligible(true, false));
+        assert!(!emoji_expansion_is_eligible(false, true));
+        assert!(!emoji_expansion_is_eligible(true, true));
+    }
+
+    #[test]
+    fn eligible_markdown_text_and_link_labels_expand() {
+        let markdown = "Paragraph :pushpin: *:rocket:* [:pushpin:](https://e/:rocket:)";
+        assert_eq!(expanded_visible_text(markdown), "Paragraph 📌 🚀 📌");
+    }
+
+    #[test]
+    fn production_inline_code_stays_literal_and_keeps_source_highlighting() {
+        // Drive the production Event::Code branch and inspect its heading accumulator output.
+        egui::__run_test_ui(|ui| {
+            let markdown = "`:pushpin:`";
+            let mut renderer = CommonMarkViewerInternal::new();
+            let mut cache = CommonMarkCache::default();
+            cache.set_search_ranges(std::iter::once(1..10).collect());
+            cache.set_active_search_range(Some(1..10));
+            renderer.text_style.heading = Some(1);
+
+            renderer.event(
+                ui,
+                Event::Code(":pushpin:".into()),
+                0..markdown.len(),
+                &mut cache,
+                &CommonMarkOptions::default(),
+                540.0,
+            );
+
+            assert_eq!(renderer.current_heading_rich_texts.len(), 1);
+            assert_eq!(renderer.current_heading_rich_texts[0].text(), ":pushpin:");
+            assert_eq!(renderer.current_heading_text, ":pushpin:");
+            assert!(
+                cache.active_search_y().is_some(),
+                "inline-code active search range was not recorded"
+            );
+        });
+    }
+
+    #[test]
+    fn production_heading_accumulates_emoji_display_and_raw_shortcode_identity() {
+        // Drive production Event::Text while heading mode is active.
+        egui::__run_test_ui(|ui| {
+            let mut renderer = CommonMarkViewerInternal::new();
+            let mut cache = CommonMarkCache::default();
+            renderer.text_style.heading = Some(1);
+
+            renderer.event(
+                ui,
+                Event::Text("Pin :pushpin:".into()),
+                3..16,
+                &mut cache,
+                &CommonMarkOptions::default(),
+                540.0,
+            );
+
+            let display: String = renderer
+                .current_heading_rich_texts
+                .iter()
+                .map(|text| text.text())
+                .collect();
+            assert_eq!(display, "Pin 📌");
+            assert_eq!(renderer.current_heading_text, "Pin :pushpin:");
+        });
+    }
+
+    #[test]
+    fn production_duplicate_shortcode_headings_use_raw_occurrence_keys() {
+        // Run complete heading start/text/end production events twice against one cache.
+        egui::__run_test_ui(|ui| {
+            let mut renderer = CommonMarkViewerInternal::new();
+            let mut cache = CommonMarkCache::default();
+            let options = CommonMarkOptions::default();
+
+            for _ in 0..2 {
+                renderer.start_tag(
+                    ui,
+                    Tag::Heading {
+                        level: HeadingLevel::H2,
+                        id: None,
+                        classes: Vec::new(),
+                        attrs: Vec::new(),
+                    },
+                    &options,
+                );
+                renderer.event(
+                    ui,
+                    Event::Text("Pin :pushpin:".into()),
+                    3..16,
+                    &mut cache,
+                    &options,
+                    540.0,
+                );
+                renderer.end_tag(
+                    ui,
+                    pulldown_cmark::TagEnd::Heading(HeadingLevel::H2),
+                    &mut cache,
+                    &options,
+                    540.0,
+                );
+            }
+
+            assert!(cache.get_header_position("pin :pushpin:").is_some());
+            assert!(cache.get_header_position("pin :pushpin:#1").is_some());
+            assert!(cache.get_header_position("pin 📌").is_none());
+            assert!(cache.get_header_position("pin 📌#1").is_none());
+        });
+    }
+
+    #[test]
+    fn inline_fenced_and_indented_code_remain_literal() {
+        let markdown = "`:pushpin:`\n\n```text\n:rocket:\n```\n\n    :pushpin:\n";
+        assert_eq!(
+            expanded_visible_text(markdown),
+            ":pushpin::rocket:\n:pushpin:\n"
+        );
+    }
+
+    #[test]
+    fn image_alt_text_and_url_remain_literal() {
+        let markdown = "![:pushpin:](https://e/:rocket:.png)";
+        assert_eq!(expanded_visible_text(markdown), ":pushpin:");
     }
 }

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -100,6 +100,14 @@ egui_commonmark_extended = { features = ["svg", "svg_text", ...] }
 
 ---
 
+### Emoji shortcode expansion must preserve raw source identity
+**Context:** Issue #38 — render recognized GitHub shortcodes such as `:pushpin:` as emoji glyphs.
+**Problem:** Replacing shortcodes in the whole Markdown string changes byte offsets and can mutate code, links, image syntax, and heading identity before pulldown-cmark parses them. Replacing text without retaining raw spelling also breaks search ranges and duplicate-heading keys because `:pushpin:` is 9 source bytes while `📌` is 4 UTF-8 bytes.
+**Fix:** Expand only eligible `Event::Text` segments inside the renderer. Each scanner segment carries rendered text, raw spelling, and its absolute original source range. Advance the cursor by raw bytes. Keep replacement segments indivisible for painting: any search-range overlap highlights the whole glyph, with Active taking precedence. Feed the rendered glyph to `current_heading_rich_texts`, but feed the raw shortcode to `current_heading_text`. Skip image alt text and code blocks; route `Event::Code` through a separate literal-only highlight path so inline code keeps both source text and search highlights. Destinations, URLs, and malformed/unknown candidates remain literal.
+**Files:** `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`, `src/main.rs`, `docs/devlog/045-emoji-shortcodes.md`
+
+---
+
 ## egui
 
 ### CommonMarkCache must persist across frames
@@ -744,6 +752,12 @@ Belt-and-suspenders: keep `cargo publish --allow-dirty` in `scripts/publish-crat
 **Fix:** For new versions, prepend a `## [X.Y.Z] - YYYY-MM-DD` section manually using the existing entry style (rich prose with PR refs, root-cause + fix structure). git-cliff can be used as a *starting point* (`git-cliff --tag vX.Y.Z` to stdout) but the output requires heavy editing and shouldn't overwrite the file.
 **Recovery:** `git checkout CHANGELOG.md` if you accidentally regenerated.
 **Files:** `CHANGELOG.md`, `.claude/rules/release-workflow.md` (rule could be tightened with a "git-cliff for inspiration only" note).
+
+### Renderer transformations need borrowed unchanged fast paths
+**Context:** GitHub emoji shortcode expansion originally built a `Vec<EmojiTextSegment>` plus owned raw/rendered `String` values for every eligible `Event::Text`, then built another owned highlight vector.
+**Problem:** Most text events contain no recognized shortcode, so paint-time allocation churn paid transformation costs for unchanged content.
+**Fix:** Use direct visitor callbacks. Plain/raw slices borrow parser input, recognized emoji borrow static `Emoji::as_str()` values, and highlight splitting emits borrowed slices directly. Capture active-match Y during emission, then mutate cache only after immutable search-range borrows end. Tests collect owned snapshots only at the test boundary and use pointer identity to prove no-colon and unknown-only paths borrow original input.
+**Files:** `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`
 
 ---
 

--- a/docs/devlog/045-emoji-shortcodes.md
+++ b/docs/devlog/045-emoji-shortcodes.md
@@ -1,0 +1,55 @@
+# Feature 045: GitHub emoji shortcode rendering
+
+**Status:** Complete
+**Branch:** `fix/38-emoji-shortcodes`
+**Date:** 2026-07-12
+**Issue:** #38
+
+## Summary
+
+Recognized GitHub/gemoji shortcodes in visible Markdown text now render as Unicode emoji. The renderer expands `Event::Text` only, after pulldown-cmark has parsed the document, so Markdown syntax and source offsets remain authoritative.
+
+## Scope
+
+- Expands recognized ordinary text and link-label shortcodes such as `:pushpin:`.
+- Leaves inline code, fenced code, image alt text, destinations, URLs, unknown names, and malformed candidates literal.
+- Preserves raw source byte ranges for search highlighting and raw heading identity for outline navigation.
+- Adds the publishable `emojis` 0.9.0 dependency and bumps the vendored fork workspace from 0.24.0 to 0.25.0.
+
+## Architecture
+
+The UTF-8-safe scanner visits borrowed segments containing rendered text, raw spelling, absolute original source range, and replacement identity. Unchanged slices borrow parser input; recognized replacements borrow static `Emoji::as_str()` values. Its cursor advances through raw event bytes. A `:pushpin:` replacement therefore renders `📌` while retaining its original nine-byte source range.
+
+Plain segments continue through borrowed, fine-grained search splitting without intermediate vectors or strings. Replacement segments are indivisible: any source overlap highlights the whole glyph, Active wins over Match, and active-match Y is captured during direct emission then written after immutable cache borrows end. Heading rendering receives the glyph, while heading identity receives raw shortcode spelling.
+
+This keeps the implementation in the renderer's text-event boundary rather than preprocessing the whole document, which would alter Markdown parsing, code content, links, and byte offsets.
+
+## Dependency And Publishing Findings
+
+- `emojis` 0.9.0 provides `get_by_shortcode(&str)` and `Emoji::as_str()`.
+- Registry metadata declares Rust 1.66 and exact license expression `(MIT OR Apache-2.0) AND Unicode-3.0`; renderer workspace requires Rust 1.76, so MSRV is compatible.
+- Root and vendored lockfiles contain `emojis` 0.9.0 and renderer packages at 0.25.0.
+- `emojis` bundles gemoji lookup data under Unicode-3.0. Its `LICENSE-UNICODE` permission condition requires copyright and permission notice with copies or associated documentation. `THIRD_PARTY_NOTICES` therefore carries full notice; release archives and package manifests install it beside project license material.
+- Vendored renderer crate package includes `THIRD_PARTY_NOTICES`, so crates.io source distribution retains notice for dependency-derived lookup behavior.
+
+## Testing
+
+TDD RED was captured before implementation: renderer tests initially failed to compile because scanner, eligibility, and overlap helpers did not exist. Review-fix RED then drove production `Event::Code` and failed with `left: "📌", right: ":pushpin:"`; GREEN routes inline code through literal-only range highlighting. Allocation-review RED failed because borrowed visitor APIs did not exist; GREEN adds pointer-identity checks for no-colon and unknown-only unchanged paths plus a `hello world :rocket:` query-boundary regression. Production-boundary tests also verify heading display accumulates emoji while raw identity retains shortcode spelling, and duplicate heading keys remain raw/source-authoritative. Broader GREEN coverage includes scanner/range behavior, UTF-8 boundaries, adjacent and unknown candidates, search precedence, ordinary/link/fenced/indented-code/image contexts, raw app search ranges, and literal Unicode search.
+
+Validation run from repository root or explicit manifests:
+
+- `cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --lib --locked`
+- `cargo test --manifest-path Cargo.toml --locked` — 34 passed
+- `cargo check --manifest-path Cargo.toml --locked`
+- `cargo clippy --manifest-path Cargo.toml --locked --all-targets`
+- `cargo clippy --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --lib --tests --locked`
+- locked root and vendored `cargo metadata`
+- `scripts/check-fork-publishable.sh`
+- root and renderer `cargo package --no-verify --list` notice checks
+- AUR `.SRCINFO`, shell syntax, release/Snap/Flatpak YAML parsing, `rustfmt`, and `git diff --check`
+
+Known baseline warning: vendored `cargo check --workspace --all-targets` still fails because examples import upstream crate name `egui_commonmark` rather than renamed package `egui_commonmark_extended`; relevant library/tests and root targets pass. Full renderer package verification also cannot resolve fresh unpublished `egui_commonmark_backend_extended` 0.25.0 from crates.io; publishability check confirms all 0.25.0 fork crates are fresh and ready for ordered publication.
+
+## Coding Style And Technique Rationale
+
+A small explicit scanner was chosen over regex replacement because raw-byte cursor movement and absolute ranges are part of the contract. Segment metadata keeps rendered and source identities separate at one boundary. Existing renderer paths remain intact for plain text, minimizing regression surface and avoiding unrelated parser or app refactors.

--- a/flatpak/cargo-sources.json
+++ b/flatpak/cargo-sources.json
@@ -2108,6 +2108,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/emojis/emojis-0.9.0.crate",
+        "sha256": "0b1514ced566c94991ed9563258ecf61e311fd773bf0a3f20606830386bf66e3",
+        "dest": "cargo/vendor/emojis-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b1514ced566c94991ed9563258ecf61e311fd773bf0a3f20606830386bf66e3\", \"files\": {}}",
+        "dest": "cargo/vendor/emojis-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ena/ena-0.14.4.crate",
         "sha256": "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1",
         "dest": "cargo/vendor/ena-0.14.4"

--- a/flatpak/io.github.aydiler.md-viewer.yaml
+++ b/flatpak/io.github.aydiler.md-viewer.yaml
@@ -49,6 +49,9 @@ modules:
       - cargo --offline build --release --verbose
       # Install binary
       - install -Dm755 target/release/md-viewer /app/bin/md-viewer
+      # Install license and third-party attribution notices
+      - install -Dm644 LICENSE /app/share/licenses/md-viewer/LICENSE
+      - install -Dm644 THIRD_PARTY_NOTICES /app/share/licenses/md-viewer/THIRD_PARTY_NOTICES
       # Install desktop file under the new app-id name
       - install -Dm644 data/md-viewer.desktop /app/share/applications/io.github.aydiler.md-viewer.desktop
       # Rewrite the Icon= line to reference our app-id icon

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # md-viewer installer: downloads the latest prebuilt binary for your platform,
 # verifies its SHA256, and installs to ~/.local/bin (override with INSTALL_DIR).
+# Bundled third-party notices are installed under the matching prefix.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/aydiler/md-viewer/main/scripts/install.sh | sh
@@ -59,7 +60,7 @@ case "$OS" in
 esac
 
 # --- check required tools ----------------------------------------------------
-for tool in curl tar; do
+for tool in curl tar install; do
     command -v "$tool" >/dev/null 2>&1 || err "$tool is required but not installed"
 done
 
@@ -88,7 +89,15 @@ BASE_URL="https://github.com/$REPO/releases/download/$TAG"
 
 # --- download into temp ------------------------------------------------------
 TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+STAGED_BINARY=""
+STAGED_NOTICE=""
+cleanup() {
+    rm -rf "$TMPDIR"
+    [ -z "$STAGED_BINARY" ] || rm -f "$STAGED_BINARY"
+    [ -z "$STAGED_NOTICE" ] || rm -f "$STAGED_NOTICE"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
 
 info "Downloading $ASSET..."
 curl -fsSL -o "$TMPDIR/$ASSET" "$BASE_URL/$ASSET"
@@ -99,11 +108,31 @@ info "Verifying checksum..."
     || err "SHA256 checksum verification failed"
 
 # --- install -----------------------------------------------------------------
+# Derive the data prefix from the binary directory so custom INSTALL_DIR values
+# keep their license material in the same installation prefix.
+case "$INSTALL_DIR" in
+    */bin) INSTALL_PREFIX="${INSTALL_DIR%/bin}" ;;
+    *) INSTALL_PREFIX="${INSTALL_DIR%/}" ;;
+esac
+NOTICE_DIR="$INSTALL_PREFIX/share/licenses/md-viewer"
+
 info "Installing to $INSTALL_DIR..."
-mkdir -p "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR" "$NOTICE_DIR"
 tar -xzf "$TMPDIR/$ASSET" -C "$TMPDIR"
-mv "$TMPDIR/md-viewer" "$INSTALL_DIR/md-viewer"
-chmod +x "$INSTALL_DIR/md-viewer"
+[ -f "$TMPDIR/md-viewer" ] || err "release archive is missing md-viewer"
+[ -f "$TMPDIR/THIRD_PARTY_NOTICES" ] \
+    || err "release archive is missing THIRD_PARTY_NOTICES"
+
+# Stage inside each destination directory, then rename atomically over old files.
+STAGED_BINARY="$INSTALL_DIR/.md-viewer.new.$$"
+STAGED_NOTICE="$NOTICE_DIR/.THIRD_PARTY_NOTICES.new.$$"
+rm -f "$STAGED_BINARY" "$STAGED_NOTICE"
+install -m 0755 "$TMPDIR/md-viewer" "$STAGED_BINARY"
+install -m 0644 "$TMPDIR/THIRD_PARTY_NOTICES" "$STAGED_NOTICE"
+mv -f "$STAGED_BINARY" "$INSTALL_DIR/md-viewer"
+STAGED_BINARY=""
+mv -f "$STAGED_NOTICE" "$NOTICE_DIR/THIRD_PARTY_NOTICES"
+STAGED_NOTICE=""
 
 # Desktop integration (Linux only)
 if [ "$OS" = "Linux" ]; then

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,3 +91,5 @@ parts:
       sed -i '/egui-mcp-bridge/d' Cargo.toml
       sed -i 's/mcp = \["dep:egui-mcp-bridge"\]/mcp = []/' Cargo.toml
       craftctl default
+      install -Dm644 LICENSE "$CRAFT_PART_INSTALL/usr/share/doc/md-viewer/LICENSE"
+      install -Dm644 THIRD_PARTY_NOTICES "$CRAFT_PART_INSTALL/usr/share/doc/md-viewer/THIRD_PARTY_NOTICES"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4686,6 +4686,60 @@ mod tests {
     }
 
     #[test]
+    fn shortcode_search_range_uses_raw_source_bytes() {
+        let content = "before :pushpin: after";
+        let matches = find_matches(content, ":pushpin:");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].byte_start, 7);
+        assert_eq!(matches[0].byte_end, 16);
+        assert_eq!(
+            &content[matches[0].byte_start..matches[0].byte_end],
+            ":pushpin:"
+        );
+    }
+
+    #[test]
+    fn rendered_emoji_does_not_match_shortcode_only_source() {
+        assert!(find_matches("before :pushpin: after", "📌").is_empty());
+    }
+
+    #[test]
+    fn literal_unicode_emoji_still_matches_raw_source() {
+        let matches = find_matches("before 📌 after", "📌");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].byte_start, 7);
+        assert_eq!(matches[0].byte_end, 11);
+    }
+
+    #[test]
+    fn shortcode_heading_parser_keeps_raw_identity_and_duplicate_index() {
+        let parsed = parse_headers("# Doc\n\n## Pin :pushpin:\n\n## Pin :pushpin:\n");
+        assert_eq!(parsed.outline_headers.len(), 3);
+        assert_eq!(parsed.outline_headers[1].title, "Pin :pushpin:");
+        assert_eq!(parsed.outline_headers[1].normalized_title, "pin :pushpin:");
+        assert_eq!(parsed.outline_headers[1].nth_with_same_text, 0);
+        assert_eq!(parsed.outline_headers[2].normalized_title, "pin :pushpin:");
+        assert_eq!(parsed.outline_headers[2].nth_with_same_text, 1);
+        assert_eq!(
+            header_position_key(
+                &parsed.outline_headers[2].normalized_title,
+                parsed.outline_headers[2].nth_with_same_text,
+            ),
+            "pin :pushpin:#1"
+        );
+    }
+
+    #[test]
+    fn unknown_shortcode_heading_stays_raw() {
+        let parsed = parse_headers("# Doc\n\n## Pin :not_a_gemoji:\n");
+        assert_eq!(parsed.outline_headers[1].title, "Pin :not_a_gemoji:");
+        assert_eq!(
+            parsed.outline_headers[1].normalized_title,
+            "pin :not_a_gemoji:"
+        );
+    }
+
+    #[test]
     fn keyboard_scroll_target_moves_by_line_step() {
         assert_eq!(
             keyboard_scroll_target(100.0, 500.0, 2_000.0, KeyboardScrollAction::LineDown),


### PR DESCRIPTION
## Summary
- expand recognized GitHub emoji shortcodes in rendered Markdown while preserving source-byte ranges for search highlights and heading identity
- keep inline/fenced code, image alt text, URLs, destinations, malformed tokens, and unknown shortcodes literal
- add dependency notices and carry them through Cargo packages, release archives, installers, AUR, Snap, and Flatpak

Fixes aydiler/md-viewer#38

## Test plan
- [x] `cargo test --locked` (34 passed)
- [x] `cargo test -p egui_commonmark_extended --lib --locked` (19 passed)
- [x] locked checks and clippy
- [x] Cargo package contains `THIRD_PARTY_NOTICES` and excludes `docs/superpowers`
- [x] installer success, staged-copy failure preservation, and uninstall smoke tests
- [x] `git diff --check`

Independent verification was PARTIAL only because `flatpak-builder-lint`, `yamllint`, `shellcheck`, `snapcraft`, `reuse`, `cargo-deny`, and a full Flatpak build were unavailable. All runnable deterministic gates passed.