### PR TITLE
fix(ui): describe tab action as opening a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A fast, lightweight markdown viewer for Linux built with Rust and egui. Designed
 
 | Shortcut | Action |
 |----------|--------|
-| Ctrl+T | New tab (open file dialog) |
+| Ctrl+T | Open file in new tab |
 | Ctrl+W | Close current tab |
 | Ctrl+Tab | Next tab |
 | Ctrl+Shift+Tab | Previous tab |
@@ -110,7 +110,7 @@ A fast, lightweight markdown viewer for Linux built with Rust and egui. Designed
 
 | Shortcut | Action |
 |----------|--------|
-| Ctrl+O | Open file dialog |
+| Ctrl+O | Open file in new tab |
 | Alt+Left | Navigate back in history |
 | Alt+Right | Navigate forward in history |
 | Click link | Navigate in current tab |
@@ -235,7 +235,7 @@ md-viewer --foreground README.md
 md-viewer README.md --no-watch
 ```
 
-Run `md-viewer` with no file to start on the welcome page, then choose Open File, Open Folder, or a recent document. In the app, use File → Open File… or Ctrl+O to open a document, and File → Open Folder… to choose the file explorer root.
+Run `md-viewer` with no file to start on the welcome page, then choose Open File, Open Folder, or a recent document. Opening a file always creates or focuses its tab; use the `+` button, File → Open File in New Tab…, Ctrl+T, or Ctrl+O. Use File → Open Folder… to choose the file explorer root.
 
 When launched from a terminal, `md-viewer` detaches by default so the shell prompt is available while the window stays open. Use `--foreground` when you want terminal logs or blocking process behavior.
 

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -4,7 +4,7 @@
 
 | Shortcut | Action |
 |----------|--------|
-| Ctrl+T | New tab (open file dialog) |
+| Ctrl+T | Open file in new tab |
 | Ctrl+W | Close current tab |
 | Ctrl+Tab | Next tab |
 | Ctrl+Shift+Tab | Previous tab |
@@ -14,7 +14,7 @@
 
 | Shortcut | Action |
 |----------|--------|
-| Ctrl+O | Open file dialog |
+| Ctrl+O | Open file in new tab |
 | F5 | Toggle file watching |
 | Ctrl+Q | Quit application |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2385,12 +2385,19 @@ impl MarkdownApp {
                 ui.add_space(4.0);
             }
 
-            // New tab button
-            let new_tab_btn = ui.button("+").on_hover_text("New Tab (Ctrl+T)");
+            // Opening a file is what creates a new tab; there is no empty-tab state.
+            let new_tab_btn = ui
+                .button("+")
+                .on_hover_text("Open File in New Tab... (Ctrl+T)");
 
-            // Collect new tab button widget data for MCP
+            // Collect the open-file action for MCP.
             #[cfg(feature = "mcp")]
-            widget_data.push(("New Tab".to_string(), "button", new_tab_btn.rect, None));
+            widget_data.push((
+                "Open File in New Tab".to_string(),
+                "button",
+                new_tab_btn.rect,
+                None,
+            ));
 
             if new_tab_btn.clicked() {
                 self.open_file_dialog();
@@ -3745,7 +3752,7 @@ impl eframe::App for MarkdownApp {
                 if i.modifiers.ctrl && i.key_pressed(egui::Key::W) {
                     close_tab = true;
                 }
-                // Ctrl+T: New tab (open file dialog)
+                // Ctrl+T: Open a file in a new tab
                 if i.modifiers.ctrl && i.key_pressed(egui::Key::T) {
                     new_tab = true;
                 }
@@ -3955,7 +3962,7 @@ impl eframe::App for MarkdownApp {
             egui::MenuBar::new().ui(ui, |ui| {
                 ui.menu_button("File", |ui| {
                     if ui
-                        .add(egui::Button::new("New Tab...").shortcut_text("Ctrl+T"))
+                        .add(egui::Button::new("Open File in New Tab...").shortcut_text("Ctrl+T"))
                         .clicked()
                     {
                         self.open_file_dialog();


### PR DESCRIPTION
## Summary

- rename the plus-button action from New Tab to Open File in New Tab
- use the same wording in the File menu, MCP widget metadata, shortcut tables, and README
- clarify that opening a file creates or focuses its tab; md-viewer has no empty-tab state

No behavior changes are included.

## Testing

- application tests: 47 passed, 1 ignored
- cargo fmt --all -- --check
- git diff --check