### PR TITLE
ci: cover the vendored renderer workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,44 @@ jobs:
       - run: cargo build --release
       - run: cargo test
 
+  renderer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      RENDERER_FEATURES: better_syntax_highlighting,svg,svg_text,load-images,fetch,mermaid,math,macros
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang pkg-config libxcb1-dev libxcb-render0-dev \
+            libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev \
+            libgtk-3-dev libfontconfig1-dev libdbus-1-dev
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates/egui_commonmark -> target
+
+      - name: Lint renderer crates
+        run: |
+          cargo clippy --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --all-targets --features "$RENDERER_FEATURES"
+          cargo clippy --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_backend_extended --all-targets --all-features
+          cargo clippy --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_macros_extended --all-targets
+
+      - name: Test renderer crates
+        run: |
+          cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --features "$RENDERER_FEATURES"
+          cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_backend_extended --all-features
+          cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_macros_extended
+
   version-sync:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/crates/egui_commonmark/egui_commonmark/examples/book.rs
+++ b/crates/egui_commonmark/egui_commonmark/examples/book.rs
@@ -7,7 +7,7 @@
 //! Shows a simple way to use the crate to implement a book like view.
 
 use eframe::egui;
-use egui_commonmark::*;
+use egui_commonmark_extended::*;
 
 struct Page {
     name: String,

--- a/crates/egui_commonmark/egui_commonmark/examples/hello_world.rs
+++ b/crates/egui_commonmark/egui_commonmark/examples/hello_world.rs
@@ -5,7 +5,7 @@
 //! is system theme. `cargo r --features better_syntax_highlighting,svg,fetch -- dark`
 
 use eframe::egui;
-use egui_commonmark::*;
+use egui_commonmark_extended::*;
 
 struct App {
     cache: CommonMarkCache,

--- a/crates/egui_commonmark/egui_commonmark/examples/html.rs
+++ b/crates/egui_commonmark/egui_commonmark/examples/html.rs
@@ -2,7 +2,7 @@
 //! is light. `cargo r --example html -- dark`
 
 use eframe::egui;
-use egui_commonmark::*;
+use egui_commonmark_extended::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/crates/egui_commonmark/egui_commonmark/examples/interactive.rs
+++ b/crates/egui_commonmark/egui_commonmark/examples/interactive.rs
@@ -7,7 +7,7 @@
 //! An easy way to visualize rendered markdown interactively
 
 use eframe::egui;
-use egui_commonmark::*;
+use egui_commonmark_extended::*;
 
 struct App {
     cache: CommonMarkCache,

--- a/crates/egui_commonmark/egui_commonmark/examples/link_hooks.rs
+++ b/crates/egui_commonmark/egui_commonmark/examples/link_hooks.rs
@@ -2,7 +2,7 @@
 //! is system theme. `cargo r --example link_hooks -- dark`
 
 use eframe::egui;
-use egui_commonmark::*;
+use egui_commonmark_extended::*;
 
 struct App {
     cache: CommonMarkCache,

--- a/crates/egui_commonmark/egui_commonmark/examples/macros.rs
+++ b/crates/egui_commonmark/egui_commonmark/examples/macros.rs
@@ -5,7 +5,7 @@
 //! is system theme. `cargo r --example macro --features macros,better_syntax_highlighting -- dark`
 
 use eframe::egui;
-use egui_commonmark::*;
+use egui_commonmark_extended::*;
 
 struct App {
     cache: CommonMarkCache,

--- a/crates/egui_commonmark/egui_commonmark/examples/mixing.rs
+++ b/crates/egui_commonmark/egui_commonmark/examples/mixing.rs
@@ -10,7 +10,7 @@ macro_rules! m {
         }
         #[cfg(not(feature = "macros"))]
         {
-            egui_commonmark::CommonMarkViewer::new().show($ui, &mut $cache, $a);
+            egui_commonmark_extended::CommonMarkViewer::new().show($ui, &mut $cache, $a);
         }
         )*
     };
@@ -25,7 +25,7 @@ const WINDOW_NAME: &str = "Mixed egui and markdown (normal version)";
 // Ensure that there are no newlines that should not be present when mixing markdown
 // and egui widgets.
 fn main() -> eframe::Result<()> {
-    let mut cache = egui_commonmark::CommonMarkCache::default();
+    let mut cache = egui_commonmark_extended::CommonMarkCache::default();
 
     eframe::run_simple_native(WINDOW_NAME, Default::default(), move |ctx, _frame| {
         egui::CentralPanel::default().show(ctx, |ui| {

--- a/crates/egui_commonmark/egui_commonmark/examples/scroll.rs
+++ b/crates/egui_commonmark/egui_commonmark/examples/scroll.rs
@@ -6,7 +6,7 @@
 //! is system theme. `cargo r --example scroll --all-features dark`
 
 use eframe::egui;
-use egui_commonmark::*;
+use egui_commonmark_extended::*;
 
 struct App {
     cache: CommonMarkCache,

--- a/crates/egui_commonmark/egui_commonmark/examples/show_mut.rs
+++ b/crates/egui_commonmark/egui_commonmark/examples/show_mut.rs
@@ -2,7 +2,7 @@
 //! is light. `cargo r --example show_mut -- dark`
 
 use eframe::egui;
-use egui_commonmark::*;
+use egui_commonmark_extended::*;
 
 struct App {
     cache: CommonMarkCache,

--- a/crates/egui_commonmark/egui_commonmark/src/lib.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Example
 //!
 //! ```
-//! # use egui_commonmark::*;
+//! # use egui_commonmark_extended::*;
 //! # use egui::__run_test_ui;
 //! let markdown =
 //! r"# Hello world
@@ -47,7 +47,7 @@
 //! ## Example
 //!
 //! ```
-//! use egui_commonmark::{CommonMarkCache, commonmark};
+//! use egui_commonmark_extended::{CommonMarkCache, commonmark};
 //! # egui::__run_test_ui(|ui| {
 //! let mut cache = CommonMarkCache::default();
 //! let _response = commonmark!(ui, &mut cache, "# ATX Heading Level 1");
@@ -60,7 +60,7 @@
 //! ## Example
 //!
 //! ```rust,ignore
-//! use egui_commonmark::{CommonMarkCache, commonmark_str};
+//! use egui_commonmark_extended::{CommonMarkCache, commonmark_str};
 //! # egui::__run_test_ui(|ui| {
 //! let mut cache = CommonMarkCache::default();
 //! commonmark_str!(ui, &mut cache, "content.md");
@@ -167,7 +167,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().default_implicit_uri_scheme("https://example.org/");
     /// ```
     pub fn default_implicit_uri_scheme<S: Into<String>>(mut self, scheme: S) -> Self {
@@ -217,7 +217,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// ```
     /// # use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// let mut math_images = Rc::new(RefCell::new(HashMap::new()));
     /// CommonMarkViewer::new()
     ///     .render_math_fn(Some(&move |ui, math, inline| {
@@ -274,7 +274,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().line_height(1.5); // 150% of font size
     /// ```
     pub fn line_height(mut self, multiplier: f32) -> Self {
@@ -286,7 +286,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().line_height_px(24.0); // 24 pixels
     /// ```
     pub fn line_height_px(mut self, pixels: f32) -> Self {
@@ -300,7 +300,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().paragraph_spacing(1.5); // 150% of font size
     /// ```
     pub fn paragraph_spacing(mut self, multiplier: f32) -> Self {
@@ -312,7 +312,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().paragraph_spacing_px(24.0); // 24 pixels
     /// ```
     pub fn paragraph_spacing_px(mut self, pixels: f32) -> Self {
@@ -326,7 +326,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().heading_spacing_above(2.0); // 200% of font size
     /// ```
     pub fn heading_spacing_above(mut self, multiplier: f32) -> Self {
@@ -338,7 +338,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().heading_spacing_above_px(32.0); // 32 pixels
     /// ```
     pub fn heading_spacing_above_px(mut self, pixels: f32) -> Self {
@@ -352,7 +352,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().heading_spacing_below(0.5); // 50% of font size
     /// ```
     pub fn heading_spacing_below(mut self, multiplier: f32) -> Self {
@@ -364,7 +364,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().heading_spacing_below_px(8.0); // 8 pixels
     /// ```
     pub fn heading_spacing_below_px(mut self, pixels: f32) -> Self {
@@ -379,7 +379,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().code_line_height(1.3); // 130% of font size
     /// ```
     pub fn code_line_height(mut self, multiplier: f32) -> Self {
@@ -391,7 +391,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().code_line_height_px(18.0); // 18 pixels
     /// ```
     pub fn code_line_height_px(mut self, pixels: f32) -> Self {
@@ -410,7 +410,7 @@ impl<'f> CommonMarkViewer<'f> {
     ///
     /// # Example
     /// ```
-    /// # use egui_commonmark::CommonMarkViewer;
+    /// # use egui_commonmark_extended::CommonMarkViewer;
     /// CommonMarkViewer::new().typography_recommended();
     /// ```
     pub fn typography_recommended(mut self) -> Self {

--- a/crates/egui_commonmark/egui_commonmark_macros/src/generator.rs
+++ b/crates/egui_commonmark/egui_commonmark_macros/src/generator.rs
@@ -834,11 +834,11 @@ impl CommonMarkViewerInternal {
             stream.extend(if let Some(lang) = block.lang {
                 quote!(egui_commonmark_backend_extended::CodeBlock {
                     lang: Some(#lang.to_owned()), content: #content.to_owned()}
-                    .end(ui, #cache, &options, max_width);)
+                    .end(ui, #cache, &options, max_width, ui.next_auto_id());)
             } else {
                 quote!(egui_commonmark_backend_extended::CodeBlock {
                     lang: None, content: #content.to_owned()}
-                    .end(ui, #cache, &options, max_width);)
+                    .end(ui, #cache, &options, max_width, ui.next_auto_id());)
             });
 
             stream.extend(self.line.try_insert_end());

--- a/crates/egui_commonmark/egui_commonmark_macros/src/lib.rs
+++ b/crates/egui_commonmark/egui_commonmark_macros/src/lib.rs
@@ -145,7 +145,18 @@ pub fn commonmark_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream
         proc_macro::tracked_path::path(&path);
     }
 
-    let Ok(md) = std::fs::read_to_string(path) else {
+    let candidates = [
+        std::path::PathBuf::from(&path),
+        std::env::var_os("CARGO_MANIFEST_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_default()
+            .join(&path),
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(&path),
+    ];
+    let Some(md) = candidates
+        .iter()
+        .find_map(|candidate| std::fs::read_to_string(candidate).ok())
+    else {
         return quote_spanned!(markdown.span()=>
             compile_error!("Could not find markdown file");
         )

--- a/crates/egui_commonmark/egui_commonmark_macros/tests/pass/commonmark_str.rs
+++ b/crates/egui_commonmark/egui_commonmark_macros/tests/pass/commonmark_str.rs
@@ -8,7 +8,7 @@ fn main() {
         let _response: egui::InnerResponse<()> = commonmark_str!(
             ui,
             &mut cache,
-            "../../../../egui_commonmark_macros_extended/tests/file.md"
+            "tests/file.md"
         );
     });
 }


### PR DESCRIPTION
## Summary
- add a dedicated CI job for the nested `crates/egui_commonmark` workspace
- lint and test the renderer, backend, and macro crates with the feature sets used by md-viewer
- repair stale example and doctest imports left behind by the `*_extended` crate rename
- update macro code generation for the current code-block API and make `commonmark_str!` paths robust in trybuild/Cargo contexts

The root Cargo commands compile the path-patched renderer as a dependency, but did not run its own unit, integration, doctest, example, or proc-macro tests. Enabling that coverage exposed the stale targets fixed in the first commit.

Existing renderer warnings are reported but are not promoted to errors in this PR; warning cleanup can be reviewed separately.

## Verification
- Clippy for all three nested crates and renderer examples
- 40 renderer unit tests, 12 wrapping tests, and 16 doctests
- 14 backend unit tests and its doctest
- proc-macro trybuild suite and doctest
