### PR TITLE
test(math): cover commands before table delimiters

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/latex_delimiters.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/latex_delimiters.rs
@@ -306,6 +306,35 @@ mod tests {
     }
 
     #[test]
+    fn table_formula_keeps_command_before_closing_delimiter() {
+        let text = concat!(
+            "| formula |\n|---|\n",
+            r"| \(D_t+\epsilon\) |",
+            "\n",
+            r"| \(a_t/(D_t^{opp}+\epsilon)\) |",
+            "\n",
+        );
+        let formulas: Vec<_> = parse_events(text, true)
+            .into_iter()
+            .filter_map(|(event, range)| match event {
+                Event::InlineMath(tex) => Some((tex.into_string(), text[range].to_string())),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            formulas,
+            [
+                (r"D_t+\epsilon".into(), r"\(D_t+\epsilon\)".into()),
+                (
+                    r"a_t/(D_t^{opp}+\epsilon)".into(),
+                    r"\(a_t/(D_t^{opp}+\epsilon)\)".into(),
+                ),
+            ]
+        );
+    }
+
+    #[test]
     fn display_pair_across_lines_converts() {
         let text = "\\[\nr_a=1\n\\]";
         let (event, slice) =


### PR DESCRIPTION
## Summary

Add a regression for LaTeX-style inline formulas in Markdown tables when the final expression before the closing delimiter contains a command such as epsilon.

The current pre-parse delimiter implementation already handles this correctly. The test preserves both the complete math source and the exact original source range, guarding against the earlier class of one-character truncation bugs without restoring the superseded parser implementation.

## Testing

- targeted regression passed
- renderer library tests: 38 passed
- renderer wrapping tests: 12 passed
- git diff --check