### PR TITLE
fix(lists): centre list markers on the item text's line box

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/lib.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/lib.rs
@@ -556,13 +556,21 @@ impl List {
         if let Some(item) = self.items.last_mut() {
             ui.label(" ".repeat((len - 1) * options.indentation_spaces));
 
+            // Match the marker box to the item text's line-height so the marker
+            // bottom-aligns with (and vertically centres on) the text.
+            let body_h = ui.text_style_height(&egui::TextStyle::Body);
+            let row_height = options
+                .typography
+                .resolve_line_height(body_h)
+                .unwrap_or(body_h);
+
             if let Some(number) = &mut item.current_number {
-                number_point(ui, &number.to_string());
+                number_point(ui, &number.to_string(), row_height);
                 *number += 1;
             } else if len > 1 {
-                bullet_point_hollow(ui);
+                bullet_point_hollow(ui, row_height);
             } else {
-                bullet_point(ui);
+                bullet_point(ui, row_height);
             }
         } else {
             unreachable!();

--- a/crates/egui_commonmark/egui_commonmark_backend/src/elements.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/elements.rs
@@ -53,43 +53,60 @@ pub fn newline(ui: &mut Ui) {
     ui.label("\n");
 }
 
-pub fn bullet_point(ui: &mut Ui) {
+pub fn bullet_point(ui: &mut Ui, row_height: f32) {
+    // The list row is `Align::BOTTOM` and as tall as the item text, which carries
+    // the 1.5× accessibility line-height. Size the marker box to that same
+    // row_height so it bottom-aligns identically to the text; keep the dot radius
+    // tied to the raw glyph height so the marker size is unchanged. Without this,
+    // the marker box was only the raw font height and its centre sat above the
+    // text's optical centre (marker high, text low).
+    let raw = height_body(ui);
     let (rect, _) = ui.allocate_exact_size(
-        egui::vec2(width_body_space(ui) * 4.0, height_body(ui)),
+        egui::vec2(width_body_space(ui) * 4.0, row_height.max(raw)),
         Sense::hover(),
     );
     ui.painter().circle_filled(
-        rect.center(),
-        rect.height() / 6.0,
+        marker_center(rect, raw),
+        raw / 6.0,
         ui.visuals().strong_text_color(),
     );
 }
 
-pub fn bullet_point_hollow(ui: &mut Ui) {
+pub fn bullet_point_hollow(ui: &mut Ui, row_height: f32) {
+    let raw = height_body(ui);
     let (rect, _) = ui.allocate_exact_size(
-        egui::vec2(width_body_space(ui) * 4.0, height_body(ui)),
+        egui::vec2(width_body_space(ui) * 4.0, row_height.max(raw)),
         Sense::hover(),
     );
     ui.painter().circle(
-        rect.center(),
-        rect.height() / 6.0,
+        marker_center(rect, raw),
+        raw / 6.0,
         egui::Color32::TRANSPARENT,
         egui::Stroke::new(0.6, ui.visuals().strong_text_color()),
     );
 }
 
-pub fn number_point(ui: &mut Ui, number: &str) {
+pub fn number_point(ui: &mut Ui, number: &str, row_height: f32) {
+    let raw = height_body(ui);
     let (rect, _) = ui.allocate_exact_size(
-        egui::vec2(width_body_space(ui) * 4.0, height_body(ui)),
+        egui::vec2(width_body_space(ui) * 4.0, row_height.max(raw)),
         Sense::hover(),
     );
     ui.painter().text(
-        rect.right_center(),
+        egui::pos2(rect.right(), marker_center(rect, raw).y),
         egui::Align2::RIGHT_CENTER,
         format!("{number}."),
         TextStyle::Body.resolve(ui.style()),
         ui.visuals().strong_text_color(),
     );
+}
+
+/// Vertical centre for a list marker inside a `row_height`-tall, bottom-aligned box.
+/// egui lays a `line_height`-boosted galley with the glyph near the bottom of the
+/// line box (extra leading above), so the text's optical centre is one raw
+/// half-height up from the row bottom — match the marker to that, not the box centre.
+fn marker_center(rect: egui::Rect, raw: f32) -> egui::Pos2 {
+    egui::pos2(rect.center().x, rect.bottom() - raw / 2.0)
 }
 
 #[inline]

--- a/crates/egui_commonmark/egui_commonmark_macros/src/generator.rs
+++ b/crates/egui_commonmark/egui_commonmark_macros/src/generator.rs
@@ -108,14 +108,16 @@ impl List {
             let spaces = " ".repeat((len - 1) * options.indentation_spaces);
             stream.extend(quote!( ui.label(#spaces); ));
 
+            // The compile-time macro path has no typography config; pass the raw
+            // body height so marker layout is unchanged from the runtime default.
             if let Some(number) = &mut item.current_number {
                 let num = number.to_string();
-                stream.extend(quote!( egui_commonmark_backend_extended::number_point(ui, #num);));
+                stream.extend(quote!( egui_commonmark_backend_extended::number_point(ui, #num, ui.text_style_height(&egui::TextStyle::Body));));
                 *number += 1;
             } else if len > 1 {
-                stream.extend(quote!( egui_commonmark_backend_extended::bullet_point_hollow(ui);));
+                stream.extend(quote!( egui_commonmark_backend_extended::bullet_point_hollow(ui, ui.text_style_height(&egui::TextStyle::Body));));
             } else {
-                stream.extend(quote!( egui_commonmark_backend_extended::bullet_point(ui);));
+                stream.extend(quote!( egui_commonmark_backend_extended::bullet_point(ui, ui.text_style_height(&egui::TextStyle::Body));));
             }
         } else {
             unreachable!();

--- a/docs/devlog/046-list-marker-alignment.md
+++ b/docs/devlog/046-list-marker-alignment.md
@@ -1,0 +1,70 @@
+# Fix: List marker vertical alignment
+
+**Status:** ✅ Complete
+**Branch:** `fix/list-marker-alignment`
+**Date:** 2026-07-15
+**Lines Changed:** ~+35 / -12 in the vendored renderer (`elements.rs`, `lib.rs`, `generator.rs`)
+
+## Summary
+
+List markers (the `•` bullet, the hollow `◦` nested bullet, and the `N.` number)
+sat visibly **above** the optical centre of their list-item text — the marker
+looked high, the text looked low. This affected every bullet and ordered list.
+
+## Root Cause
+
+The item text carries the 1.5× accessibility line-height (WCAG 2.1 SC 1.4.12,
+applied via `TextFormat.line_height`), so its galley row is 1.5× the raw font
+height. The list row is laid out with `Layout::left_to_right(Align::BOTTOM)`, so
+it is as tall as that 1.5× text and everything bottom-aligns to the row.
+
+`bullet_point` / `bullet_point_hollow` / `number_point` (in
+`egui_commonmark_backend/src/elements.rs`) sized their marker box to only the
+**raw** body-font height (`height_body`) and drew the marker at that small box's
+centre. Bottom-aligned, a raw-height box centres its marker well above where the
+text — sitting near the bottom of its taller line box — actually renders.
+
+## Fix
+
+Pass the resolved body line-height into the three marker functions and:
+
+1. Size the marker box to that `row_height` (`row_height.max(raw)`), so it
+   bottom-aligns identically to the text.
+2. Place the marker at the text's optical centre — `rect.bottom() - raw/2.0`
+   via a shared `marker_center` helper — instead of the box centre.
+3. Keep the dot radius / number font tied to the **raw** glyph height, so marker
+   size is unchanged; only its vertical position moves.
+
+`List::start_item` (in `egui_commonmark/src/lib.rs`) computes the line-height
+from `options.typography.resolve_line_height(body_h)` (falling back to the raw
+height when typography is off) and passes it through.
+
+The compile-time macro path (`egui_commonmark_macros/src/generator.rs`) has no
+typography config, so it passes `ui.text_style_height(&egui::TextStyle::Body)`
+(the raw height) — marker layout there is unchanged from before.
+
+## Architecture
+
+### Modified Functions
+
+| Function | Change |
+|----------|--------|
+| `bullet_point(ui, row_height)` | new `row_height` param; box sized to it; marker at `marker_center` |
+| `bullet_point_hollow(ui, row_height)` | same |
+| `number_point(ui, number, row_height)` | same; number drawn at `marker_center().y`, right-aligned |
+| `marker_center(rect, raw)` | new helper: optical centre = `rect.bottom() - raw/2.0` |
+| `List::start_item` | resolves line-height from typography and threads it in |
+
+## Testing Notes
+
+- Verified visually on Xvfb with filled bullets, hollow nested bullets, ordered
+  numbers, and nested ordered numbers — all markers now centre on the text.
+- Confirmed font-independent: correct with both egui's bundled Ubuntu-Light body
+  font and a Noto Sans body.
+- `cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --test wrapping` — 12 passed.
+
+## Future Improvements
+
+- `marker_center`'s `rect.bottom() - raw/2.0` assumes egui lays the boosted
+  line-height galley with the glyph near the bottom of the line box. If a future
+  egui changes that leading distribution, revisit this offset.


### PR DESCRIPTION
## Summary

List markers sat visibly **above** the optical centre of their list-item text —
the marker looked high, the text looked low — on every bullet and ordered list.
This centres the `•` bullet, the hollow `◦` nested bullet, and the `N.` number
on the text.

## Before / After

| | Marker position |
|---|---|
| **Before** | dot/number centred near the text's cap-top |
| **After** | dot centred on the text x-height; number shares the text baseline |

## Root cause

List-item text carries the 1.5× accessibility line-height (WCAG 2.1 SC 1.4.12,
via `TextFormat.line_height`), so its galley row is 1.5× the raw font height. The
list row is `Layout::left_to_right(Align::BOTTOM)`, so it is as tall as that text
and everything bottom-aligns.

`bullet_point` / `bullet_point_hollow` / `number_point` sized their marker box to
only the **raw** body-font height (`height_body`) and drew the marker at that
small box's centre. Bottom-aligned, a raw-height box centres its marker well
above where the taller text actually renders.

## Fix

Thread the resolved body line-height into the three marker functions and:

1. Size the marker box to that `row_height` so it bottom-aligns like the text.
2. Draw the marker at the text's optical centre (`rect.bottom() - raw/2`) via a
   shared `marker_center` helper, not the box centre.
3. Keep dot radius / number font tied to the raw glyph height, so marker size is
   unchanged — only its vertical position moves.

`List::start_item` resolves the line-height from
`options.typography.resolve_line_height(..)` (falling back to raw height when
typography is off) and passes it through. The compile-time macro path has no
typography config, so it passes the raw height and its layout is unchanged.

## Testing

- Verified on Xvfb: filled bullets, hollow nested bullets, ordered numbers, and
  nested ordered numbers all centre on their text.
- Font-independent: correct with egui's bundled Ubuntu-Light body font **and** a
  Noto Sans body.
- `cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --test wrapping` — **12 passed**.
- `cargo clippy` — no new warnings (pre-existing vendored warnings only).

Only the vendored renderer changes; no `src/main.rs` behaviour change.
