### PR TITLE
fix(#65): fall back to X11 when the Wayland socket is unreachable

### DIFF
--- a/docs/devlog/052-winit-wayland-fallback.md
+++ b/docs/devlog/052-winit-wayland-fallback.md
@@ -1,0 +1,71 @@
+# Feature: X11 fallback when the Wayland socket is dead (#65)
+
+**Status:** ✅ Complete
+**Branch:** `fix/65-winit-wayland-fallback`
+**Date:** 2026-08-22
+**Lines Changed:** +85 / -3 in `src/main.rs`
+
+## Summary
+
+Snap-installed md-viewer aborted at startup on Ubuntu 26.04 (Wayland) with
+`Error: WinitEventLoop(Os(... WaylandError(Connection(NoCompositor))))`. The
+session had `WAYLAND_DISPLAY` set but the socket could not be connected from
+inside the snap's confinement, and winit never considered Xwayland. The fix
+probes the Wayland socket before eframe starts and clears the Wayland
+variables when it is unreachable, so winit selects X11 up front.
+
+## Features
+
+- [x] Pre-flight Unix-socket probe of `$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY`
+- [x] Clear `WAYLAND_DISPLAY`/`WAYLAND_SOCKET` on connect failure (forces winit's X11 path)
+- [x] Trust inherited `WAYLAND_SOCKET` fds (cannot be probed without consuming them)
+- [x] Unit tests for socket path resolution mirroring libwayland's lookup rules
+
+## Key Discoveries
+
+### winit 0.30 has no backend fallback — and no second chance
+
+winit 0.30's Linux `EventLoop::new()` picks **exactly one** backend from the
+environment: non-empty `WAYLAND_DISPLAY`/`WAYLAND_SOCKET` → Wayland, else
+`DISPLAY` → X11, else error. There is no try-Wayland-catch-X11 chain, so a
+set-but-unusable Wayland socket is fatal even on sessions with working
+Xwayland.
+
+```rust
+// winit-0.30.12/src/platform_impl/linux/mod.rs
+(None, true, _) => Backend::Wayland, // WAYLAND_DISPLAY set → committed
+```
+
+A post-failure retry inside the same process is impossible: creating a second
+event loop returns `EventLoopError::RecreationAttempt`. The first attempt in
+this branch did exactly that:
+
+```text
+WARN: Wayland event loop failed (... NoCompositor); retrying with X11
+Error: WinitEventLoop(RecreationAttempt)
+```
+
+Hence the decision must happen **before** `eframe::run_native`.
+
+### A std-only Wayland reachability probe
+
+libwayland's lookup rules are simple enough to mirror without adding a
+dependency: absolute `WAYLAND_DISPLAY` passes through, otherwise it joins
+`XDG_RUNTIME_DIR`. A `UnixStream::connect` then tells us what libwayland will
+find. Snap confinement failures (AppArmor denial, missing socket) surface as
+connect errors exactly like a missing compositor, which is what makes this
+work for the snap case.
+
+### Verification setup
+
+Reproduced #65 locally by pointing `WAYLAND_DISPLAY` at a nonexistent socket
+on Xvfb :99: pre-fix the process died, post-fix it logs one warning and opens
+via X11. The inverse case was checked with a dummy listening `AF_UNIX`
+socket — the probe accepts it and leaves the variables untouched.
+
+## Future Improvements
+
+- Root-cause why Ubuntu 26.04 snaps cannot reach a socket that the session
+  exposes (snapd interface vs. socket naming); the app-level fallback covers
+  users either way.
+- Consider the same guard for other eframe apps built from this template.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::{self, IsTerminal};
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, Receiver};
@@ -1180,6 +1181,15 @@ fn main() -> eframe::Result<()> {
         }
     }
 
+    fall_back_to_x11_if_wayland_socket_is_dead();
+    run_native_once(&args)
+}
+
+/// Build the native options and hand the app to eframe. Called once per
+/// process: if the event loop cannot be created, winit forbids a second
+/// attempt (`RecreationAttempt`), which is why backend selection is settled
+/// up front instead of via retry.
+fn run_native_once(args: &Args) -> eframe::Result<()> {
     // Calculate optimal window width assuming both sidebars are shown (the default)
     let optimal_width =
         CONTENT_OPTIMAL_WIDTH + EXPLORER_DEFAULT_WIDTH + OUTLINE_DEFAULT_WIDTH + PANEL_SEPARATORS;
@@ -1193,11 +1203,71 @@ fn main() -> eframe::Result<()> {
         ..Default::default()
     };
 
+    let file = args.file.clone();
+    let watch = !args.no_watch;
+
     eframe::run_native(
         "md-viewer",
         options,
-        Box::new(move |cc| Ok(Box::new(MarkdownApp::new(cc, args.file, !args.no_watch)))),
+        Box::new(move |cc| Ok(Box::new(MarkdownApp::new(cc, file, watch)))),
     )
+}
+
+/// winit 0.30 selects exactly one windowing backend from the environment and
+/// never falls back: a non-empty WAYLAND_DISPLAY/WAYLAND_SOCKET commits it to
+/// Wayland, and an unusable socket then aborts startup even when Xwayland is
+/// available (seen in strict snaps on Ubuntu 26.04, #65). Probe the socket
+/// before handing control to eframe; if it cannot be connected, clear the
+/// Wayland variables so winit picks X11 up front.
+#[cfg(unix)]
+fn fall_back_to_x11_if_wayland_socket_is_dead() {
+    // An inherited WAYLAND_SOCKET fd cannot be probed without consuming it;
+    // trust it and let libwayland report any problem.
+    if std::env::var_os("WAYLAND_SOCKET").is_some_and(|value| !value.is_empty()) {
+        return;
+    }
+
+    let display = std::env::var("WAYLAND_DISPLAY")
+        .ok()
+        .filter(|v| !v.is_empty());
+    let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR").unwrap_or_default();
+    let Some(path) = wayland_display_socket_path(display.as_deref(), &runtime_dir) else {
+        return;
+    };
+
+    if UnixStream::connect(&path).is_ok() {
+        return;
+    }
+
+    log::warn!(
+        "WAYLAND_DISPLAY points at {}, which cannot be connected to; falling back to X11",
+        path.display()
+    );
+    std::env::remove_var("WAYLAND_DISPLAY");
+    std::env::remove_var("WAYLAND_SOCKET");
+}
+
+#[cfg(not(unix))]
+fn fall_back_to_x11_if_wayland_socket_is_dead() {}
+
+/// Resolve the filesystem path of the Wayland socket from `WAYLAND_DISPLAY`
+/// and `XDG_RUNTIME_DIR`, mirroring libwayland's lookup rules: an absolute
+/// display name passes through, otherwise it is joined onto the runtime
+/// directory. Returns `None` when the pair does not describe a concrete
+/// socket — Wayland was never usable in that case, so there is nothing to
+/// probe or clear.
+fn wayland_display_socket_path(display: Option<&str>, runtime_dir: &OsStr) -> Option<PathBuf> {
+    let name = Path::new(display?);
+    if name.as_os_str().is_empty() {
+        return None;
+    }
+    if name.is_absolute() {
+        return Some(name.to_path_buf());
+    }
+    if runtime_dir.is_empty() {
+        return None;
+    }
+    Some(Path::new(runtime_dir).join(name))
 }
 
 /// Source of a lightbox texture. Mermaid pre-rasterizes its own texture so we
@@ -4349,6 +4419,31 @@ mod tests {
         assert_eq!(format_relative_time(now - 3 * 86_400, now), "3d ago");
         // Clock skew (future timestamp) must not underflow.
         assert_eq!(format_relative_time(now + 500, now), "just now");
+    }
+
+    #[test]
+    fn wayland_socket_path_mirrors_libwayland_lookup() {
+        assert_eq!(
+            wayland_display_socket_path(Some("wayland-0"), OsStr::new("/run/user/1000")),
+            Some(PathBuf::from("/run/user/1000/wayland-0"))
+        );
+        assert_eq!(
+            wayland_display_socket_path(Some("/custom/wayland-1"), OsStr::new("/run/user/1000")),
+            Some(PathBuf::from("/custom/wayland-1"))
+        );
+        // Nothing usable to probe when the variables are missing or empty.
+        assert_eq!(
+            wayland_display_socket_path(None, OsStr::new("/run/user/1000")),
+            None
+        );
+        assert_eq!(
+            wayland_display_socket_path(Some(""), OsStr::new("/run/user/1000")),
+            None
+        );
+        assert_eq!(
+            wayland_display_socket_path(Some("wayland-0"), OsStr::new("")),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- winit 0.30 picks exactly one Linux backend from the environment (non-empty `WAYLAND_DISPLAY` → Wayland, never X11 as fallback), so the strict-confinement snap on Ubuntu 26.04 aborted with `WinitEventLoop(NoCompositor)` even though Xwayland worked
- probe `$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY` with a std-only `UnixStream::connect` **before** `eframe::run_native`; on connect failure clear `WAYLAND_DISPLAY`/`WAYLAND_SOCKET` so winit selects X11 up front
- inherited `WAYLAND_SOCKET` fds are trusted untouched (cannot be probed without consuming them)
- in-process retry was rejected: a second event loop dies with `RecreationAttempt`, hence the up-front decision

Closes #65

## Testing

- `cargo test` — 47 passed (incl. new libwayland-lookup tests for absolute/relative/empty variable handling)
- `cargo clippy -- -D warnings`, `cargo fmt --check`
- E2E on Xvfb :99: `WAYLAND_DISPLAY=wayland-bogus` pre-fix reproduced #65; post-fix logs one warning and opens via X11
- dummy listening AF_UNIX socket: probe accepts, variables left intact