### PR TITLE
build: align MSRV with Typst requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "md-viewer"
 version = "0.1.17"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.89"
 description = "Fast, lightweight markdown viewer for Linux with tabs, file explorer, and live reload"
 license = "MIT"
 repository = "https://github.com/aydiler/md-viewer"

--- a/crates/egui_commonmark/Cargo.toml
+++ b/crates/egui_commonmark/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.89"
 version = "0.27.0"
 repository = "https://github.com/aydiler/md-viewer"
 

--- a/crates/egui_commonmark/rust-toolchain
+++ b/crates/egui_commonmark/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- set the application MSRV to Rust 1.89
- set the vendored renderer workspace MSRV to Rust 1.89
- update its pinned development toolchain from 1.88 to 1.89

The enabled Typst 0.14.2 dependency graph requires Rust 1.89, so the previous 1.80/1.76 declarations and 1.88 toolchain were no longer buildable contracts.

## Verification
- `cargo +1.88.0 check --locked` fails with Typst packages requiring Rust 1.89
- `cargo +1.89.0 check --locked`
- `cargo +1.89.0 check --locked --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_backend_extended --all-features`
