### PR TITLE
fix: gate UnixStream import behind cfg(unix)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::{self, IsTerminal};
+#[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};


### PR DESCRIPTION
One-line fix for the Windows release build failure on tag v0.1.16 (`cannot find unix in os`, E0433): the Wayland-socket probe added in #66 is unix-only but its `use std::os::unix::net::UnixStream` was unconditional. CI builds Linux only so it slipped through; caught by the release workflow's Windows job.