### PR TITLE
fix(#64): let tables span the full content pane in reading mode

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/lib.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/lib.rs
@@ -148,6 +148,14 @@ impl<'f> CommonMarkViewer<'f> {
         self
     }
 
+    /// Independent width bound for tables (markdown and HTML). Lets wide
+    /// tables use the full content pane while prose stays at the reading
+    /// column set by [`default_width`](Self::default_width).
+    pub fn table_max_width(mut self, width: Option<usize>) -> Self {
+        self.options.table_max_width = width;
+        self
+    }
+
     /// Show alt text when hovering over images. By default this is enabled.
     pub fn show_alt_text_on_hover(mut self, show: bool) -> Self {
         self.options.show_alt_text_on_hover = show;

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -1218,87 +1218,118 @@ impl CommonMarkViewerInternal {
             // relative to the parent's cursor, but the parent here is a horizontal-
             // flow Ui from the markdown renderer. Without the vertical scope the
             // body's first row overlaps the header row.
-            let mut scroll_out = egui::ScrollArea::horizontal()
-                .id_salt(id.with("_scroll"))
-                .max_width(max_width)
-                .auto_shrink([false, true])
-                .show(ui, |ui| {
-                    ui.vertical(|ui| {
-                        egui::Frame::group(ui.style()).show(ui, |ui| {
-                            let table = egui_extras::TableBuilder::new(ui)
-                                .id_salt(id)
-                                .striped(true)
-                                .resizable(true)
-                                .vscroll(false)
-                                // Shrink horizontally to the columns' content so a
-                                // table narrower than the panel hugs its columns
-                                // instead of stretching the bordered frame full width
-                                // with an empty gap after the last column (#47). The
-                                // outer ScrollArea still bounds wide tables at
-                                // max_width and provides horizontal scroll.
-                                .auto_shrink([true, true])
-                                .min_scrolled_height(0.0)
-                                .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-                                .columns(
-                                    egui_extras::Column::auto().resizable(true).at_least(40.0),
-                                    num_cols,
-                                )
-                                .header(header_h, |mut row| {
-                                    for col in header {
-                                        row.col(|ui| {
-                                            let col_w = ui.available_width();
-                                            for (e, src_span) in col {
-                                                let tmp_start = std::mem::replace(
-                                                    &mut self.line.should_start_newline,
-                                                    false,
-                                                );
-                                                let tmp_end = std::mem::replace(
-                                                    &mut self.line.should_end_newline,
-                                                    false,
-                                                );
-                                                self.event(
-                                                    ui, e, src_span, cache, options, col_w,
-                                                );
-                                                self.line.should_start_newline = tmp_start;
-                                                self.line.should_end_newline = tmp_end;
+            //
+            // The bound is `table_max_width` rather than the prose `max_width` so a
+            // wide table spreads over the whole content pane even in reading mode,
+            // instead of being clipped at the reading column with its right side
+            // unreachable (#64).
+            let table_bound = options
+                .table_max_width
+                .map(|w| w as f32)
+                .unwrap_or(max_width);
+            // The document ui is allocated at the prose width, and a child ui
+            // can never exceed its parent's allocation — so a wider viewport
+            // must be carved out explicitly. egui does not clamp an explicit
+            // child max_rect to the parent, which lets the table scope span
+            // the full pane while prose keeps the reading width. Anchor at
+            // the current cursor, not max_rect, or the table would repaint on
+            // top of everything above it.
+            let mut table_scope_rect = ui.cursor();
+            table_scope_rect.max.x = table_scope_rect.min.x + table_bound;
+            table_scope_rect.max.y = ui.max_rect().bottom();
+            let scroll_out = ui
+                .scope_builder(egui::UiBuilder::new().max_rect(table_scope_rect), |ui| {
+                    let mut scroll_out = egui::ScrollArea::horizontal()
+                        .id_salt(id.with("_scroll"))
+                        .max_width(table_bound)
+                        .auto_shrink([false, true])
+                        .show(ui, |ui| {
+                            ui.vertical(|ui| {
+                                egui::Frame::group(ui.style()).show(ui, |ui| {
+                                    let table = egui_extras::TableBuilder::new(ui)
+                                        .id_salt(id)
+                                        .striped(true)
+                                        .resizable(true)
+                                        .vscroll(false)
+                                        // Shrink horizontally to the columns' content so a
+                                        // table narrower than the panel hugs its columns
+                                        // instead of stretching the bordered frame full width
+                                        // with an empty gap after the last column (#47). The
+                                        // outer ScrollArea still bounds wide tables at
+                                        // max_width and provides horizontal scroll.
+                                        .auto_shrink([true, true])
+                                        .min_scrolled_height(0.0)
+                                        .cell_layout(egui::Layout::left_to_right(
+                                            egui::Align::Center,
+                                        ))
+                                        .columns(
+                                            egui_extras::Column::auto()
+                                                .resizable(true)
+                                                .at_least(40.0),
+                                            num_cols,
+                                        )
+                                        .header(header_h, |mut row| {
+                                            for col in header {
+                                                row.col(|ui| {
+                                                    let col_w = ui.available_width();
+                                                    for (e, src_span) in col {
+                                                        let tmp_start = std::mem::replace(
+                                                            &mut self.line.should_start_newline,
+                                                            false,
+                                                        );
+                                                        let tmp_end = std::mem::replace(
+                                                            &mut self.line.should_end_newline,
+                                                            false,
+                                                        );
+                                                        self.event(
+                                                            ui, e, src_span, cache, options,
+                                                            col_w,
+                                                        );
+                                                        self.line.should_start_newline = tmp_start;
+                                                        self.line.should_end_newline = tmp_end;
+                                                    }
+                                                });
                                             }
                                         });
-                                    }
-                                });
-                            table.body(|mut body| {
-                                for (row_idx, row) in rows.into_iter().enumerate() {
-                                    let h = body_heights
-                                        .get(row_idx)
-                                        .copied()
-                                        .unwrap_or(cell_h);
-                                    body.row(h, |mut row_ui| {
-                                        for col in row {
-                                            row_ui.col(|ui| {
-                                                let col_w = ui.available_width();
-                                                for (e, src_span) in col {
-                                                    let tmp_start = std::mem::replace(
-                                                        &mut self.line.should_start_newline,
-                                                        false,
-                                                    );
-                                                    let tmp_end = std::mem::replace(
-                                                        &mut self.line.should_end_newline,
-                                                        false,
-                                                    );
-                                                    self.event(
-                                                        ui, e, src_span, cache, options, col_w,
-                                                    );
-                                                    self.line.should_start_newline = tmp_start;
-                                                    self.line.should_end_newline = tmp_end;
+                                    table.body(|mut body| {
+                                        for (row_idx, row) in rows.into_iter().enumerate() {
+                                            let h = body_heights
+                                                .get(row_idx)
+                                                .copied()
+                                                .unwrap_or(cell_h);
+                                            body.row(h, |mut row_ui| {
+                                                for col in row {
+                                                    row_ui.col(|ui| {
+                                                        let col_w = ui.available_width();
+                                                        for (e, src_span) in col {
+                                                            let tmp_start = std::mem::replace(
+                                                                &mut self.line.should_start_newline,
+                                                                false,
+                                                            );
+                                                            let tmp_end = std::mem::replace(
+                                                                &mut self.line.should_end_newline,
+                                                                false,
+                                                            );
+                                                            self.event(
+                                                                ui, e, src_span, cache, options,
+                                                                col_w,
+                                                            );
+                                                            self.line.should_start_newline =
+                                                                tmp_start;
+                                                            self.line.should_end_newline = tmp_end;
+                                                        }
+                                                    });
                                                 }
                                             });
                                         }
                                     });
-                                }
+                                });
                             });
                         });
-                    });
-                });
-            forward_shift_wheel_to_horizontal_scroll(ui, &mut scroll_out);
+                    forward_shift_wheel_to_horizontal_scroll(ui, &mut scroll_out);
+                    scroll_out
+                })
+                .inner;
             self.is_table = false;
             if events.peek().is_none() {
                 self.line.should_end_newline_forced = false;
@@ -1943,11 +1974,23 @@ impl CommonMarkViewerInternal {
         // ui.vertical() prevents the header/body Y-overlap quirk. Plain vertical wheel
         // stays with the outer document scroller (#22); Shift+wheel opts in to
         // horizontal table scrolling via `forward_shift_wheel_to_horizontal_scroll`.
-        let mut scroll_out = egui::ScrollArea::horizontal()
-            .id_salt(id.with("_scroll"))
-            .max_width(max_width)
-            .auto_shrink([false, true])
-            .show(ui, |ui| {
+        // Bound at `table_max_width` over the prose cap (#64), same as markdown tables.
+        let table_bound = options
+            .table_max_width
+            .map(|w| w as f32)
+            .unwrap_or(max_width);
+        // Same reading-column escape as markdown tables (#64): carve out a
+        // scope wider than the prose allocation, anchored at the cursor.
+        let mut table_scope_rect = ui.cursor();
+        table_scope_rect.max.x = table_scope_rect.min.x + table_bound;
+        table_scope_rect.max.y = ui.max_rect().bottom();
+        let scroll_out = ui
+            .scope_builder(egui::UiBuilder::new().max_rect(table_scope_rect), |ui| {
+                let mut scroll_out = egui::ScrollArea::horizontal()
+                    .id_salt(id.with("_scroll"))
+                    .max_width(table_bound)
+                    .auto_shrink([false, true])
+                    .show(ui, |ui| {
                 ui.vertical(|ui| {
                     egui::Frame::group(ui.style()).show(ui, |ui| {
                         let builder = egui_extras::TableBuilder::new(ui)
@@ -2052,7 +2095,10 @@ impl CommonMarkViewerInternal {
                     });
                 });
             });
-        forward_shift_wheel_to_horizontal_scroll(ui, &mut scroll_out);
+                forward_shift_wheel_to_horizontal_scroll(ui, &mut scroll_out);
+                scroll_out
+            })
+            .inner;
         self.line.try_insert_end(ui);
     }
 }

--- a/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
@@ -40,6 +40,12 @@ pub struct CommonMarkOptions<'f> {
     pub max_image_width: Option<usize>,
     pub show_alt_text_on_hover: bool,
     pub default_width: Option<usize>,
+    /// Width bound for tables, independent of `default_width`. Tables may
+    /// exceed the reading column: when set, markdown and HTML tables scroll
+    /// horizontally within this width instead of the `default_width` cap, so
+    /// wide tables use the full content pane while prose stays at the reading
+    /// width (#64). `None` falls back to `max_width`.
+    pub table_max_width: Option<usize>,
     #[cfg(feature = "better_syntax_highlighting")]
     pub theme_light: String,
     #[cfg(feature = "better_syntax_highlighting")]
@@ -65,7 +71,8 @@ impl std::fmt::Debug for CommonMarkOptions<'_> {
         s.field("indentation_spaces", &self.indentation_spaces)
             .field("max_image_width", &self.max_image_width)
             .field("show_alt_text_on_hover", &self.show_alt_text_on_hover)
-            .field("default_width", &self.default_width);
+            .field("default_width", &self.default_width)
+            .field("table_max_width", &self.table_max_width);
 
         #[cfg(feature = "better_syntax_highlighting")]
         s.field("theme_light", &self.theme_light)
@@ -91,6 +98,7 @@ impl Default for CommonMarkOptions<'_> {
             max_image_width: None,
             show_alt_text_on_hover: true,
             default_width: None,
+            table_max_width: None,
             #[cfg(feature = "better_syntax_highlighting")]
             theme_light: DEFAULT_THEME_LIGHT.to_owned(),
             #[cfg(feature = "better_syntax_highlighting")]

--- a/docs/devlog/053-tables-full-pane-width.md
+++ b/docs/devlog/053-tables-full-pane-width.md
@@ -1,0 +1,62 @@
+# Feature: Tables use the full content pane (#64)
+
+**Status:** ✅ Complete
+**Branch:** `fix/64-tables-full-width`
+**Date:** 2026-08-22
+**Lines Changed:** `src/main.rs`, vendored `egui_commonmark` (options + 2 table renderers)
+
+## Summary
+
+In reading mode (`full_width_content = false`) the whole document ui is
+allocated at the prose cap (~600px), so wide tables were clipped at that
+column with their right side unreachable — the reporter's "window width not
+fully used, tables cut on the right". Markdown and HTML tables now escape
+the reading column: they span the full content pane (horizontally scrolling
+within it when still wider), while prose keeps the reading width.
+
+## Features
+
+- [x] `CommonMarkOptions::table_max_width` + `CommonMarkViewer::table_max_width()` builder setter
+- [x] md-viewer passes the content pane's real width; tables bound to it, prose unchanged
+- [x] Applies to both markdown tables and HTML tables
+- [x] Verified at 1920px (A–G of an 8-col table visible vs cut-at-C before) and narrow widths
+
+## Key Discoveries
+
+### A child Ui cannot exceed its parent allocation — unless you force max_rect
+
+The document renderer wraps everything in
+`allocate_ui_with_layout(vec2(max_width, 0.0), …)`. Any nested ScrollArea is
+clamped to that 600px parent, so raising `ScrollArea::max_width` alone does
+nothing. But egui's `Ui::new_child` uses a builder-supplied `max_rect`
+verbatim — **it is not intersected with the parent's rect**. Carving out a
+wider scope lets the table escape:
+
+```rust
+let mut table_scope_rect = ui.cursor();
+table_scope_rect.max.x = table_scope_rect.min.x + table_bound;
+table_scope_rect.max.y = ui.max_rect().bottom();
+ui.scope_builder(egui::UiBuilder::new().max_rect(table_scope_rect), |ui| { … })
+```
+
+### Anchor the carve-out at `ui.cursor()`, not `ui.max_rect()`
+
+First attempt built the scope from `max_rect()` (document top): the table
+repainted on top of the heading/paragraph above it while later content
+flowed underneath. The cursor position is the correct top-left anchor;
+extend only right/down.
+
+### Nested-context overshoot is bounded
+
+Inside lists/blockquotes `cursor().min.x` is indented, so
+`min.x + pane_width` can overshoot the pane by the indent amount. At the
+top level (the common case for wide tables) the offset is just the frame
+margin. Accepted as a known trade-off; no clipping regressions observed at
+900px or 1920px.
+
+## Future Improvements
+
+- Make overflow affordance stronger: currently egui's on-hover scrollbar +
+  Shift+wheel; consider always-visible thin scrollbar for overflowing tables.
+- Root fix upstream: egui could expose per-block width overrides so this
+  hack (scope_builder with forced rect) becomes unnecessary.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2823,6 +2823,10 @@ impl MarkdownApp {
                     .default_implicit_uri_scheme(&tab.base_uri)
                     .max_image_width(Some(800))
                     .default_width(default_width)
+                    // Tables are not bound by the reading column (#64): a wide
+                    // table spans the whole content pane and scrolls there,
+                    // while prose keeps the reading width.
+                    .table_max_width(Some(content_rect.width() as usize))
                     .indentation_spaces(2)
                     .use_strong_font_family(true)
                     .show_alt_text_on_hover(true)


### PR DESCRIPTION
## Summary

- reading mode allocates the whole document ui at the prose cap (~600px); egui clamps nested ScrollAreas to their parent, so wide tables were cut at that column with the right side unreachable (#64)
- add `table_max_width` option + builder setter; md-viewer passes the content pane's real width
- markdown **and** HTML tables carve out a wider child scope (`UiBuilder::max_rect` is not intersected with the parent) anchored at the current cursor; prose keeps the reading width
- overflow still scrolls horizontally (Shift+wheel / scrollbar), small tables still hug their columns (#47 behavior preserved)

Closes #64

## Testing

- `cargo test` 47 passed, clippy -D warnings, fmt clean
- E2E on Xvfb :99 at 1920px: 8-column table now shows columns A–G (previously clipped mid-column-C at ~600px), no overlap with heading/paragraph
- narrow window (900px): small table hugs, wide tables bounded at pane edge, no overshoot past the sidebar divider