### PR TITLE
fix: render linked SVG badges completely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,7 @@ dependencies = [
  "egui_extras",
  "emojis",
  "pulldown-cmark 0.13.0",
+ "resvg",
 ]
 
 [[package]]

--- a/crates/egui_commonmark/Cargo.lock
+++ b/crates/egui_commonmark/Cargo.lock
@@ -1169,6 +1169,7 @@ dependencies = [
  "emojis",
  "image",
  "pulldown-cmark 0.13.0",
+ "resvg",
 ]
 
 [[package]]

--- a/crates/egui_commonmark/egui_commonmark/Cargo.toml
+++ b/crates/egui_commonmark/egui_commonmark/Cargo.toml
@@ -21,6 +21,7 @@ egui_commonmark_macros_extended = { workspace = true, optional = true }
 
 egui_extras = { workspace = true }
 egui = { workspace = true }
+resvg = { version = "0.45", optional = true }
 
 # Expand recognized GitHub shortcodes in visible Markdown text.
 emojis = { workspace = true }
@@ -57,7 +58,7 @@ better_syntax_highlighting = [
 load-images = ["egui_extras/image", "egui_extras/file"]
 
 ## Support loading svg images
-svg = ["egui_extras/svg"]
+svg = ["egui_extras/svg", "dep:resvg"]
 
 ## Support text rendering in SVG images (requires system fonts like Verdana)
 svg_text = ["egui_extras/svg_text"]

--- a/crates/egui_commonmark/egui_commonmark/Cargo.toml
+++ b/crates/egui_commonmark/egui_commonmark/Cargo.toml
@@ -21,7 +21,7 @@ egui_commonmark_macros_extended = { workspace = true, optional = true }
 
 egui_extras = { workspace = true }
 egui = { workspace = true }
-resvg = { version = "0.45", optional = true }
+resvg = { version = "0.45", optional = true, default-features = false }
 
 # Expand recognized GitHub shortcodes in visible Markdown text.
 emojis = { workspace = true }
@@ -61,7 +61,7 @@ load-images = ["egui_extras/image", "egui_extras/file"]
 svg = ["egui_extras/svg", "dep:resvg"]
 
 ## Support text rendering in SVG images (requires system fonts like Verdana)
-svg_text = ["egui_extras/svg_text"]
+svg_text = ["svg", "egui_extras/svg_text"]
 
 ## Images with urls will be downloaded and displayed
 fetch = ["egui_extras/http"]

--- a/crates/egui_commonmark/egui_commonmark/src/lib.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/lib.rs
@@ -74,6 +74,8 @@
 
 use egui::{self, Id};
 
+#[cfg(feature = "svg")]
+mod mime_svg_loader;
 mod parsers;
 
 pub use egui_commonmark_backend_extended::RenderHtmlFn;
@@ -95,6 +97,12 @@ pub use egui_commonmark_macros_extended::*;
 pub use egui_commonmark_backend_extended;
 
 use egui_commonmark_backend_extended::*;
+
+fn prepare_show(cache: &mut CommonMarkCache, ctx: &egui::Context) {
+    egui_commonmark_backend_extended::prepare_show(cache, ctx);
+    #[cfg(feature = "svg")]
+    mime_svg_loader::install(ctx);
+}
 
 #[derive(Debug, Default)]
 pub struct CommonMarkViewer<'f> {
@@ -437,7 +445,7 @@ impl<'f> CommonMarkViewer<'f> {
         cache: &mut CommonMarkCache,
         text: &str,
     ) -> egui::InnerResponse<()> {
-        egui_commonmark_backend_extended::prepare_show(cache, ui.ctx());
+        prepare_show(cache, ui.ctx());
 
         let (response, _) = parsers::pulldown::CommonMarkViewerInternal::new().show(
             ui,
@@ -460,7 +468,7 @@ impl<'f> CommonMarkViewer<'f> {
         text: &mut String,
     ) -> egui::InnerResponse<()> {
         self.options.mutable = true;
-        egui_commonmark_backend_extended::prepare_show(cache, ui.ctx());
+        prepare_show(cache, ui.ctx());
 
         let (mut inner_response, checkmark_events) =
             parsers::pulldown::CommonMarkViewerInternal::new().show(
@@ -509,7 +517,7 @@ impl<'f> CommonMarkViewer<'f> {
         cache: &mut CommonMarkCache,
         text: &str,
     ) -> egui::scroll_area::ScrollAreaOutput<()> {
-        egui_commonmark_backend_extended::prepare_show(cache, ui.ctx());
+        prepare_show(cache, ui.ctx());
         parsers::pulldown::CommonMarkViewerInternal::new().show_scrollable(
             Id::new(source_id),
             ui,

--- a/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
@@ -4,13 +4,18 @@
 //! loader currently accepts only URIs ending in `.svg`. Dynamic image URLs
 //! commonly omit that suffix while returning `image/svg+xml` correctly.
 
-use std::sync::Arc;
+use std::{collections::HashMap, mem::size_of, sync::Arc};
 
-use egui::load::{BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint};
+use egui::{
+    load::{BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint},
+    mutex::Mutex,
+    ColorImage,
+};
 #[cfg(feature = "svg_text")]
 use resvg::usvg::fontdb::{Database, Family};
 
 struct MimeSvgLoader {
+    cache: Mutex<HashMap<(String, SizeHint), Result<Arc<ColorImage>, String>>>,
     options: resvg::usvg::Options<'static>,
 }
 
@@ -28,7 +33,10 @@ impl Default for MimeSvgLoader {
             repair_generic_font_families(options.fontdb_mut());
             options
         };
-        Self { options }
+        Self {
+            cache: Mutex::default(),
+            options,
+        }
     }
 }
 
@@ -119,7 +127,10 @@ fn fallback_family_name(
 
 #[cfg(feature = "svg_text")]
 fn fontconfig_family(pattern: &str) -> Option<String> {
-    #[cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))]
+    #[cfg(all(
+        unix,
+        not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+    ))]
     {
         use std::process::{Command, Stdio};
 
@@ -162,11 +173,21 @@ impl ImageLoader for MimeSvgLoader {
             return Err(LoadError::NotSupported);
         }
 
+        let key = (uri.to_owned(), size_hint);
+        if let Some(result) = self.cache.lock().get(&key).cloned() {
+            return result
+                .map(|image| ImagePoll::Ready { image })
+                .map_err(LoadError::Loading);
+        }
+
         match ctx.try_load_bytes(uri)? {
             BytesPoll::Pending { size } => Ok(ImagePoll::Pending { size }),
             BytesPoll::Ready { bytes, mime, .. } if mime.as_deref().is_some_and(is_svg_mime) => {
-                egui_extras::image::load_svg_bytes_with_size(&bytes, size_hint, &self.options)
-                    .map(Arc::new)
+                let result =
+                    egui_extras::image::load_svg_bytes_with_size(&bytes, size_hint, &self.options)
+                        .map(Arc::new);
+                self.cache.lock().insert(key, result.clone());
+                result
                     .map(|image| ImagePoll::Ready { image })
                     .map_err(LoadError::Loading)
             }
@@ -174,13 +195,25 @@ impl ImageLoader for MimeSvgLoader {
         }
     }
 
-    fn forget(&self, _uri: &str) {}
+    fn forget(&self, uri: &str) {
+        self.cache
+            .lock()
+            .retain(|(cached_uri, _), _| cached_uri != uri);
+    }
 
-    fn forget_all(&self) {}
+    fn forget_all(&self) {
+        self.cache.lock().clear();
+    }
 
     fn byte_size(&self) -> usize {
-        // Decoded textures are cached by egui's DefaultTextureLoader.
-        0
+        self.cache
+            .lock()
+            .values()
+            .map(|result| match result {
+                Ok(image) => image.pixels.len() * size_of::<egui::Color32>(),
+                Err(error) => error.len(),
+            })
+            .sum()
     }
 }
 
@@ -200,9 +233,16 @@ pub(crate) fn install(ctx: &egui::Context) {
 
 #[cfg(test)]
 mod tests {
-    use super::is_svg_mime;
+    use std::sync::Arc;
+
+    use egui::{
+        load::{ImageLoader, SizeHint},
+        Color32, ColorImage,
+    };
+
     #[cfg(feature = "svg_text")]
     use super::parse_fontconfig_family;
+    use super::{is_svg_mime, MimeSvgLoader};
 
     #[test]
     fn recognizes_svg_mime_with_optional_parameters() {
@@ -221,5 +261,35 @@ mod tests {
         );
         assert_eq!(parse_fontconfig_family(b"\n"), None);
         assert_eq!(parse_fontconfig_family(b""), None);
+    }
+
+    #[test]
+    fn forget_removes_every_cached_size_for_uri() {
+        let loader = MimeSvgLoader {
+            cache: Default::default(),
+            options: resvg::usvg::Options::default(),
+        };
+        let image = Arc::new(ColorImage::filled([1, 1], Color32::WHITE));
+
+        loader.cache.lock().insert(
+            ("https://example.com/badge".to_owned(), SizeHint::Width(10)),
+            Ok(image.clone()),
+        );
+        loader.cache.lock().insert(
+            ("https://example.com/badge".to_owned(), SizeHint::Width(20)),
+            Ok(image.clone()),
+        );
+        loader.cache.lock().insert(
+            ("https://example.com/other".to_owned(), SizeHint::Width(10)),
+            Ok(image),
+        );
+
+        loader.forget("https://example.com/badge");
+
+        let cache = loader.cache.lock();
+        assert_eq!(cache.len(), 1);
+        assert!(cache
+            .keys()
+            .all(|(uri, _)| uri == "https://example.com/other"));
     }
 }

--- a/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
@@ -1,0 +1,87 @@
+//! SVG loader fallback for resources whose URL does not end in `.svg`.
+//!
+//! egui_extras 0.33 documents MIME-based SVG detection, but its built-in
+//! loader currently accepts only URIs ending in `.svg`. Dynamic image URLs
+//! commonly omit that suffix while returning `image/svg+xml` correctly.
+
+use std::sync::Arc;
+
+use egui::load::{BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint};
+
+struct MimeSvgLoader {
+    options: resvg::usvg::Options<'static>,
+}
+
+impl MimeSvgLoader {
+    const ID: &'static str = egui::generate_loader_id!(MimeSvgLoader);
+}
+
+impl Default for MimeSvgLoader {
+    fn default() -> Self {
+        let mut options = resvg::usvg::Options::default();
+        #[cfg(feature = "svg_text")]
+        options.fontdb_mut().load_system_fonts();
+        Self { options }
+    }
+}
+
+impl ImageLoader for MimeSvgLoader {
+    fn id(&self) -> &str {
+        Self::ID
+    }
+
+    fn load(&self, ctx: &egui::Context, uri: &str, size_hint: SizeHint) -> ImageLoadResult {
+        // Let egui_extras' built-in loader handle ordinary `.svg` URIs. This
+        // fallback is deliberately limited to the MIME-detection gap.
+        if uri.ends_with(".svg") {
+            return Err(LoadError::NotSupported);
+        }
+
+        match ctx.try_load_bytes(uri)? {
+            BytesPoll::Pending { size } => Ok(ImagePoll::Pending { size }),
+            BytesPoll::Ready { bytes, mime, .. } if mime.as_deref().is_some_and(is_svg_mime) => {
+                egui_extras::image::load_svg_bytes_with_size(&bytes, size_hint, &self.options)
+                    .map(Arc::new)
+                    .map(|image| ImagePoll::Ready { image })
+                    .map_err(LoadError::Loading)
+            }
+            BytesPoll::Ready { .. } => Err(LoadError::NotSupported),
+        }
+    }
+
+    fn forget(&self, _uri: &str) {}
+
+    fn forget_all(&self) {}
+
+    fn byte_size(&self) -> usize {
+        // Decoded textures are cached by egui's DefaultTextureLoader.
+        0
+    }
+}
+
+fn is_svg_mime(mime: &str) -> bool {
+    mime.split(';')
+        .next()
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("image/svg+xml"))
+}
+
+pub(crate) fn install(ctx: &egui::Context) {
+    if !ctx.is_loader_installed(MimeSvgLoader::ID) {
+        // Image loaders are tried newest-first, so install this after the
+        // standard egui_extras loaders initialized by prepare_show().
+        ctx.add_image_loader(Arc::new(MimeSvgLoader::default()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_svg_mime;
+
+    #[test]
+    fn recognizes_svg_mime_with_optional_parameters() {
+        assert!(is_svg_mime("image/svg+xml"));
+        assert!(is_svg_mime("image/svg+xml;charset=utf-8"));
+        assert!(is_svg_mime("IMAGE/SVG+XML; charset=UTF-8"));
+        assert!(!is_svg_mime("image/png"));
+    }
+}

--- a/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
@@ -7,6 +7,8 @@
 use std::sync::Arc;
 
 use egui::load::{BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint};
+#[cfg(feature = "svg_text")]
+use resvg::usvg::fontdb::{Database, Family};
 
 struct MimeSvgLoader {
     options: resvg::usvg::Options<'static>,
@@ -18,11 +20,134 @@ impl MimeSvgLoader {
 
 impl Default for MimeSvgLoader {
     fn default() -> Self {
-        let mut options = resvg::usvg::Options::default();
+        let options = resvg::usvg::Options::default();
         #[cfg(feature = "svg_text")]
-        options.fontdb_mut().load_system_fonts();
+        let options = {
+            let mut options = options;
+            options.fontdb_mut().load_system_fonts();
+            repair_generic_font_families(options.fontdb_mut());
+            options
+        };
         Self { options }
     }
+}
+
+/// fontdb reads generic-family aliases from fontconfig configuration files,
+/// but an alias may name a font that is not installed (for example FreeSans on
+/// a minimal Linux desktop). Validate the aliases and, when necessary, ask the
+/// system's fontconfig matcher for a concrete installed family. The final scan
+/// keeps SVG text working on systems without the `fc-match` utility.
+#[cfg(feature = "svg_text")]
+fn repair_generic_font_families(database: &mut Database) {
+    let serif = resolve_generic_family(
+        database,
+        database.family_name(&Family::Serif),
+        "serif",
+        "serif",
+        false,
+    );
+    let sans_serif = resolve_generic_family(
+        database,
+        database.family_name(&Family::SansSerif),
+        "sans-serif",
+        "sans",
+        false,
+    );
+    let monospace = resolve_generic_family(
+        database,
+        database.family_name(&Family::Monospace),
+        "monospace",
+        "mono",
+        true,
+    );
+
+    if let Some(family) = serif {
+        database.set_serif_family(family);
+    }
+    if let Some(family) = sans_serif {
+        database.set_sans_serif_family(family);
+    }
+    if let Some(family) = monospace {
+        database.set_monospace_family(family);
+    }
+}
+
+#[cfg(feature = "svg_text")]
+fn resolve_generic_family(
+    database: &Database,
+    configured: &str,
+    fontconfig_pattern: &str,
+    preferred_name_fragment: &str,
+    monospaced: bool,
+) -> Option<String> {
+    canonical_family_name(database, configured)
+        .or_else(|| {
+            fontconfig_family(fontconfig_pattern)
+                .and_then(|family| canonical_family_name(database, &family))
+        })
+        .or_else(|| fallback_family_name(database, preferred_name_fragment, monospaced))
+}
+
+#[cfg(feature = "svg_text")]
+fn canonical_family_name(database: &Database, requested: &str) -> Option<String> {
+    database.faces().find_map(|face| {
+        face.families
+            .iter()
+            .find(|(family, _)| family.eq_ignore_ascii_case(requested))
+            .map(|(family, _)| family.clone())
+    })
+}
+
+#[cfg(feature = "svg_text")]
+fn fallback_family_name(
+    database: &Database,
+    preferred_name_fragment: &str,
+    monospaced: bool,
+) -> Option<String> {
+    let matching_width: Vec<_> = database
+        .faces()
+        .filter(|face| face.monospaced == monospaced)
+        .collect();
+
+    matching_width
+        .iter()
+        .flat_map(|face| &face.families)
+        .find(|(family, _)| family.to_lowercase().contains(preferred_name_fragment))
+        .or_else(|| matching_width.iter().flat_map(|face| &face.families).next())
+        .map(|(family, _)| family.clone())
+}
+
+#[cfg(feature = "svg_text")]
+fn fontconfig_family(pattern: &str) -> Option<String> {
+    #[cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))]
+    {
+        use std::process::{Command, Stdio};
+
+        let output = Command::new("fc-match")
+            .arg("--format=%{family}\\n")
+            .arg(pattern)
+            .stdin(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if output.status.success() {
+            return parse_fontconfig_family(&output.stdout);
+        }
+    }
+
+    let _ = pattern;
+    None
+}
+
+#[cfg(feature = "svg_text")]
+fn parse_fontconfig_family(stdout: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .next()?
+        .split(',')
+        .map(str::trim)
+        .find(|family| !family.is_empty())
+        .map(str::to_owned)
 }
 
 impl ImageLoader for MimeSvgLoader {
@@ -76,6 +201,8 @@ pub(crate) fn install(ctx: &egui::Context) {
 #[cfg(test)]
 mod tests {
     use super::is_svg_mime;
+    #[cfg(feature = "svg_text")]
+    use super::parse_fontconfig_family;
 
     #[test]
     fn recognizes_svg_mime_with_optional_parameters() {
@@ -83,5 +210,16 @@ mod tests {
         assert!(is_svg_mime("image/svg+xml;charset=utf-8"));
         assert!(is_svg_mime("IMAGE/SVG+XML; charset=UTF-8"));
         assert!(!is_svg_mime("image/png"));
+    }
+
+    #[cfg(feature = "svg_text")]
+    #[test]
+    fn parses_first_concrete_fontconfig_family() {
+        assert_eq!(
+            parse_fontconfig_family(b"DejaVu Sans,DejaVu Sans Condensed\n"),
+            Some("DejaVu Sans".to_string())
+        );
+        assert_eq!(parse_fontconfig_family(b"\n"), None);
+        assert_eq!(parse_fontconfig_family(b""), None);
     }
 }

--- a/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
@@ -30,7 +30,7 @@ impl Default for MimeSvgLoader {
         let options = {
             let mut options = options;
             options.fontdb_mut().load_system_fonts();
-            repair_generic_font_families(options.fontdb_mut());
+            repair_sans_serif_family(options.fontdb_mut());
             options
         };
         Self {
@@ -40,93 +40,36 @@ impl Default for MimeSvgLoader {
     }
 }
 
-/// fontdb reads generic-family aliases from fontconfig configuration files,
-/// but an alias may name a font that is not installed (for example FreeSans on
-/// a minimal Linux desktop). Validate the aliases and, when necessary, ask the
-/// system's fontconfig matcher for a concrete installed family. The final scan
-/// keeps SVG text working on systems without the `fc-match` utility.
+/// fontdb may map the generic sans-serif family to a font that is not installed.
+/// Preserve valid mappings and otherwise ask Fontconfig for the concrete system
+/// sans-serif family used by SVG badges.
 #[cfg(feature = "svg_text")]
-fn repair_generic_font_families(database: &mut Database) {
-    let serif = resolve_generic_family(
-        database,
-        database.family_name(&Family::Serif),
-        "serif",
-        "serif",
-        false,
-    );
-    let sans_serif = resolve_generic_family(
-        database,
-        database.family_name(&Family::SansSerif),
-        "sans-serif",
-        "sans",
-        false,
-    );
-    let monospace = resolve_generic_family(
-        database,
-        database.family_name(&Family::Monospace),
-        "monospace",
-        "mono",
-        true,
-    );
-
-    if let Some(family) = serif {
-        database.set_serif_family(family);
+fn repair_sans_serif_family(database: &mut Database) {
+    if family_is_loaded(database, database.family_name(&Family::SansSerif)) {
+        return;
     }
-    if let Some(family) = sans_serif {
+
+    if let Some(family) =
+        fontconfig_sans_serif_family().filter(|family| family_is_loaded(database, family))
+    {
         database.set_sans_serif_family(family);
     }
-    if let Some(family) = monospace {
-        database.set_monospace_family(family);
-    }
 }
 
 #[cfg(feature = "svg_text")]
-fn resolve_generic_family(
-    database: &Database,
-    configured: &str,
-    fontconfig_pattern: &str,
-    preferred_name_fragment: &str,
-    monospaced: bool,
-) -> Option<String> {
-    canonical_family_name(database, configured)
-        .or_else(|| {
-            fontconfig_family(fontconfig_pattern)
-                .and_then(|family| canonical_family_name(database, &family))
-        })
-        .or_else(|| fallback_family_name(database, preferred_name_fragment, monospaced))
-}
-
-#[cfg(feature = "svg_text")]
-fn canonical_family_name(database: &Database, requested: &str) -> Option<String> {
-    database.faces().find_map(|face| {
+fn family_is_loaded(database: &Database, requested: &str) -> bool {
+    database.faces().any(|face| {
         face.families
             .iter()
-            .find(|(family, _)| family.eq_ignore_ascii_case(requested))
-            .map(|(family, _)| family.clone())
+            // Match fontdb's family-name query semantics exactly. Accepting a
+            // differently-cased spelling here would still leave it unresolved
+            // when usvg later queries the database.
+            .any(|(family, _)| family == requested)
     })
 }
 
 #[cfg(feature = "svg_text")]
-fn fallback_family_name(
-    database: &Database,
-    preferred_name_fragment: &str,
-    monospaced: bool,
-) -> Option<String> {
-    let matching_width: Vec<_> = database
-        .faces()
-        .filter(|face| face.monospaced == monospaced)
-        .collect();
-
-    matching_width
-        .iter()
-        .flat_map(|face| &face.families)
-        .find(|(family, _)| family.to_lowercase().contains(preferred_name_fragment))
-        .or_else(|| matching_width.iter().flat_map(|face| &face.families).next())
-        .map(|(family, _)| family.clone())
-}
-
-#[cfg(feature = "svg_text")]
-fn fontconfig_family(pattern: &str) -> Option<String> {
+fn fontconfig_sans_serif_family() -> Option<String> {
     #[cfg(all(
         unix,
         not(any(target_os = "macos", target_os = "ios", target_os = "android"))
@@ -135,8 +78,8 @@ fn fontconfig_family(pattern: &str) -> Option<String> {
         use std::process::{Command, Stdio};
 
         let output = Command::new("fc-match")
-            .arg("--format=%{family}\\n")
-            .arg(pattern)
+            .arg("--format=%{family[0]}\\n")
+            .arg("sans-serif")
             .stdin(Stdio::null())
             .stderr(Stdio::null())
             .output()
@@ -146,19 +89,14 @@ fn fontconfig_family(pattern: &str) -> Option<String> {
         }
     }
 
-    let _ = pattern;
     None
 }
 
 #[cfg(feature = "svg_text")]
 fn parse_fontconfig_family(stdout: &[u8]) -> Option<String> {
-    String::from_utf8_lossy(stdout)
-        .lines()
-        .next()?
-        .split(',')
-        .map(str::trim)
-        .find(|family| !family.is_empty())
-        .map(str::to_owned)
+    let family = String::from_utf8_lossy(stdout);
+    let family = family.trim();
+    (!family.is_empty()).then(|| family.to_owned())
 }
 
 impl ImageLoader for MimeSvgLoader {
@@ -254,9 +192,9 @@ mod tests {
 
     #[cfg(feature = "svg_text")]
     #[test]
-    fn parses_first_concrete_fontconfig_family() {
+    fn parses_concrete_fontconfig_family() {
         assert_eq!(
-            parse_fontconfig_family(b"DejaVu Sans,DejaVu Sans Condensed\n"),
+            parse_fontconfig_family(b"DejaVu Sans\n"),
             Some("DejaVu Sans".to_string())
         );
         assert_eq!(parse_fontconfig_family(b"\n"), None);

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -1835,7 +1835,15 @@ impl CommonMarkViewerInternal {
             }
             pulldown_cmark::TagEnd::Link => {
                 if let Some(link) = self.link.take() {
-                    link.end(ui, cache);
+                    // A linked image has already rendered its image widget and
+                    // leaves no text in the surrounding Link. Rendering an
+                    // empty Label here resets egui's wrapped-row cursor to the
+                    // row start, so the next inline image is painted on top of
+                    // the previous one. Empty links have no visible widget to
+                    // render; keep the cursor where the image left it.
+                    if !link.text.is_empty() {
+                        link.end(ui, cache);
+                    }
                 }
             }
             pulldown_cmark::TagEnd::Image => {
@@ -2415,5 +2423,45 @@ mod tests {
     fn image_alt_text_and_url_remain_literal() {
         let markdown = "![:pushpin:](https://e/:rocket:.png)";
         assert_eq!(expanded_visible_text(markdown), ":pushpin:");
+    }
+
+    #[test]
+    fn ending_linked_image_keeps_wrapped_row_cursor_after_image() {
+        egui::__run_test_ui(|ui| {
+            let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
+            ui.allocate_ui_with_layout(egui::vec2(400.0, 0.0), layout, |ui| {
+                let mut renderer = CommonMarkViewerInternal::new();
+                let mut cache = CommonMarkCache::default();
+                let options = CommonMarkOptions::default();
+
+                renderer.link = Some(crate::Link {
+                    destination: "https://example.com".to_string(),
+                    text: Vec::new(),
+                });
+                renderer.image = Some(crate::Image::new(
+                    "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>",
+                    &options,
+                ));
+
+                renderer.end_tag(
+                    ui,
+                    pulldown_cmark::TagEnd::Image,
+                    &mut cache,
+                    &options,
+                    400.0,
+                );
+                let cursor_after_image = ui.next_widget_position();
+
+                renderer.end_tag(
+                    ui,
+                    pulldown_cmark::TagEnd::Link,
+                    &mut cache,
+                    &options,
+                    400.0,
+                );
+
+                assert_eq!(ui.next_widget_position(), cursor_after_image);
+            });
+        });
     }
 }


### PR DESCRIPTION
## Summary

- keep egui's inline cursor after a linked image instead of rendering an empty link label that resets the wrapped row
- add a MIME-aware SVG fallback loader for dynamic URLs that do not end in `.svg`, such as the GitHub stars Shields endpoint
- validate the `fontdb` sans-serif alias for MIME-detected SVGs and, only when it is unavailable, resolve the concrete installed family through Fontconfig
- cache MIME-decoded SVGs by URI and size hint, including the expected loader cache invalidation hooks

## Problem

The badges at the top of this repository's own README expose three related rendering failures:

1. ending an image-only link renders an empty `Label`, which moves egui's wrapped-row cursor back to the row start and makes subsequent badges overlap;
2. egui_extras 0.33's SVG loader accepts only URIs ending in `.svg`, although Shields dynamic endpoints correctly return `image/svg+xml`;
3. on a minimal Rocky Linux 9.5 installation, `fontdb` maps `sans-serif` to the unavailable `FreeSans`, while `fc-match sans-serif` resolves the installed `DejaVu Sans`. The GitHub badge therefore renders its shapes but drops `Stars` and the count.

The font issue is environment-triggered but not distro-specific: it can occur whenever the first parsed Fontconfig alias is not actually installed. A concrete reproduction and timing data were added to upstream fontdb issue [#24](https://github.com/RazrFalcon/fontdb/issues/24#issuecomment-5199471341).

The application-side resolver does not hard-code Rocky Linux font names. Existing valid aliases are preserved, `fc-match` is invoked only when the sans-serif mapping is unavailable on supported Unix targets, and its result must already exist in the loaded font database. Systems without the command retain their existing behavior.

## Validation

- `cargo test --locked` — 34 passed
- `cargo test --locked --manifest-path crates/egui_commonmark/egui_commonmark/Cargo.toml --features svg,svg_text,fetch --lib` — 23 passed
- `cargo check --locked --manifest-path crates/egui_commonmark/egui_commonmark/Cargo.toml --no-default-features --features svg,fetch`
- `cargo check --locked --manifest-path crates/egui_commonmark/egui_commonmark/Cargo.toml --no-default-features --features svg_text`
- `cargo clippy --locked --bin md-viewer --no-deps -- -D warnings`
- manual README rendering on Rocky Linux 9.5: all five badges remain separate, and the extensionless GitHub badge displays both `Stars` and its count
