### PR TITLE
fix(snap): stage X11 dlopen libs, XKB data, and DRI path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to markdown-viewer will be documented in this file.
 
+## [0.1.15] - 2026-07-23
+
+### Bug Fixes
+
+- **Snap no longer crashes on X11 sessions (#55, diagnosed and fix verified by [@HartmutLeister](https://github.com/HartmutLeister)).** The strictly-confined snap aborted at startup on X11 (`Library libxkbcommon-x11.so could not be loaded`; Wayland was unaffected). Three gaps compounded, all on the X11-only code path: winit `dlopen`s its X11 stack at runtime so snapcraft's link-time dependency staging never included `libxkbcommon-x11.so.0` and the `libxcb-xkb`/`libX11` chain; XKB keymap data (`/usr/share/X11/xkb`) was absent from both the snap and the core22 base; and Mesa's loader searched its compiled-in absolute DRI path, which resolves to the empty base inside the mount namespace, so GLX context creation failed (`GLXBadFBConfig`) even though the drivers were staged. The snap now stages `libxkbcommon-x11-0`, `libx11-6`, `libx11-data`, and `xkb-data`, and sets `XKB_CONFIG_ROOT` and `LIBGL_DRIVERS_PATH` to the staged copies.
+
 ## [0.1.14] - 2026-07-15
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "md-viewer"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "clap",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-viewer"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 rust-version = "1.80"
 description = "Fast, lightweight markdown viewer for Linux with tabs, file explorer, and live reload"

--- a/docs/devlog/051-snap-x11-libs.md
+++ b/docs/devlog/051-snap-x11-libs.md
@@ -1,0 +1,99 @@
+# Fix: Snap crashes on X11 sessions (missing dlopen'd libs, XKB data, DRI path)
+
+**Status:** 🚧 In Progress
+**Branch:** `fix/snap-x11-libs`
+**Date:** 2026-07-23
+**Lines Changed:** +8 / -1 in `snap/snapcraft.yaml` (plus release version bumps)
+
+## Summary
+
+Issue #55 (reported and fully root-caused by @HartmutLeister): the strictly-confined
+snap aborts on startup on any **X11** session (`Library libxkbcommon-x11.so could not
+be loaded` → after that, `XKBNotFound` → after that, `GLXBadFBConfig`). Wayland
+sessions were unaffected, which is why no prior release caught it — all three
+failures live on the X11-only code path.
+
+Three independent gaps, all fixed in `snap/snapcraft.yaml`:
+
+1. **dlopen'd X11 libraries not staged.** winit's X11 backend loads
+   `libxkbcommon-x11.so.0` (and through it `libxcb-xkb1`/`libX11`/`libXau`/`libXdmcp`)
+   via `dlopen` at runtime instead of dynamic linking. snapcraft's automatic
+   dependency staging only follows link-time dependencies, so none of these were in
+   the snap. `stage-packages` gains `libxkbcommon-x11-0` + `libx11-6`.
+2. **XKB keymap data missing.** Neither the snap nor the core22 base contains
+   `/usr/share/X11/xkb`; winit panics `XKBNotFound` once the libraries exist.
+   `stage-packages` gains `xkb-data`, and `XKB_CONFIG_ROOT=$SNAP/usr/share/X11/xkb`
+   points xkbcommon at it. `libx11-data` is also staged to provide Compose files
+   (silences a cosmetic `couldn't find a Compose file for locale` warning).
+3. **Mesa DRI drivers unreachable.** The DRI drivers *are* staged (dep of libgl1),
+   but Mesa's loader searches its compiled-in absolute path
+   `/usr/lib/x86_64-linux-gnu/dri`, which inside the mount namespace is the (empty)
+   core22 base → GLX `BadConfig`. Fixed with
+   `LIBGL_DRIVERS_PATH=$SNAP/usr/lib/x86_64-linux-gnu/dri`.
+
+The exact combination was verified end-to-end by the reporter on Ubuntu 24.04/X11
+(copying matching libs + XKB data into `$SNAP_USER_DATA` inside the confinement via
+`snap run --shell`). The alternative — `extensions: [gnome]` — would also work but
+drags in the whole gnome-42-2204 content snap; the targeted staging keeps the snap
+lean (~7 MB compressed).
+
+## Features
+
+- [x] Stage `libxkbcommon-x11-0`, `libx11-6`, `libx11-data`, `xkb-data`
+- [x] Set `XKB_CONFIG_ROOT` and `LIBGL_DRIVERS_PATH` in app environment
+- [ ] Release v0.1.15 so the fixed snap revision ships
+- [ ] Verify shipped snap contents (unsquashfs of the store revision)
+- [ ] Confirm with reporter on real Ubuntu/X11 hardware, close #55
+
+## Key Discoveries
+
+### snapcraft only stages link-time dependencies — dlopen is invisible to it
+
+`stage-packages` dependency resolution walks the ELF `DT_NEEDED` graph of staged
+binaries. Libraries the app opens with `dlopen()` at runtime (winit does this for
+most of its X11 stack) are never discovered. Any dlopen'd library must be listed
+explicitly. This is the same class of problem for every winit/egui app packaged as
+a strict snap without a desktop extension.
+
+### Staged files ≠ reachable files: compiled-in absolute paths resolve against the base
+
+Mesa's DRI drivers were *in* the snap all along, at
+`$SNAP/usr/lib/x86_64-linux-gnu/dri/`. The loader still failed because it searches
+the absolute path baked in at Mesa build time, and inside the snap's mount
+namespace `/usr/lib/...` is the core22 base, not `$SNAP`. Anything with a
+compiled-in search path (GL drivers, XKB data) needs its env-var override
+(`LIBGL_DRIVERS_PATH`, `XKB_CONFIG_ROOT`) pointed into `$SNAP`.
+
+### Wayland-only testing hides the entire X11 dlopen chain
+
+All three failures sat on the X11-only path. Local dev (Wayland) and presumably
+every prior user report exercised Wayland. When packaging a toolkit that has
+per-display-server backends, a smoke test on *each* backend
+(`WAYLAND_DISPLAY= DISPLAY=:0`-style forcing) is the only way to catch this class.
+
+## Architecture
+
+No code changes. `snap/snapcraft.yaml` only:
+
+- `parts.md-viewer.stage-packages`: + `libxkbcommon-x11-0`, `libx11-6`,
+  `libx11-data`, `xkb-data`
+- `apps.md-viewer.environment`: + `XKB_CONFIG_ROOT`, `LIBGL_DRIVERS_PATH`
+
+## Testing Notes
+
+- Cannot build the snap locally (Arch host; `--destructive-mode` is banned per
+  LESSONS "Never snapcraft --destructive-mode"). Verification path:
+  1. CI `publish-snap` (LXD, core22) builds and publishes the revision
+  2. Download the published .snap from the store, `unsquashfs -l`: confirm
+     `libxkbcommon-x11.so.0`, `usr/share/X11/xkb/`, and the env vars in
+     `meta/snap.yaml`
+  3. Reporter confirms on their Ubuntu 24.04 X11 machine (exact repro env)
+- Residual risk: `LIBGL_DRIVERS_PATH` also applies on Wayland, pointing EGL at the
+  staged core22 Mesa drivers. Staged libGL + staged drivers are version-consistent
+  (same core22 archive), so this should be neutral; if a Wayland-snap regression
+  report appears, this is the first suspect.
+
+## Future Improvements
+
+- [ ] Consider a CI smoke test that boots the built snap under Xvfb in an Ubuntu
+      container (would have caught all three gaps before release)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: md-viewer
 base: core22
-version: '0.1.14'
+version: '0.1.15'
 summary: Fast, lightweight markdown viewer for Linux
 description: |
   A fast, lightweight markdown viewer for Linux built with Rust and egui.
@@ -59,6 +59,11 @@ apps:
       - gsettings
     environment:
       XDG_DATA_DIRS: $SNAP/usr/share:$XDG_DATA_DIRS
+      # xkbcommon and Mesa search compiled-in absolute paths, which inside the
+      # strict-confinement mount namespace resolve to the (empty) core22 base,
+      # not $SNAP — point both at the staged copies (#55).
+      XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
+      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/x86_64-linux-gnu/dri
 
 parts:
   md-viewer:
@@ -80,6 +85,12 @@ parts:
     stage-packages:
       - libxcb1
       - libxkbcommon0
+      # winit dlopens its X11 stack at runtime, so snapcraft's link-time
+      # dependency staging never picks these up (#55):
+      - libxkbcommon-x11-0
+      - libx11-6
+      - libx11-data
+      - xkb-data
       - libfontconfig1
       - libgtk-3-0
       - libglib2.0-0


### PR DESCRIPTION
Addresses #55 (not auto-closing — the fix only reaches users with the v0.1.15 snap revision; the issue will be closed once that is published).

## Problem

The strictly-confined snap aborts at startup on **X11** sessions (Wayland unaffected):

```
thread 'main' panicked at xkbcommon-dl-0.4.2/src/x11.rs:59:28:
Library libxkbcommon-x11.so could not be loaded.
```

@HartmutLeister root-caused all three layers and verified the exact fix combination on Ubuntu 24.04/X11 — see the issue for the full analysis:

1. **dlopen'd X11 libs not staged** — winit loads `libxkbcommon-x11.so.0` (+ `libxcb-xkb1`/`libX11`/`libXau`/`libXdmcp`) via `dlopen`, invisible to snapcraft's link-time dependency staging.
2. **XKB keymap data missing** — `/usr/share/X11/xkb` exists in neither the snap nor core22 → `XKBNotFound` panic.
3. **Mesa DRI drivers unreachable** — staged, but Mesa searches its compiled-in absolute path, which is the empty core22 base inside the mount namespace → `GLXBadFBConfig`.

## Fix

`snap/snapcraft.yaml` only:

- `stage-packages` += `libxkbcommon-x11-0`, `libx11-6`, `libx11-data`, `xkb-data`
- `environment` += `XKB_CONFIG_ROOT=$SNAP/usr/share/X11/xkb`, `LIBGL_DRIVERS_PATH=$SNAP/usr/lib/x86_64-linux-gnu/dri`

Chosen over `extensions: [gnome]`, which would fix the same gaps but drags in the whole gnome-42-2204 content snap.

Also bumps versions to 0.1.15 (Cargo.toml/lock, snapcraft.yaml, CHANGELOG) so the release tag can follow immediately. Devlog: `docs/devlog/051-snap-x11-libs.md`.

## Verification plan

- CI `publish-snap` (LXD/core22) builds the revision on the v0.1.15 tag
- unsquashfs the published snap: confirm the staged libs, XKB tree, and env vars in `meta/snap.yaml`
- Reporter confirms on real Ubuntu 24.04/X11 hardware, then close #55