### PR TITLE
fix: bound MIME SVG caching and defer font loading

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
@@ -4,7 +4,11 @@
 //! loader currently accepts only URIs ending in `.svg`. Dynamic image URLs
 //! commonly omit that suffix while returning `image/svg+xml` correctly.
 
-use std::{collections::HashMap, mem::size_of, sync::Arc};
+use std::{
+    collections::HashMap,
+    mem::size_of,
+    sync::{Arc, OnceLock},
+};
 
 use egui::{
     load::{BytesPoll, ImageLoadResult, ImageLoader, ImagePoll, LoadError, SizeHint},
@@ -16,7 +20,7 @@ use resvg::usvg::fontdb::{Database, Family};
 
 struct MimeSvgLoader {
     cache: Mutex<SvgCache>,
-    options: resvg::usvg::Options<'static>,
+    options: OnceLock<resvg::usvg::Options<'static>>,
 }
 
 struct SvgCacheEntry {
@@ -65,19 +69,23 @@ impl MimeSvgLoader {
 
 impl Default for MimeSvgLoader {
     fn default() -> Self {
-        let options = resvg::usvg::Options::default();
-        #[cfg(feature = "svg_text")]
-        let options = {
-            let mut options = options;
-            options.fontdb_mut().load_system_fonts();
-            repair_sans_serif_family(options.fontdb_mut());
-            options
-        };
         Self {
             cache: Mutex::default(),
-            options,
+            options: OnceLock::new(),
         }
     }
+}
+
+fn svg_options() -> resvg::usvg::Options<'static> {
+    let options = resvg::usvg::Options::default();
+    #[cfg(feature = "svg_text")]
+    let options = {
+        let mut options = options;
+        options.fontdb_mut().load_system_fonts();
+        repair_sans_serif_family(options.fontdb_mut());
+        options
+    };
+    options
 }
 
 /// fontdb may map the generic sans-serif family to a font that is not installed.
@@ -170,8 +178,9 @@ impl ImageLoader for MimeSvgLoader {
         match ctx.try_load_bytes(uri)? {
             BytesPoll::Pending { size } => Ok(ImagePoll::Pending { size }),
             BytesPoll::Ready { bytes, mime, .. } if mime.as_deref().is_some_and(is_svg_mime) => {
+                let options = self.options.get_or_init(svg_options);
                 let result =
-                    egui_extras::image::load_svg_bytes_with_size(&bytes, size_hint, &self.options)
+                    egui_extras::image::load_svg_bytes_with_size(&bytes, size_hint, options)
                         .map(Arc::new);
                 if svg_result_bytes(&result) <= MAX_SVG_CACHE_BYTES {
                     let mut cache = self.cache.lock();
@@ -265,7 +274,7 @@ mod tests {
     fn forget_removes_every_cached_size_for_uri() {
         let loader = MimeSvgLoader {
             cache: Default::default(),
-            options: resvg::usvg::Options::default(),
+            options: resvg::usvg::Options::default().into(),
         };
         let image = Arc::new(ColorImage::filled([1, 1], Color32::WHITE));
 
@@ -299,6 +308,13 @@ mod tests {
             .entries
             .keys()
             .all(|(uri, _)| uri == "https://example.com/other"));
+    }
+
+    #[test]
+    fn svg_options_are_initialized_lazily() {
+        let loader = MimeSvgLoader::default();
+
+        assert!(loader.options.get().is_none());
     }
 
     #[test]

--- a/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
@@ -15,8 +15,48 @@ use egui::{
 use resvg::usvg::fontdb::{Database, Family};
 
 struct MimeSvgLoader {
-    cache: Mutex<HashMap<(String, SizeHint), Result<Arc<ColorImage>, String>>>,
+    cache: Mutex<SvgCache>,
     options: resvg::usvg::Options<'static>,
+}
+
+struct SvgCacheEntry {
+    result: Result<Arc<ColorImage>, String>,
+    last_used: u64,
+}
+
+#[derive(Default)]
+struct SvgCache {
+    entries: HashMap<(String, SizeHint), SvgCacheEntry>,
+    use_tick: u64,
+}
+
+const MAX_SVG_CACHE_BYTES: usize = 64 * 1024 * 1024;
+
+fn svg_result_bytes(result: &Result<Arc<ColorImage>, String>) -> usize {
+    match result {
+        Ok(image) => image.pixels.len() * size_of::<egui::Color32>(),
+        Err(error) => error.len(),
+    }
+}
+
+fn trim_svg_cache(cache: &mut SvgCache, max_bytes: usize) {
+    while cache
+        .entries
+        .values()
+        .map(|entry| svg_result_bytes(&entry.result))
+        .sum::<usize>()
+        > max_bytes
+    {
+        let Some(victim) = cache
+            .entries
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_used)
+            .map(|(key, _)| key.clone())
+        else {
+            break;
+        };
+        cache.entries.remove(&victim);
+    }
 }
 
 impl MimeSvgLoader {
@@ -112,7 +152,16 @@ impl ImageLoader for MimeSvgLoader {
         }
 
         let key = (uri.to_owned(), size_hint);
-        if let Some(result) = self.cache.lock().get(&key).cloned() {
+        let cached = {
+            let mut cache = self.cache.lock();
+            cache.use_tick = cache.use_tick.wrapping_add(1);
+            let tick = cache.use_tick;
+            cache.entries.get_mut(&key).map(|entry| {
+                entry.last_used = tick;
+                entry.result.clone()
+            })
+        };
+        if let Some(result) = cached {
             return result
                 .map(|image| ImagePoll::Ready { image })
                 .map_err(LoadError::Loading);
@@ -124,7 +173,19 @@ impl ImageLoader for MimeSvgLoader {
                 let result =
                     egui_extras::image::load_svg_bytes_with_size(&bytes, size_hint, &self.options)
                         .map(Arc::new);
-                self.cache.lock().insert(key, result.clone());
+                if svg_result_bytes(&result) <= MAX_SVG_CACHE_BYTES {
+                    let mut cache = self.cache.lock();
+                    cache.use_tick = cache.use_tick.wrapping_add(1);
+                    let tick = cache.use_tick;
+                    cache.entries.insert(
+                        key,
+                        SvgCacheEntry {
+                            result: result.clone(),
+                            last_used: tick,
+                        },
+                    );
+                    trim_svg_cache(&mut cache, MAX_SVG_CACHE_BYTES);
+                }
                 result
                     .map(|image| ImagePoll::Ready { image })
                     .map_err(LoadError::Loading)
@@ -136,21 +197,20 @@ impl ImageLoader for MimeSvgLoader {
     fn forget(&self, uri: &str) {
         self.cache
             .lock()
+            .entries
             .retain(|(cached_uri, _), _| cached_uri != uri);
     }
 
     fn forget_all(&self) {
-        self.cache.lock().clear();
+        self.cache.lock().entries.clear();
     }
 
     fn byte_size(&self) -> usize {
         self.cache
             .lock()
+            .entries
             .values()
-            .map(|result| match result {
-                Ok(image) => image.pixels.len() * size_of::<egui::Color32>(),
-                Err(error) => error.len(),
-            })
+            .map(|entry| svg_result_bytes(&entry.result))
             .sum()
     }
 }
@@ -180,7 +240,7 @@ mod tests {
 
     #[cfg(feature = "svg_text")]
     use super::parse_fontconfig_family;
-    use super::{is_svg_mime, MimeSvgLoader};
+    use super::{is_svg_mime, trim_svg_cache, MimeSvgLoader, SvgCacheEntry};
 
     #[test]
     fn recognizes_svg_mime_with_optional_parameters() {
@@ -209,25 +269,58 @@ mod tests {
         };
         let image = Arc::new(ColorImage::filled([1, 1], Color32::WHITE));
 
-        loader.cache.lock().insert(
+        loader.cache.lock().entries.insert(
             ("https://example.com/badge".to_owned(), SizeHint::Width(10)),
-            Ok(image.clone()),
+            SvgCacheEntry {
+                result: Ok(image.clone()),
+                last_used: 1,
+            },
         );
-        loader.cache.lock().insert(
+        loader.cache.lock().entries.insert(
             ("https://example.com/badge".to_owned(), SizeHint::Width(20)),
-            Ok(image.clone()),
+            SvgCacheEntry {
+                result: Ok(image.clone()),
+                last_used: 2,
+            },
         );
-        loader.cache.lock().insert(
+        loader.cache.lock().entries.insert(
             ("https://example.com/other".to_owned(), SizeHint::Width(10)),
-            Ok(image),
+            SvgCacheEntry {
+                result: Ok(image),
+                last_used: 3,
+            },
         );
 
         loader.forget("https://example.com/badge");
 
         let cache = loader.cache.lock();
-        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.entries.len(), 1);
         assert!(cache
+            .entries
             .keys()
             .all(|(uri, _)| uri == "https://example.com/other"));
+    }
+
+    #[test]
+    fn cache_limit_evicts_least_recently_used_entries() {
+        let loader = MimeSvgLoader::default();
+        let image = Arc::new(ColorImage::filled([2, 1], Color32::WHITE));
+        let mut cache = loader.cache.lock();
+        for (uri, last_used) in [("old", 1), ("recent", 3), ("middle", 2)] {
+            cache.entries.insert(
+                (uri.to_owned(), SizeHint::Width(10)),
+                SvgCacheEntry {
+                    result: Ok(image.clone()),
+                    last_used,
+                },
+            );
+        }
+
+        trim_svg_cache(&mut cache, 16);
+
+        assert_eq!(cache.entries.len(), 2);
+        assert!(!cache
+            .entries
+            .contains_key(&("old".to_owned(), SizeHint::Width(10))));
     }
 }


### PR DESCRIPTION
## Summary
- cap cached MIME-detected SVG rasters at 64 MiB
- evict least-recently-used entries when the budget is exceeded
- avoid retaining a single raster larger than the cache budget while still rendering it
- initialize SVG options and scan system fonts only when the first MIME SVG is rendered
- keep forget, forget_all, and byte_size behavior intact

The lazy initialization belongs in this PR because both changes govern the lifetime and resource cost of the same MIME SVG loader. Keeping it here avoids a dependent follow-up PR and uses standard-library OnceLock without another synchronization layer.

## Tests
- added LRU eviction and lazy-initialization regression tests
- cargo +1.89.0 test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --features svg,svg_text mime_svg_loader (5 passed)