### PR TITLE
feat(#60): render LaTeX \(...\) and \[...\] math delimiters

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/latex_delimiters.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/latex_delimiters.rs
@@ -1,0 +1,442 @@
+//! LaTeX-style math delimiter support (#60): `\(...\)` renders as inline
+//! math and `\[...\]` as display math, matching LaTeX/Pandoc conventions.
+//!
+//! pulldown-cmark applies CommonMark backslash escapes while parsing, so the
+//! backslash of `\(` never survives into a [`Event::Text`] and such
+//! delimiters cannot be recognized after parsing. The conversion therefore
+//! rewrites the raw source before it reaches the parser.
+//!
+//! A blind rewrite would shift byte offsets and silently break search
+//! highlighting, which is defined against the original text. Instead this
+//! module
+//!
+//! 1. parses the original text once without math to find contexts that must
+//!    never be converted (inline code, fenced/indented code blocks, raw
+//!    HTML) and the blocks within which delimiters may pair (paragraphs,
+//!    headings, table cells),
+//! 2. scans only prose bytes for paired, unescaped delimiters,
+//! 3. splices `$` / `$$` replacements into a copy of the source while
+//!    recording every length change, and
+//! 4. remaps every event range parsed from the rewritten copy back to
+//!    original coordinates before caching.
+
+use egui_commonmark_backend_extended::pulldown::parser_options;
+use pulldown_cmark::{Event, Options, Parser, Tag};
+use std::ops::Range;
+
+/// One delimiter replacement: the two bytes starting at `at` in the original
+/// source are replaced by `replacement` (`"$"` or `"$$"`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Rewrite {
+    at: usize,
+    replacement: &'static str,
+}
+
+/// Maps normalized-text coordinates back to original-source coordinates so
+/// parsed event ranges stay valid against the original text.
+#[derive(Debug, Default)]
+struct OffsetMap {
+    /// Sorted by `norm_pos`, recorded after every replacement. For a
+    /// normalized position `p`, the original position is `p + delta` using
+    /// the last entry with `norm_pos <= p` (`delta = 0` before the first).
+    shifts: Vec<(usize, i64)>,
+}
+
+impl OffsetMap {
+    fn map_pos(&self, pos: usize) -> usize {
+        match self.shifts.partition_point(|&(n, _)| n <= pos) {
+            0 => pos,
+            i => {
+                let &(n, delta) = &self.shifts[i - 1];
+                debug_assert!(n <= pos);
+                (pos as i64 + delta) as usize
+            }
+        }
+    }
+
+    fn map_range(&self, range: &mut Range<usize>) {
+        range.start = self.map_pos(range.start);
+        range.end = self.map_pos(range.end);
+    }
+}
+
+/// Parse markdown with optional math support, converting LaTeX-style
+/// `\(...\)` / `\[...\]` delimiters to `$...$` / `$$...$$` on an in-memory
+/// copy when paired occurrences exist in prose. Returned event ranges always
+/// refer to `text`, the original source.
+pub fn parse_events(text: &str, math_enabled: bool) -> Vec<(Event<'static>, Range<usize>)> {
+    if !math_enabled {
+        return parse_owned(text, false);
+    }
+    let rewrites = find_rewrites(text);
+    if rewrites.is_empty() {
+        return parse_owned(text, true);
+    }
+    let (normalized, map) = build_normalized(text, &rewrites);
+    let mut events = parse_owned(&normalized, true);
+    for (_, range) in events.iter_mut() {
+        map.map_range(range);
+    }
+    events
+}
+
+fn parse_owned(text: &str, math_enabled: bool) -> Vec<(Event<'static>, Range<usize>)> {
+    let options = if math_enabled {
+        parser_options() | Options::ENABLE_MATH
+    } else {
+        parser_options()
+    };
+    Parser::new_ext(text, options)
+        .into_offset_iter()
+        .map(|(event, range)| (event.into_static(), range))
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DelimKind {
+    Inline,
+    Display,
+}
+
+impl DelimKind {
+    fn replacement(self) -> &'static str {
+        match self {
+            DelimKind::Inline => "$",
+            DelimKind::Display => "$$",
+        }
+    }
+}
+
+/// Contexts extracted from a plain parse of the original text.
+struct Contexts {
+    /// Ranges that must never be converted or scanned through: inline code,
+    /// fenced/indented code blocks, raw HTML (block and inline).
+    protected_ranges: Vec<Range<usize>>,
+    /// Container ranges within which delimiters may pair (paragraphs,
+    /// headings, table cells). Restricting pairing to one block keeps a
+    /// stray opener in one paragraph from swallowing prose up to a closer
+    /// paragraphs later.
+    block_ranges: Vec<Range<usize>>,
+}
+
+fn context_ranges(text: &str) -> Contexts {
+    let mut protected: Vec<Range<usize>> = Vec::new();
+    let mut blocks: Vec<Range<usize>> = Vec::new();
+    for (event, range) in Parser::new_ext(text, parser_options()).into_offset_iter() {
+        match event {
+            Event::Code(_) | Event::Html(_) | Event::InlineHtml(_) => protected.push(range),
+            Event::Start(Tag::CodeBlock(_)) => protected.push(range),
+            Event::Start(Tag::Paragraph | Tag::Heading { .. } | Tag::Table(_)) => {
+                blocks.push(range)
+            }
+            _ => {}
+        }
+    }
+    protected.sort_by_key(|r| r.start);
+    // Merge overlapping ranges (e.g. an inline code span inside a paragraph
+    // is fine, but nested containers can overlap) for cheap skip-ahead.
+    let mut merged: Vec<Range<usize>> = Vec::with_capacity(protected.len());
+    for range in protected {
+        match merged.last_mut() {
+            Some(last) if last.end >= range.start => last.end = last.end.max(range.end),
+            _ => merged.push(range),
+        }
+    }
+    Contexts {
+        protected_ranges: merged,
+        block_ranges: blocks,
+    }
+}
+
+/// Find paired, unescaped `\(...\)` / `\[...\]` delimiters in prose.
+///
+/// Returns rewrites ordered by position. An opener supersedes a pending one
+/// (mirroring how `$...$` scanning behaves); a closer only completes a
+/// pending opener of the same kind, so mismatched leftovers stay literal.
+fn find_rewrites(text: &str) -> Vec<Rewrite> {
+    let contexts = context_ranges(text);
+    if contexts.block_ranges.is_empty() {
+        return Vec::new();
+    }
+    let mut rewrites = Vec::new();
+    for block in &contexts.block_ranges {
+        for run in unprotected_runs(block.clone(), &contexts.protected_ranges) {
+            scan_run(text, run, &mut rewrites);
+        }
+    }
+    rewrites
+}
+
+/// Split `range` into the sub-ranges not covered by the sorted, merged
+/// `protected` ranges.
+fn unprotected_runs(range: Range<usize>, protected: &[Range<usize>]) -> Vec<Range<usize>> {
+    let mut runs = Vec::new();
+    let mut cursor = range.start;
+    for p in protected {
+        if p.end <= cursor || p.start >= range.end {
+            continue;
+        }
+        if p.start > cursor {
+            runs.push(cursor..p.start);
+        }
+        cursor = cursor.max(p.end);
+    }
+    if cursor < range.end {
+        runs.push(cursor..range.end);
+    }
+    runs
+}
+
+fn scan_run(text: &str, run: Range<usize>, out: &mut Vec<Rewrite>) {
+    #[derive(Clone, Copy)]
+    enum Pending {
+        Inline(usize),
+        Display(usize),
+    }
+
+    let bytes = text.as_bytes();
+    let mut pending: Option<Pending> = None;
+    let mut i = run.start;
+    while i + 2 <= run.end {
+        if bytes[i] != b'\\' {
+            i += 1;
+            continue;
+        }
+        let kind = match bytes[i + 1] {
+            b'(' | b')' => DelimKind::Inline,
+            b'[' | b']' => DelimKind::Display,
+            _ => {
+                i += 2;
+                continue;
+            }
+        };
+        // An active delimiter needs its backslash free, i.e. an even number
+        // of backslashes before it. `\\(` is an escaped backslash followed by
+        // an escaped parenthesis and must stay literal.
+        let mut slashes = 0usize;
+        while slashes < i && bytes[i - 1 - slashes] == b'\\' {
+            slashes += 1;
+        }
+        if slashes % 2 == 1 {
+            i += 2;
+            continue;
+        }
+        let opening = matches!(bytes[i + 1], b'(' | b'[');
+        if opening {
+            pending = Some(match kind {
+                DelimKind::Inline => Pending::Inline(i),
+                DelimKind::Display => Pending::Display(i),
+            });
+        } else if let Some(open_at) = pending.and_then(|p| match (p, kind) {
+            (Pending::Inline(at), DelimKind::Inline) => Some(at),
+            (Pending::Display(at), DelimKind::Display) => Some(at),
+            _ => None,
+        }) {
+            out.push(Rewrite {
+                at: open_at,
+                replacement: kind.replacement(),
+            });
+            out.push(Rewrite {
+                at: i,
+                replacement: kind.replacement(),
+            });
+            pending = None;
+        }
+        i += 2;
+    }
+}
+
+/// Splice `rewrites` (sorted by position) into a copy of `text` and build the
+/// offset map from rewritten coordinates back to original ones.
+fn build_normalized<'a>(text: &'a str, rewrites: &[Rewrite]) -> (String, OffsetMap) {
+    let mut out = String::with_capacity(text.len());
+    let mut shifts: Vec<(usize, i64)> = Vec::with_capacity(rewrites.len());
+    let mut delta: i64 = 0;
+    let mut prev = 0usize;
+    for rw in rewrites {
+        out.push_str(&text[prev..rw.at]);
+        out.push_str(rw.replacement);
+        delta += 2i64 - rw.replacement.len() as i64;
+        shifts.push((out.len(), delta));
+        prev = rw.at + 2;
+    }
+    out.push_str(&text[prev..]);
+    (out, OffsetMap { shifts })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pulldown_cmark::TagEnd;
+
+    /// Collect (event-debug, original-slice) pairs.
+    fn outline(text: &str) -> Vec<(String, String)> {
+        parse_events(text, true)
+            .into_iter()
+            .map(|(event, range)| (format!("{event:?}"), text[range].to_string()))
+            .collect()
+    }
+
+    fn find_math(text: &str, needle: &str) -> Option<(String, String)> {
+        outline(text).into_iter().find(|(event, slice)| {
+            (event.contains("InlineMath") || event.contains("DisplayMath"))
+                && slice.contains(needle)
+        })
+    }
+
+    fn plain_texts(text: &str) -> Vec<String> {
+        parse_events(text, true)
+            .into_iter()
+            .filter(|(event, _)| matches!(event, Event::Text(_)))
+            .map(|(event, _)| match event {
+                Event::Text(t) => t.to_string(),
+                _ => unreachable!(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn inline_pair_converts_with_original_range() {
+        let text = "before \\(P_B,P_A\\) after";
+        let (event, slice) = find_math(text, "P_B,P_A").expect("inline math expected");
+        assert!(event.contains("InlineMath"));
+        assert_eq!(slice, "\\(P_B,P_A\\)");
+        // Prose around the formula still lands in Text events unchanged.
+        assert!(plain_texts(text).iter().any(|t| t.contains("after")));
+    }
+
+    #[test]
+    fn display_pair_across_lines_converts() {
+        let text = "\\[\nr_a=1\n\\]";
+        let (event, slice) =
+            find_math(text, "r_a=1").expect("display math expected");
+        assert!(event.contains("DisplayMath"));
+        assert_eq!(slice, "\\[\nr_a=1\n\\]");
+    }
+
+    #[test]
+    fn mixed_inline_and_display_and_plain_dollar_still_work() {
+        let text = "$a$ then \\(b\\) and\n\n\\[\nc\n\\]";
+        let events = outline(text);
+        let inline: Vec<&(String, String)> = events
+            .iter()
+            .filter(|(e, _)| e.contains("InlineMath"))
+            .collect();
+        assert_eq!(inline.len(), 2, "both $a$ and \\(b\\) become inline math");
+        let display: Vec<&(String, String)> = events
+            .iter()
+            .filter(|(e, _)| e.contains("DisplayMath"))
+            .collect();
+        assert_eq!(display.len(), 1);
+        assert!(inline.iter().any(|(_, s)| s == "$a$"));
+        assert!(inline.iter().any(|(_, s)| s == "\\(b\\)"));
+    }
+
+    #[test]
+    fn dollar_math_unchanged_without_latex_pairs() {
+        let (event, _) = find_math("$a^2$", "a^2").expect("dollar math expected");
+        assert!(event.contains("InlineMath"));
+    }
+
+    #[test]
+    fn escaped_delimiters_stay_literal() {
+        let text = "\\\\(x\\\\) stays text";
+        assert!(find_math(text, "x").is_none());
+    }
+
+    #[test]
+    fn unmatched_open_stays_literal() {
+        let text = "an \\( open pair";
+        assert!(find_math(text, "open pair").is_none());
+        // Unmatched delimiters keep their CommonMark meaning: literal paren.
+        assert!(plain_texts(text).iter().any(|t| t.contains('(')));
+    }
+
+    #[test]
+    fn unmatched_close_stays_literal() {
+        let text = "a lone \\) close";
+        assert!(find_math(text, "lone").is_none());
+        assert!(plain_texts(text).iter().any(|t| t.contains(')')));
+    }
+
+    #[test]
+    fn mismatched_kinds_do_not_pair() {
+        let text = "\\(a \\] b\\)";
+        // Mismatched closers are ignored like stray brackets; the inline
+        // pair still completes around them.
+        let (event, _) = find_math(text, "b").expect("inline pair completes");
+        assert!(event.contains("InlineMath"));
+    }
+
+    #[test]
+    fn inline_code_is_protected() {
+        let text = "`\\(x\\)` stays code";
+        assert!(find_math(text, "x").is_none());
+    }
+
+    #[test]
+    fn fenced_code_block_is_protected() {
+        let text = "```\n\\(x\\)\n```";
+        assert!(find_math(text, "x").is_none());
+    }
+
+    #[test]
+    fn indented_code_block_is_protected() {
+        let text = "text\n\n    \\(x\\)\n";
+        assert!(find_math(text, "x").is_none());
+    }
+
+    #[test]
+    fn html_block_is_protected() {
+        let text = "<div>\n\\(x\\)\n</div>\n";
+        assert!(find_math(text, "x").is_none());
+    }
+
+    #[test]
+    fn no_pairing_across_paragraphs() {
+        let text = "open \\( here\n\nand \\) there";
+        assert!(find_math(text, "").is_none());
+    }
+
+    #[test]
+    fn crlf_line_endings_survive() {
+        let text = "\\[\r\nr_a=1\r\n\\]\r\n";
+        let (event, slice) = find_math(text, "r_a=1").expect("display math expected");
+        assert!(event.contains("DisplayMath"));
+        assert_eq!(slice, "\\[\r\nr_a=1\r\n\\]");
+    }
+
+    #[test]
+    fn ranges_after_conversion_point_into_the_original() {
+        let text = "a \\(x\\) b";
+        let events = parse_events(text, true);
+        let after = events
+            .iter()
+            .find(|(e, _)| matches!(e, Event::Text(t) if t.contains('b')))
+            .expect("trailing text");
+        assert_eq!(&text[after.1.clone()], " b");
+        let end_tag = events
+            .iter()
+            .find(|(e, _)| matches!(e, Event::End(TagEnd::Paragraph)))
+            .unwrap();
+        assert_eq!(end_tag.1, 0..text.len());
+    }
+
+    #[test]
+    fn fast_path_when_nothing_converts() {
+        // No LaTeX pairs: identical output to a direct parse.
+        assert_eq!(
+            parse_events("plain $x$ text", true),
+            parse_owned("plain $x$ text", true)
+        );
+    }
+
+    #[test]
+    fn math_disabled_leaves_everything_alone() {
+        let events = parse_events("\\(x\\)", false);
+        assert!(events.iter().all(|(e, _)| !matches!(
+            e,
+            Event::InlineMath(_) | Event::DisplayMath(_)
+        )));
+    }
+}

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/mod.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/mod.rs
@@ -1,1 +1,2 @@
+pub mod latex_delimiters;
 pub mod pulldown;

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -597,11 +597,11 @@ impl CommonMarkViewerInternal {
         let content_hash = Self::hash_content(text);
         if cache.get_cached_events(content_hash).is_none() {
             let math_enabled = options.math_fn.is_some() || cfg!(feature = "math");
+            // LaTeX-style \(...\) / \[...\] support (#60): delimiters are
+            // rewritten pre-parse on an in-memory copy and ranges are mapped
+            // back, so they stay valid against the original text.
             let owned_events: Vec<(pulldown_cmark::Event<'static>, Range<usize>)> =
-                pulldown_cmark::Parser::new_ext(text, parser_options_math(math_enabled))
-                    .into_offset_iter()
-                    .map(|(event, range)| (event.into_static(), range))
-                    .collect();
+                super::latex_delimiters::parse_events(text, math_enabled);
             cache.set_cached_events(content_hash, owned_events);
         }
 
@@ -734,13 +734,10 @@ impl CommonMarkViewerInternal {
                 // (`lib.rs:566 unreachable!()`). See docs/devlog/027.
                 let math_enabled =
                     options.math_fn.is_some() || cfg!(feature = "math");
-                sc.events = pulldown_cmark::Parser::new_ext(
-                    text,
-                    parser_options_math(math_enabled),
-                )
-                .into_offset_iter()
-                .map(|(e, r)| (e.into_static(), r))
-                .collect();
+                // Must produce byte-identical events to the cache-fill parse
+                // above — including any LaTeX delimiter rewrite (#60) — or
+                // split_points index into an unrelated stream (see devlog 027).
+                sc.events = super::latex_delimiters::parse_events(text, math_enabled);
                 sc.content_version = version;
                 // Content changed — cached split_points y-coords are no
                 // longer valid for this content. Drop them so the first

--- a/docs/devlog/054-latex-delimiters.md
+++ b/docs/devlog/054-latex-delimiters.md
@@ -1,0 +1,59 @@
+# Feature: LaTeX `\(...\)` / `\[...\]` math delimiters (#60)
+
+**Status:** ✅ Complete
+**Branch:** `feat/60-latex-delimiters`
+**Date:** 2026-08-22
+**Lines Changed:** new vendored module `latex_delimiters.rs` (~430 lines with tests), 2 call sites in `pulldown.rs`
+
+## Summary
+
+md-viewer rendered only `$...$` / `$$...$$`; LaTeX/Pandoc-style `\(...\)` and
+`\[...\]` stayed literal. Delimiters are now rewritten pre-parse on an
+in-memory copy and every event range is mapped back to original coordinates,
+so search highlighting and selection offsets stay exact.
+
+## Features
+
+- [x] Paired `\(...\)` → `$...$`, `\[...\]` → `$$...$$` in prose contexts
+- [x] Protected: inline code, fenced + indented code blocks, raw HTML
+- [x] Pairing restricted to a single paragraph/heading/table block
+- [x] Backslash-parity escape handling (`\\(` stays literal)
+- [x] Unmatched/mismatched delimiters stay literal (mismatched closer ignored like stray bracket)
+- [x] `$...$` behavior untouched; currency filter still applies downstream
+- [x] Source files never modified; CRLF preserved
+- [x] 15 unit tests covering all acceptance cases; E2E screenshot verified
+
+## Key Discoveries
+
+### pulldown-cmark strips the backslash before you can look at it
+
+CommonMark treats `\(` as an escaped paren, so by the time events exist the
+delimiter is indistinguishable from prose punctuation — post-parse rewriting
+is impossible. The reporter's prototype (raw-source scanner) was the right
+shape; the missing piece was keeping byte ranges valid.
+
+### Range remapping instead of equal-length tricks
+
+`$` is shorter than `\(`, so naive splicing shifts every later offset.
+Instead each replacement records a checkpoint `(norm_pos, delta)`; remapping
+a parsed range is two binary searches. The math event for `\(x\)` maps back
+to exactly the full `\(...\)` span, so slices round-trip.
+
+### Contexts come free from a second parse
+
+Rather than hand-scanning for code fences/HTML, parse the ORIGINAL text once
+with plain options and use its event ranges: Code/Html/InlineHtml events and
+CodeBlock containers become protected ranges; Paragraph/Heading/Table
+containers bound pairing. Nested-context correctness falls out of the real
+parser — no duplicated CommonMark logic.
+
+### Both parse sites must transform identically
+
+The split-points bootstrap re-parses independently (devlog 027 divergence:
+cache events vs re-parsed stream must match or viewport-skip panics). Both
+sites now route through `parse_events()`.
+
+## Future Improvements
+
+- Expose an option to disable LaTeX delimiters if a document uses them as literal text heavily.
+- Upstream: a pulldown-cmark option for these delimiters would remove the rewrite layer entirely.


### PR DESCRIPTION
## Summary

- LaTeX/Pandoc-style `\(...\)` (inline) and `\[...\]` (display) now render as math; previously only $...$ / $$...$$ worked
- implemented pre-parse on an in-memory copy (source files untouched): pulldown-cmark applies CommonMark backslash escapes, so the delimiters cannot be detected post-parse
- a plain parse of the original marks protected contexts (inline code, fenced/indented code blocks, raw HTML) and pairing scopes (paragraph/heading/table); prose is scanned for paired unescaped delimiters with backslash-parity escape handling
- every event range is remapped back to original coordinates — search highlighting and selection offsets stay exact
- both parse sites route through the same transformation, keeping the cache and split-point streams identical (devlog 027 divergence guard)

Closes #60

## Testing

- 15 new unit tests in `latex_delimiters.rs` covering all acceptance cases from the issue: inline/display/mixed/escaped/unmatched/mismatched, inline-code/fenced/indented/html protection, cross-paragraph non-pairing, CRLF, range mapping, fast path when nothing converts
- vendored crate: 37 lib tests pass; app: 47 tests; clippy -D warnings + fmt clean (both workspaces)
- E2E on Xvfb: the issue's example document renders \\(P_B,P_A\\), the display block, inline \\(E=mc^2\\); escaped \\\\(...\\\\ stays literal, unmatched openers literal, code fences untouched