### PR TITLE
fix(ci): snapcraft push-metadata → upload-metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
       # Push the store-listing description / summary embedded in the snap.
       # snapcore/action-publish above only ships the .snap artifact to a
       # channel; the Snap Store listing description is curated separately and
-      # won't pick up changes unless we explicitly push-metadata. --force
+      # won't pick up changes unless we explicitly upload-metadata. --force
       # overwrites any web-UI edits, treating snap/snapcraft.yaml in the repo
       # as source of truth.
       #
@@ -249,11 +249,17 @@ jobs:
       # .snap file's embedded yaml (which came from snap/snapcraft.yaml at
       # build time), so the freshly-built snap from steps.build already
       # carries the current description.
+      #
+      # `push-metadata` was renamed to `upload-metadata` (the whole `push`
+      # verb family became `upload`). v0.1.14's release used the old verb and
+      # this step failed with "no such command 'push-metadata'" — the snap
+      # itself still published fine (action-publish above does the upload),
+      # only this listing-metadata sync broke. See docs/LESSONS.md.
       - name: Push snap store listing metadata
         if: steps.check.outputs.proceed == 'true'
         run: |
           sudo snap install snapcraft --classic
-          snapcraft push-metadata "${SNAP_FILE}" --force
+          snapcraft upload-metadata "${SNAP_FILE}" --force
         env:
           SNAP_FILE: ${{ steps.build.outputs.snap }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -586,6 +586,17 @@ objdump -T target/release/md-viewer | grep -oE 'GLIBC_[0-9.]+' | sort -u | tail
 ```
 **Files:** `snap/snapcraft.yaml`, `.github/workflows/release.yml`
 
+### snapcraft renamed `push-metadata` → `upload-metadata` (the whole `push` verb family)
+**Context:** v0.1.14 release. The **Publish to Snap Store** job went red, but the snap itself published fine — `snapcore/action-publish@v1` logged `Revision 17 created for 'md-viewer' and released to 'stable'`. The failure was the *next* step, "Push snap store listing metadata", which runs `snapcraft push-metadata "${SNAP_FILE}" --force`:
+```
+Error: no such command 'push-metadata', maybe you meant 'upload-metadata'
+```
+**Root cause:** the step does `sudo snap install snapcraft --classic` (tracks *latest*), and newer snapcraft renamed the entire `push` verb family to `upload` (`push` → `upload`, `push-metadata` → `upload-metadata`). This worked at v0.1.13 (~5 weeks earlier) because the runner's snapcraft was older — **environmental drift**, not anything the release commit changed. It would now fail on every release.
+**Fix:** `snapcraft upload-metadata "${SNAP_FILE}" --force` — identical positional `<snap-file>` and `--force` flag, just the renamed verb.
+**Non-impact:** the snap upload is a *separate* step (`action-publish`) that already succeeded, so users got the new revision regardless; only the store-listing description sync (unchanged from prior releases anyway) was skipped. The overall run still shows red because of the one trailing step.
+**Guard for next time:** consider pinning `snap install snapcraft --classic --channel=8.x/stable` in this step so the verb surface can't drift out from under the release again.
+**Files:** `.github/workflows/release.yml` (Push snap store listing metadata step), `docs/devlog/050-snap-upload-metadata-verb.md`
+
 ### `to_ascii_lowercase` preserves byte offsets; `to_lowercase` doesn't
 **Context:** Implementing case-insensitive substring search (`find_matches`) that returns byte ranges into the original content.
 **Problem:** `str::to_lowercase` does Unicode case folding which can *change byte length* (e.g. `"İ".to_lowercase() == "i̇"` — adds a combining mark). Any match offsets computed against the folded string would point at the wrong bytes in the original.

--- a/docs/devlog/050-snap-upload-metadata-verb.md
+++ b/docs/devlog/050-snap-upload-metadata-verb.md
@@ -1,0 +1,57 @@
+# Fix: snapcraft `push-metadata` → `upload-metadata`
+
+**Status:** ✅ Complete
+**Branch:** `fix/snap-upload-metadata`
+**Date:** 2026-07-15
+**Files Changed:** `.github/workflows/release.yml` (1-line command + comment), `docs/LESSONS.md`
+
+## Summary
+
+The v0.1.14 release run's **Publish to Snap Store** job failed — but only on its
+last step, "Push snap store listing metadata". The actual snap upload succeeded:
+
+```
+Status: ready to release!
+Revision 17 created for 'md-viewer' and released to 'stable'
+```
+
+`snapcore/action-publish@v1` (the step that ships the `.snap` to the `stable`
+channel) ran fine. The follow-on step then ran:
+
+```
+snapcraft push-metadata "${SNAP_FILE}" --force
+# Error: no such command 'push-metadata', maybe you meant 'upload-metadata'
+```
+
+## Root cause
+
+Snapcraft renamed its entire `push` verb family to `upload`
+(`push` → `upload`, `push-metadata` → `upload-metadata`, …). The GitHub runner's
+`snapcraft` (installed fresh via `sudo snap install snapcraft --classic` in this
+step) auto-tracked a newer release than the one present at v0.1.13 (which
+published metadata successfully ~5 weeks earlier). So this was **environmental
+drift**, not a change introduced by the v0.1.14 release commit — and it would now
+fail on every future release.
+
+## Fix
+
+One-word verb change: `push-metadata` → `upload-metadata`. Same positional
+`<snap-file>` argument and same `--force` flag. Comment above the step updated to
+record the rename and the fact that the snap upload is independent of this step.
+
+## Impact / non-impact
+
+- **No user impact for v0.1.14** — the snap is live at revision 17 on `stable`.
+  Only the store *listing* metadata (summary/description from
+  `snap/snapcraft.yaml`) wasn't re-synced, and it was unchanged from prior
+  releases anyway.
+- The overall release run shows red because of this single trailing step, even
+  though crates.io, GitHub Release, AUR (`-git` + `-bin`), and the snap upload
+  all succeeded.
+
+## Future improvement
+
+`upload-metadata` could itself be renamed/removed in a later snapcraft major.
+Consider pinning the snapcraft channel used by this step (e.g.
+`snap install snapcraft --classic --channel=8.x/stable`) so the verb surface
+stays stable across releases instead of tracking latest.


### PR DESCRIPTION
## Problem

The **Publish to Snap Store** job failed on the v0.1.14 release run — but only on its trailing `Push snap store listing metadata` step:

```
Error: no such command 'push-metadata', maybe you meant 'upload-metadata'
```

The snap **upload itself succeeded** (`snapcore/action-publish@v1` → *Revision 17 created for 'md-viewer' and released to 'stable'*). So **v0.1.14 shipped fine to snap users** — only the store-listing description sync (unchanged from prior releases anyway) was skipped, and the overall run shows red because of this one step.

## Root cause

The step does `sudo snap install snapcraft --classic` (tracks *latest*). Newer snapcraft renamed the whole `push` verb family to `upload` (`push-metadata` → `upload-metadata`). This worked at v0.1.13 (~5 weeks earlier) with an older runner snapcraft — **environmental drift**, not a change from the release commit. Left as-is it fails on every future release.

## Fix

One-word verb rename: `snapcraft push-metadata` → `snapcraft upload-metadata` (same positional `<snap-file>` argument, same `--force` flag). Plus a comment + LESSONS.md entry + devlog 050 recording the rename and a suggestion to pin the snapcraft channel so the verb surface can't drift again.

CI-config + docs only; no Rust changes.