### PR TITLE
chore: bump vendored egui_commonmark fork to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend_extended"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_extended"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "egui",
  "egui_commonmark_backend_extended",
@@ -7962,4 +7962,4 @@ dependencies = [
 
 [[patch.unused]]
 name = "egui_commonmark_macros_extended"
-version = "0.25.0"
+version = "0.26.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ egui = { version = "0.33", features = ["accesskit"] }
 # egui-mcp-bridge = { path = "/home/ahmet/dev/mcp/egui-mcp/crates/egui-mcp-bridge", optional = true }
 
 # Markdown rendering with syntax highlighting (fork with typography support)
-egui_commonmark_extended = { version = "0.25.0", features = [
+egui_commonmark_extended = { version = "0.26.0", features = [
     "better_syntax_highlighting",
     "svg",
     "svg_text",
@@ -89,6 +89,6 @@ lto = "thin"
 codegen-units = 4
 
 [patch.crates-io]
-egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark", version = "0.25.0" }
-egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend", version = "0.25.0" }
-egui_commonmark_macros_extended = { path = "crates/egui_commonmark/egui_commonmark_macros", version = "0.25.0" }
+egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark", version = "0.26.0" }
+egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend", version = "0.26.0" }
+egui_commonmark_macros_extended = { path = "crates/egui_commonmark/egui_commonmark_macros", version = "0.26.0" }

--- a/crates/egui_commonmark/CHANGELOG.md
+++ b/crates/egui_commonmark/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+- `table_max_width` option: markdown/HTML tables may exceed the prose reading column and span the full content pane (#64).
+- MIME-aware SVG loader for SVG URLs without a `.svg` extension; image-only links keep the wrapped-row cursor (#63).
+
+### Fixed
+- amsmath `\operatorname{}` / `\operatorname*{}` render as named operators (#58).
+
 ## 0.22.0 - 2025-10-09
 
 ### Changed

--- a/crates/egui_commonmark/Cargo.lock
+++ b/crates/egui_commonmark/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend_extended"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "data-url",
  "egui",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_extended"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "document-features",
  "eframe",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_macros_extended"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "document-features",
  "egui",

--- a/crates/egui_commonmark/Cargo.toml
+++ b/crates/egui_commonmark/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.76"
-version = "0.25.0"
+version = "0.26.0"
 repository = "https://github.com/aydiler/md-viewer"
 
 [workspace.dependencies]
@@ -21,8 +21,8 @@ egui = { version = "0.33", default-features = false }
 
 # Runtime lookup for recognized GitHub/gemoji shortcode names.
 emojis = "0.9.0"
-egui_commonmark_backend_extended = { version = "0.25.0", path = "egui_commonmark_backend", default-features = false }
-egui_commonmark_macros_extended = { version = "0.25.0", path = "egui_commonmark_macros", default-features = false }
+egui_commonmark_backend_extended = { version = "0.26.0", path = "egui_commonmark_backend", default-features = false }
+egui_commonmark_macros_extended = { version = "0.26.0", path = "egui_commonmark_macros", default-features = false }
 
 # To add features to documentation
 document-features = { version = "0.2" }


### PR DESCRIPTION
Fixes the release-guard failure on tag v0.1.16: fork code changed (#63/#64) but version was still the published 0.25.0. Bumps fork workspace + root pins to 0.26.0, updates both lockfiles, adds vendored CHANGELOG notes.