### PR TITLE
Release v0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to markdown-viewer will be documented in this file.
 
+## [0.1.17] - 2026-08-22
+
+### Features
+
+- **LaTeX `\(...\)` and `\[...\]` math delimiters now render (#60, PR #73).** Markdown written in LaTeX/Pandoc style previously stayed literal; paired delimiters are converted on an in-memory copy before parsing and every event range is mapped back to the original text, so search highlighting stays exact. Inline code, fenced and indented code blocks, and raw HTML are never converted; escaped (`\\(`) and unmatched delimiters stay literal.
+
+### Bug Fixes
+
+- **GNOME dock icon matches the running window (#62, PR #72).** The window never reported a Wayland `app_id`, so GNOME could not associate it with the pinned `.desktop` entry and showed a second generic icon. The app now sets `app_id: md-viewer`, matching the shipped desktop file's `StartupWMClass`.
+
 ## [0.1.16] - 2026-08-22
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend_extended"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_extended"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "egui",
  "egui_commonmark_backend_extended",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "md-viewer"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "clap",
  "eframe",
@@ -7962,4 +7962,4 @@ dependencies = [
 
 [[patch.unused]]
 name = "egui_commonmark_macros_extended"
-version = "0.26.0"
+version = "0.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-viewer"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 rust-version = "1.80"
 description = "Fast, lightweight markdown viewer for Linux with tabs, file explorer, and live reload"
@@ -35,7 +35,7 @@ egui = { version = "0.33", features = ["accesskit"] }
 # egui-mcp-bridge = { path = "/home/ahmet/dev/mcp/egui-mcp/crates/egui-mcp-bridge", optional = true }
 
 # Markdown rendering with syntax highlighting (fork with typography support)
-egui_commonmark_extended = { version = "0.26.0", features = [
+egui_commonmark_extended = { version = "0.27.0", features = [
     "better_syntax_highlighting",
     "svg",
     "svg_text",
@@ -89,6 +89,6 @@ lto = "thin"
 codegen-units = 4
 
 [patch.crates-io]
-egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark", version = "0.26.0" }
-egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend", version = "0.26.0" }
-egui_commonmark_macros_extended = { path = "crates/egui_commonmark/egui_commonmark_macros", version = "0.26.0" }
+egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark", version = "0.27.0" }
+egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend", version = "0.27.0" }
+egui_commonmark_macros_extended = { path = "crates/egui_commonmark/egui_commonmark_macros", version = "0.27.0" }

--- a/crates/egui_commonmark/CHANGELOG.md
+++ b/crates/egui_commonmark/CHANGELOG.md
@@ -1,13 +1,15 @@
 # egui_commonmark changelog
 
-## Unreleased
+## 0.27.0
 
 ### Added
 - `table_max_width` option: markdown/HTML tables may exceed the prose reading column and span the full content pane (#64).
 - MIME-aware SVG loader for SVG URLs without a `.svg` extension; image-only links keep the wrapped-row cursor (#63).
+- LaTeX-style `\(...\)` / `\[...\]` math delimiters are rewritten pre-parse with full offset remapping, so they render like `$...$` / `$$...$$` (#60).
 
 ### Fixed
 - amsmath `\operatorname{}` / `\operatorname*{}` render as named operators (#58).
+- Image-only links no longer reset the wrapped-row cursor, so linked badges stop overlapping (#63).
 
 ## 0.22.0 - 2025-10-09
 

--- a/crates/egui_commonmark/Cargo.lock
+++ b/crates/egui_commonmark/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend_extended"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "data-url",
  "egui",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_extended"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "document-features",
  "eframe",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_macros_extended"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "document-features",
  "egui",

--- a/crates/egui_commonmark/Cargo.toml
+++ b/crates/egui_commonmark/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.76"
-version = "0.26.0"
+version = "0.27.0"
 repository = "https://github.com/aydiler/md-viewer"
 
 [workspace.dependencies]
@@ -21,8 +21,8 @@ egui = { version = "0.33", default-features = false }
 
 # Runtime lookup for recognized GitHub/gemoji shortcode names.
 emojis = "0.9.0"
-egui_commonmark_backend_extended = { version = "0.26.0", path = "egui_commonmark_backend", default-features = false }
-egui_commonmark_macros_extended = { version = "0.26.0", path = "egui_commonmark_macros", default-features = false }
+egui_commonmark_backend_extended = { version = "0.27.0", path = "egui_commonmark_backend", default-features = false }
+egui_commonmark_macros_extended = { version = "0.27.0", path = "egui_commonmark_macros", default-features = false }
 
 # To add features to documentation
 document-features = { version = "0.2" }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: md-viewer
 base: core22
-version: '0.1.16'
+version: '0.1.17'
 summary: Fast, lightweight markdown viewer for Linux
 description: |
   A fast, lightweight markdown viewer for Linux built with Rust and egui.


### PR DESCRIPTION
Version bump + changelog for v0.1.17: #60/#73 LaTeX \\(…\\)/\\[…\\] math delimiters, #62/#72 Wayland app_id for GNOME dock matching. Vendored fork bumped to 0.27.0 (unpublished) per the release guard.