### PR TITLE
fix: preserve documents and history on read errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -666,10 +666,10 @@ impl Tab {
             .unwrap_or_else(|| "file://".to_string())
     }
 
-    fn new(path: PathBuf) -> Self {
+    fn new(path: PathBuf) -> io::Result<Self> {
         // Canonicalize path for consistent comparison with watcher events
         let path = path.canonicalize().unwrap_or(path);
-        let content = fs::read_to_string(&path).unwrap_or_default();
+        let content = String::from_utf8_lossy(&fs::read(&path)?).into_owned();
         let parsed = parse_headers(&content);
         let local_links = parse_local_links(&content);
         let content_lines = content.lines().count();
@@ -680,7 +680,7 @@ impl Tab {
             cache.add_link_hook(link);
         }
 
-        Self {
+        Ok(Self {
             id: egui::Id::new(&path),
             path,
             content,
@@ -701,7 +701,7 @@ impl Tab {
             history_forward: Vec::new(),
             search_matches: Vec::new(),
             content_version: 1,
-        }
+        })
     }
 
     fn title(&self) -> String {
@@ -711,32 +711,10 @@ impl Tab {
             .unwrap_or_else(|| "Unknown".to_string())
     }
 
-    fn reload(&mut self) {
-        if !self.path.exists() {
-            return;
-        }
-
-        if let Ok(bytes) = fs::read(&self.path) {
-            let content = String::from_utf8_lossy(&bytes);
-            self.content_lines = content.lines().count();
-            self.content = content.into_owned();
-            self.cache = CommonMarkCache::default();
-            self.content_version = self.content_version.wrapping_add(1);
-            self.base_uri = Self::compute_base_uri(&self.path);
-
-            let parsed = parse_headers(&self.content);
-            self.document_title = parsed.document_title;
-            self.outline_headers = parsed.outline_headers;
-            self.collapsed_headers.clear();
-
-            self.local_links = parse_local_links(&self.content);
-            for link in &self.local_links {
-                self.cache.add_link_hook(link);
-            }
-
-            // Stale byte ranges; caller rebuilds if search bar is open
-            self.search_matches.clear();
-        }
+    fn reload(&mut self) -> io::Result<()> {
+        let content = String::from_utf8_lossy(&fs::read(&self.path)?).into_owned();
+        self.apply_loaded_content(self.path.clone(), content, false);
+        Ok(())
     }
 
     /// Rebuild `search_matches` for `query`. Empty query clears matches.
@@ -744,45 +722,46 @@ impl Tab {
         self.search_matches = find_matches(&self.content, query);
     }
 
-    fn load_file(&mut self, path: &PathBuf) {
-        if !path.exists() {
-            return;
-        }
-
-        if let Ok(bytes) = fs::read(path) {
-            let content = String::from_utf8_lossy(&bytes);
-            self.content_lines = content.lines().count();
-            self.content = content.into_owned();
-            self.path = path.clone();
-            self.id = egui::Id::new(path);
-            self.cache = CommonMarkCache::default();
-            self.content_version = self.content_version.wrapping_add(1);
-            self.scroll_offset = 0.0;
-            self.pending_scroll_offset = None;
-            self.base_uri = Self::compute_base_uri(&self.path);
-
-            let parsed = parse_headers(&self.content);
-            self.document_title = parsed.document_title;
-            self.outline_headers = parsed.outline_headers;
-            self.collapsed_headers.clear();
-
-            self.local_links = parse_local_links(&self.content);
-            for link in &self.local_links {
-                self.cache.add_link_hook(link);
-            }
-
-            // Stale byte ranges; caller rebuilds if search bar is open
-            self.search_matches.clear();
-        }
+    fn load_file(&mut self, path: &Path) -> io::Result<()> {
+        let content = String::from_utf8_lossy(&fs::read(path)?).into_owned();
+        self.apply_loaded_content(path.to_path_buf(), content, true);
+        Ok(())
     }
 
-    fn navigate_to_link(&mut self, link: &str) {
+    fn apply_loaded_content(&mut self, path: PathBuf, content: String, reset_scroll: bool) {
+        self.content_lines = content.lines().count();
+        self.content = content;
+        self.path = path;
+        self.id = egui::Id::new(&self.path);
+        self.cache = CommonMarkCache::default();
+        self.content_version = self.content_version.wrapping_add(1);
+        if reset_scroll {
+            self.scroll_offset = 0.0;
+            self.pending_scroll_offset = None;
+        }
+        self.base_uri = Self::compute_base_uri(&self.path);
+
+        let parsed = parse_headers(&self.content);
+        self.document_title = parsed.document_title;
+        self.outline_headers = parsed.outline_headers;
+        self.collapsed_headers.clear();
+
+        self.local_links = parse_local_links(&self.content);
+        for link in &self.local_links {
+            self.cache.add_link_hook(link);
+        }
+
+        // Stale byte ranges; caller rebuilds if search bar is open.
+        self.search_matches.clear();
+    }
+
+    fn navigate_to_link(&mut self, link: &str) -> io::Result<bool> {
         if link.starts_with('#') {
-            return;
+            return Ok(false);
         }
 
         let Some(current_dir) = self.path.parent() else {
-            return;
+            return Ok(false);
         };
 
         let path_part = link.split('#').next().unwrap_or(link);
@@ -790,12 +769,17 @@ impl Tab {
 
         let target_path = match target_path.canonicalize() {
             Ok(p) => p,
-            Err(_) => return,
+            Err(_) => return Ok(false),
         };
 
-        self.history_back.push(self.path.clone());
+        if target_path == self.path || !target_path.is_file() {
+            return Ok(false);
+        }
+        let previous_path = self.path.clone();
+        self.load_file(&target_path)?;
+        self.history_back.push(previous_path);
         self.history_forward.clear();
-        self.load_file(&target_path);
+        Ok(true)
     }
 
     fn check_link_hooks(&self) -> Option<String> {
@@ -815,18 +799,26 @@ impl Tab {
         !self.history_forward.is_empty()
     }
 
-    fn navigate_back(&mut self) {
-        if let Some(prev_path) = self.history_back.pop() {
-            self.history_forward.push(self.path.clone());
-            self.load_file(&prev_path);
-        }
+    fn navigate_back(&mut self) -> io::Result<bool> {
+        let Some(prev_path) = self.history_back.last().cloned() else {
+            return Ok(false);
+        };
+        let current_path = self.path.clone();
+        self.load_file(&prev_path)?;
+        self.history_back.pop();
+        self.history_forward.push(current_path);
+        Ok(true)
     }
 
-    fn navigate_forward(&mut self) {
-        if let Some(next_path) = self.history_forward.pop() {
-            self.history_back.push(self.path.clone());
-            self.load_file(&next_path);
-        }
+    fn navigate_forward(&mut self) -> io::Result<bool> {
+        let Some(next_path) = self.history_forward.last().cloned() else {
+            return Ok(false);
+        };
+        let current_path = self.path.clone();
+        self.load_file(&next_path)?;
+        self.history_forward.pop();
+        self.history_back.push(current_path);
+        Ok(true)
     }
 
     fn resolve_link(&self, link: &str) -> Option<PathBuf> {
@@ -1446,15 +1438,28 @@ impl MarkdownApp {
         let show_explorer = persisted.show_explorer.unwrap_or(true);
 
         // Determine initial tabs
+        let mut startup_error = None;
         let initial_tabs: Vec<Tab> = if let Some(ref path) = file {
             // CLI argument takes priority
-            vec![Tab::new(path.clone())]
+            match Tab::new(path.clone()) {
+                Ok(tab) => vec![tab],
+                Err(error) => {
+                    startup_error = Some(format!("Unable to open {}: {error}", path.display()));
+                    Vec::new()
+                }
+            }
         } else if let Some(paths) = persisted.open_tabs {
             // Restore previous session tabs
             paths
                 .into_iter()
                 .filter(|p| p.exists())
-                .map(Tab::new)
+                .filter_map(|path| match Tab::new(path.clone()) {
+                    Ok(tab) => Some(tab),
+                    Err(error) => {
+                        log::warn!("Unable to restore {}: {error}", path.display());
+                        None
+                    }
+                })
                 .collect()
         } else {
             // No file and no saved session → start empty (welcome page).
@@ -1519,7 +1524,7 @@ impl MarkdownApp {
             show_outline,
             full_width_content,
             watch_enabled: watch,
-            error_message: None,
+            error_message: startup_error,
             is_dragging: false,
             watcher: None,
             watcher_rx: None,
@@ -1608,7 +1613,6 @@ impl MarkdownApp {
     fn open_in_new_tab(&mut self, path: PathBuf) {
         // Canonicalize for consistent comparison with existing tabs
         let path = path.canonicalize().unwrap_or(path);
-        self.record_recent(&path);
         // Check if already open
         if let Some(idx) = self.tabs.iter().position(|t| t.path == path) {
             self.active_tab = idx;
@@ -1617,7 +1621,14 @@ impl MarkdownApp {
         }
 
         // Add new tab
-        let tab = Tab::new(path);
+        let tab = match Tab::new(path.clone()) {
+            Ok(tab) => tab,
+            Err(error) => {
+                self.error_message = Some(format!("Unable to open {}: {error}", path.display()));
+                return;
+            }
+        };
+        self.record_recent(&path);
         self.tabs.push(tab);
         self.active_tab = self.tabs.len() - 1;
         self.title_dirty = true;
@@ -1626,6 +1637,19 @@ impl MarkdownApp {
         // Update watcher if enabled
         if self.watch_enabled {
             self.update_watched_paths();
+        }
+    }
+
+    fn navigate_active_history(&mut self, go_back: bool) {
+        let result = self.tabs.get_mut(self.active_tab).map(|tab| {
+            if go_back {
+                tab.navigate_back()
+            } else {
+                tab.navigate_forward()
+            }
+        });
+        if let Some(Err(error)) = result {
+            self.error_message = Some(format!("Unable to navigate history: {error}"));
         }
     }
 
@@ -2059,7 +2083,11 @@ impl MarkdownApp {
             for tab in &mut self.tabs {
                 if tab.path == path {
                     log::info!("Reloading tab: {:?}", path);
-                    tab.reload();
+                    if let Err(error) = tab.reload() {
+                        self.error_message =
+                            Some(format!("Unable to reload {}: {error}", path.display()));
+                        continue;
+                    }
                     if Some(&tab.path) == active_path.as_ref() {
                         active_was_reloaded = true;
                     }
@@ -2777,6 +2805,7 @@ impl MarkdownApp {
 
     fn render_tab_content(&mut self, ui: &mut egui::Ui, ctrl_held: bool) -> Option<PathBuf> {
         let mut open_in_new_tab: Option<PathBuf> = None;
+        let mut navigation_error = None;
 
         // Snapshot search state before taking a mutable borrow on the active tab
         let search_is_open = self.search.is_open;
@@ -2945,8 +2974,14 @@ impl MarkdownApp {
                 }
             } else {
                 // Navigate in current tab
-                tab.navigate_to_link(&clicked_link);
+                if let Err(error) = tab.navigate_to_link(&clicked_link) {
+                    navigation_error = Some(format!("Unable to open {clicked_link}: {error}"));
+                }
             }
+        }
+
+        if let Some(error) = navigation_error {
+            self.error_message = Some(error);
         }
 
         open_in_new_tab
@@ -3891,14 +3926,10 @@ impl eframe::App for MarkdownApp {
             self.focus_tab(idx);
         }
         if go_back {
-            if let Some(tab) = self.tabs.get_mut(self.active_tab) {
-                tab.navigate_back();
-            }
+            self.navigate_active_history(true);
         }
         if go_forward {
-            if let Some(tab) = self.tabs.get_mut(self.active_tab) {
-                tab.navigate_forward();
-            }
+            self.navigate_active_history(false);
         }
 
         // Search bar actions (Ctrl+F open, Enter/Shift+Enter cycle, Esc close)
@@ -4029,9 +4060,7 @@ impl eframe::App for MarkdownApp {
                         .add_enabled(can_back, egui::Button::new("← Back").shortcut_text("Alt+←"))
                         .clicked()
                     {
-                        if let Some(tab) = self.tabs.get_mut(self.active_tab) {
-                            tab.navigate_back();
-                        }
+                        self.navigate_active_history(true);
                         ui.close();
                     }
 
@@ -4047,9 +4076,7 @@ impl eframe::App for MarkdownApp {
                         )
                         .clicked()
                     {
-                        if let Some(tab) = self.tabs.get_mut(self.active_tab) {
-                            tab.navigate_forward();
-                        }
+                        self.navigate_active_history(false);
                         ui.close();
                     }
                 });
@@ -4245,14 +4272,10 @@ impl eframe::App for MarkdownApp {
 
         // Handle navigation button clicks (must be after menu bar UI)
         if go_back {
-            if let Some(tab) = self.tabs.get_mut(self.active_tab) {
-                tab.navigate_back();
-            }
+            self.navigate_active_history(true);
         }
         if go_forward {
-            if let Some(tab) = self.tabs.get_mut(self.active_tab) {
-                tab.navigate_forward();
-            }
+            self.navigate_active_history(false);
         }
 
         // Show error message if any
@@ -4679,6 +4702,43 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].byte_start, 7);
         assert_eq!(matches[0].byte_end, 11);
+    }
+
+    #[test]
+    fn tab_history_changes_only_after_successful_loads() {
+        let root = std::env::temp_dir().join(format!(
+            "md-viewer-history-safety-{}-{}",
+            std::process::id(),
+            now_epoch_secs()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let first = root.join("first.md");
+        let second = root.join("second.md");
+        fs::write(&first, "# First").unwrap();
+        fs::write(&second, "# Second").unwrap();
+
+        let mut tab = Tab::new(first.clone()).unwrap();
+        assert!(tab.navigate_to_link("second.md").unwrap());
+        assert_eq!(tab.path, second.canonicalize().unwrap());
+        assert!(tab.can_go_back());
+
+        fs::remove_file(&first).unwrap();
+        assert!(tab.navigate_back().is_err());
+        assert_eq!(tab.path, second.canonicalize().unwrap());
+        assert!(tab.can_go_back());
+        assert!(!tab.can_go_forward());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn unreadable_new_tab_returns_an_error() {
+        let missing = std::env::temp_dir().join(format!(
+            "md-viewer-missing-{}-{}.md",
+            std::process::id(),
+            now_epoch_secs()
+        ));
+        assert!(Tab::new(missing).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- return file read failures instead of silently opening an empty document
- apply loaded content only after a successful read
- mutate back/forward history only after navigation succeeds
- surface startup, open, reload, and navigation errors in the existing error bar

## Tests
- unreadable files fail to create a tab
- failed history loads preserve the current document and both history stacks
- 
running 50 tests
test system_fonts::tests::installed_fonts_cover_cjk_in_regular_and_strong_text ... ignored, requires an installed CJK font; run explicitly for local verification
test system_fonts::tests::cjk_specs_keep_region_specific_glyph_variants_separate ... ok
test system_fonts::tests::bold_query_selects_the_bold_face ... ok
test system_fonts::tests::cjk_priority_follows_the_system_locale ... ok
test system_fonts::tests::default_latin_precedes_script_bold_without_primary_system_sans ... ok
test tests::child_args_insert_marker_before_double_dash ... ok
test tests::child_args_preserve_user_args_and_append_marker ... ok
test system_fonts::tests::only_weight_700_or_higher_counts_as_bold ... ok
test system_fonts::tests::matching_primary_regular_and_bold_stay_together ... ok
test system_fonts::tests::font_family_candidates_are_prioritized ... ok
test system_fonts::tests::resolved_font_preserves_collection_face_index ... ok
test system_fonts::tests::primary_system_sans_precedes_locale_specific_cjk ... ok
test system_fonts::tests::empty_database_keeps_egui_fallbacks_for_strong_text ... ok
test system_fonts::tests::font_without_required_glyphs_is_skipped ... ok
test tests::capped_content_width_uses_optimal_width ... ok
test system_fonts::tests::script_bold_order_follows_loaded_regular_order ... ok
test tests::find_matches_empty_content_returns_none ... ok
test tests::find_matches_empty_query_returns_none ... ok
test tests::default_terminal_launch_detaches ... ok
test tests::full_width_content_uses_available_width ... ok
test tests::foreground_flag_disables_detach ... ok
test tests::keyboard_scroll_target_clamps_to_document_bounds ... ok
test tests::push_recent_caps_length_keeping_newest ... ok
test tests::keyboard_scroll_target_handles_short_documents ... ok
test tests::keyboard_scroll_target_moves_by_line_step ... ok
test tests::keyboard_scroll_target_moves_by_page_step ... ok
test tests::hidden_no_detach_marker_disables_detach ... ok
test tests::relative_time_buckets ... ok
test tests::push_recent_dedupes_and_moves_to_front ... ok
test tests::hidden_no_detach_marker_is_not_in_help ... ok
test tests::wayland_socket_path_mirrors_libwayland_lookup ... ok
test tests::non_terminal_launch_does_not_detach ... ok
test tests::unreadable_new_tab_returns_an_error ... ok
test tests::find_matches_case_insensitive_ascii ... ok
test tests::literal_unicode_emoji_still_matches_raw_source ... ok
test tests::find_matches_single_ascii ... ok
test tests::find_matches_line_numbers_one_based ... ok
test tests::find_matches_preserves_byte_offsets_with_utf8 ... ok
test tests::find_matches_skips_cross_newline_matches ... ok
test tests::rendered_emoji_does_not_match_shortcode_only_source ... ok
test tests::shortcode_search_range_uses_raw_source_bytes ... ok
test tests::find_matches_overlapping_uses_match_indices_semantics ... ok
test tests::find_matches_multiple_per_line ... ok
test tests::find_matches_skips_image_url ... ok
test tests::find_matches_skips_link_url_keeps_link_text ... ok
test tests::find_matches_skips_image_alt_text ... ok
test tests::find_matches_multiple_alt_text_images ... ok
test tests::shortcode_heading_parser_keeps_raw_identity_and_duplicate_index ... ok
test tests::unknown_shortcode_heading_stays_raw ... ok
test tests::tab_history_changes_only_after_successful_loads ... ok

test result: ok. 49 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.08s (49 passed, 1 ignored)