### PR TITLE
fix(deps): update nested rustls-webpki lock

### DIFF
--- a/crates/egui_commonmark/Cargo.lock
+++ b/crates/egui_commonmark/Cargo.lock
@@ -4180,9 +4180,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Addresses #95.

The root lockfile already resolves `rustls-webpki` to 0.103.15, but the standalone `crates/egui_commonmark/Cargo.lock` still pinned 0.103.9. This updates that nested lockfile to 0.103.15, above the 0.103.13 patched threshold for GHSA-82j2-j2ch-gfr8 / RUSTSEC-2026-0104.

No source dependency constraint changes are needed: the existing semver range already accepts the patched release.

Validation: `cargo check --manifest-path crates/egui_commonmark/Cargo.toml --locked`.