### PR TITLE
fix(#46): align inline code with body text baseline and size

### DIFF
--- a/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
@@ -267,7 +267,13 @@ impl Style {
         }
 
         if self.code {
-            rich_text = rich_text.code();
+            // `RichText::code()` sets the Monospace text style, which carries its
+            // own (smaller, 14px) size — so inline code rendered smaller than the
+            // surrounding 16px body text and sat raised off the shared baseline
+            // (issue #46). Pin the size to the current context (body, or the
+            // heading size when code is inside a heading) so code keeps the
+            // monospace family + code background but aligns with adjacent text.
+            rich_text = rich_text.code().size(selected_font_size);
         }
 
         rich_text

--- a/docs/devlog/048-inline-code-baseline.md
+++ b/docs/devlog/048-inline-code-baseline.md
@@ -1,0 +1,58 @@
+# Fix: Inline code baseline/size alignment (#46)
+
+**Status:** ✅ Complete
+**Branch:** `fix/font-fallback`
+**Date:** 2026-07-15
+**Lines Changed:** +7 / -1 in `egui_commonmark_backend/src/misc.rs`
+
+## Summary
+
+Issue #46: inline `` `code` `` rendered **smaller than and raised above** the
+surrounding body text — it did not sit on the shared baseline.
+
+## Root cause
+
+`Style::to_richtext_internal` styled inline code with egui's `RichText::code()`,
+which sets the **Monospace text style**. That text style carries its own size —
+`FontId::monospace(14.0)` in this app (`src/main.rs`) — while body text is
+`FontId::proportional(16.0)`. So inline code came out at **14px** against **16px**
+body text. Both fragments also carry the 1.5× accessibility line-height, and egui
+positions the smaller glyph within that shared line box such that it sits raised,
+not baseline-aligned.
+
+## Fix
+
+Pin inline code to the current context size after `.code()`:
+
+```rust
+if self.code {
+    rich_text = rich_text.code().size(selected_font_size);
+}
+```
+
+`selected_font_size` is the body size (16px) for normal text, and the heading
+size when inline code appears inside a heading. `RichText`'s explicit `.size()`
+overrides the Monospace text style's size while keeping the monospace **family**
+and the code background, so code now matches the adjacent text size and baseline.
+
+## Scope
+
+- Only **inline** code (`Event::Code`) goes through this path. Fenced **code
+  blocks** render via the separate syntect `LayoutJob` path (`elements.rs` /
+  `misc.rs` code-block rendering) and are unaffected — verified pixel-identical
+  (ImageMagick AE = 0) before/after on a code-block repro.
+
+## Testing
+
+- Xvfb before/after: all inline code spans (plain, mid-sentence, inside a
+  bold/italic line) now align on the body baseline and match body size.
+- Code-block region pixel-diff = 0 (no regression).
+
+## Not fixed here: #45 (`sh` code block "different font")
+
+Investigated together. #45 is **not a font bug** — in a ```` ```sh ```` block,
+syntect colors the first word of each line as a shell *command* (dim) and the
+rest as *arguments* (bright). The letterforms are identical monospace; the user
+saw the color/brightness difference. A plain ```` ``` ```` fence (no language)
+renders uniformly. Left as a separate discussion on the issue; changing it would
+mean overriding syntect theme colors for all code blocks.


### PR DESCRIPTION
## Summary

Fixes #46 — inline `` `code` `` rendered **smaller than and raised above** the surrounding body text instead of sitting on the shared baseline.

## Before / After

| | |
|---|---|
| **Before** | inline code = 14px monospace, sits raised off the baseline |
| **After** | inline code matches the 16px body size and sits on the baseline |

## Root cause

`Style::to_richtext_internal` styles inline code with egui's `RichText::code()`, which applies the **Monospace text style**. That text style carries its own size — `FontId::monospace(14.0)` in this app — while body text is `FontId::proportional(16.0)`. So inline code came out at 14px against 16px body. With the 1.5× accessibility line-height on both, egui positions the smaller glyph raised within the shared line box.

## Fix

```rust
if self.code {
    rich_text = rich_text.code().size(selected_font_size);
}
```

`RichText`'s explicit `.size()` overrides the Monospace text style's size while keeping the monospace **family** and the code background. `selected_font_size` is the body size normally, and the heading size when inline code appears inside a heading.

## Scope / testing

- Only **inline** code goes through this path. Fenced **code blocks** render via the separate syntect `LayoutJob` path and are unaffected — verified pixel-identical (ImageMagick AE = 0) before/after on a code-block repro.
- `cargo test … --test wrapping` — 12 passed.
- Xvfb before/after confirms all inline-code spans align on the body baseline.

## Note on #45 (investigated together, not fixed here)

#45 ("`sh` code block renders in another font") is **not a font bug** — in a ```` ```sh ```` block, syntect colors the first word of each line as a shell *command* (dim) and the rest as *arguments* (bright); the letterforms are identical monospace. A plain ```` ``` ```` fence renders uniformly. I'll add detail on that issue.

Closes #46.
