### PR TITLE
fix(#47): narrow tables hug their columns instead of stretching full width

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -1230,7 +1230,13 @@ impl CommonMarkViewerInternal {
                                 .striped(true)
                                 .resizable(true)
                                 .vscroll(false)
-                                .auto_shrink([false, true])
+                                // Shrink horizontally to the columns' content so a
+                                // table narrower than the panel hugs its columns
+                                // instead of stretching the bordered frame full width
+                                // with an empty gap after the last column (#47). The
+                                // outer ScrollArea still bounds wide tables at
+                                // max_width and provides horizontal scroll.
+                                .auto_shrink([true, true])
                                 .min_scrolled_height(0.0)
                                 .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                                 .columns(
@@ -1941,7 +1947,9 @@ impl CommonMarkViewerInternal {
                             .striped(true)
                             .resizable(true)
                             .vscroll(false)
-                            .auto_shrink([false, true])
+                            // Hug columns when narrower than the panel (#47); the
+                            // outer ScrollArea still handles wide-table overflow.
+                            .auto_shrink([true, true])
                             .min_scrolled_height(0.0)
                             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                             .columns(

--- a/docs/devlog/049-table-hug-content-width.md
+++ b/docs/devlog/049-table-hug-content-width.md
@@ -1,0 +1,53 @@
+# Fix: Narrow tables hug their columns (#47)
+
+**Status:** ✅ Complete
+**Branch:** `fix/table-width`
+**Date:** 2026-07-15
+**Lines Changed:** +2 / -2 in `egui_commonmark/src/parsers/pulldown.rs` (plus comments)
+
+## Summary
+
+Issue #47: a table **narrower** than the content area rendered its bordered
+frame stretched to full width, with the columns bunched on the left and an empty
+"white column" gap after the last column. Wide tables (with a horizontal
+scrollbar) were fine.
+
+## Root cause
+
+Both the markdown and HTML table renderers wrap `egui_extras::TableBuilder` in an
+outer `ScrollArea::horizontal()` (for wide-table scroll). The `TableBuilder`
+itself used `.auto_shrink([false, true])` — horizontal = `false` means "do not
+shrink horizontally," so the table (and its `Frame::group` border) expanded to
+fill the full `max_width` even when it only had a few narrow `Column::auto()`
+columns. The leftover width became the empty gap inside the border.
+
+## Fix
+
+Change the **TableBuilder**'s `auto_shrink` to `[true, true]` so the table hugs
+its columns' content width. The outer `ScrollArea::horizontal()` (unchanged,
+still `auto_shrink([false, true])` bounded at `max_width`) continues to bound
+wide tables and provide horizontal scroll.
+
+- Narrow/medium table → hugs its columns (no empty gap).
+- Wide table → content exceeds `max_width`; the ScrollArea bounds it and scrolls
+  (unchanged behavior).
+
+## Verification (Xvfb)
+
+- Normal width: small + medium tables now hug; wide table region **pixel-identical**
+  to before (ImageMagick AE = 0) → no wide-table regression.
+- Narrow window (640 px): small + medium hug within the panel; wide table is
+  bounded and scrollable; **no column clips without scroll**.
+- `cargo test … --test wrapping` — all table/list wrapping tests pass.
+
+## Why this is safe vs. the LESSONS warning
+
+`docs/LESSONS.md` ("TableBuilder columns clip on narrow window without outer
+ScrollArea::horizontal") required the **ScrollArea** to take `max_width` for
+wide-table scroll — that ScrollArea and its `auto_shrink([false, true])` are
+left untouched. Only the inner table's horizontal shrink changed, which controls
+whether the table fills or hugs *inside* that ScrollArea. The `Column::auto`
+width-caching concern from that lesson is a separate axis and is not touched.
+
+**Files:** `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`
+(`fn table`, `fn render_html_table`)


### PR DESCRIPTION
## Summary

Fixes #47 — a table **narrower** than the content area stretched its bordered frame to full width, leaving the columns bunched on the left with an empty "white column" gap after the last column. Wide tables (with a scrollbar) were fine.

## Before / After

| | Narrow / medium table |
|---|---|
| **Before** | frame stretches full width; big empty gap after last column |
| **After** | frame hugs the columns; compact |

Wide tables are **unchanged** (still bounded at `max_width` with horizontal scroll).

## Root cause

Both table renderers wrap `egui_extras::TableBuilder` in an outer `ScrollArea::horizontal()` for wide-table scroll. The `TableBuilder` used `.auto_shrink([false, true])` (horizontal = false = "don't shrink"), so the table and its `Frame::group` border filled the full `max_width` even with a few narrow `Column::auto()` columns — the leftover width became the empty gap.

## Fix

Change the **TableBuilder**'s `auto_shrink` to `[true, true]` so it hugs its columns' content width. The outer `ScrollArea::horizontal()` is untouched, so wide tables still bound at `max_width` and scroll.

## Verification (Xvfb)

- **Normal width:** small + medium tables hug; wide-table region **pixel-identical** to before (ImageMagick AE = 0) → no scroll regression.
- **Narrow window (640 px):** small + medium hug within the panel; wide table bounded + scrollable; **no column clips without scroll**.
- `cargo test … --test wrapping` — 12 passed.

Applies to both markdown and HTML tables. Does not touch the `ScrollArea` wrapper that `docs/LESSONS.md` requires for wide-table scroll.

Closes #47.
