### PR TITLE
chore: clear actionable compiler warnings

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -437,14 +437,6 @@ impl CommonMarkViewerInternal {
     }
 }
 
-fn parser_options_math(is_math_enabled: bool) -> pulldown_cmark::Options {
-    if is_math_enabled {
-        parser_options() | pulldown_cmark::Options::ENABLE_MATH
-    } else {
-        parser_options()
-    }
-}
-
 /// Hash the layout-affecting render context.
 ///
 /// `split_points` cache y-positions, which become invalid when anything that

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -1298,7 +1298,7 @@ impl CommonMarkViewerInternal {
             let mut table_scope_rect = ui.cursor();
             table_scope_rect.max.x = table_scope_rect.min.x + table_bound;
             table_scope_rect.max.y = ui.max_rect().bottom();
-            let scroll_out = ui
+            let _ = ui
                 .scope_builder(egui::UiBuilder::new().max_rect(table_scope_rect), |ui| {
                     let mut scroll_out = egui::ScrollArea::horizontal()
                         .id_salt(id.with("_scroll"))
@@ -1908,7 +1908,7 @@ impl CommonMarkViewerInternal {
                         egui::vec2(available.width() + (available.left() - left_edge), available.height()),
                     );
                     let rich_texts = std::mem::take(&mut self.current_heading_rich_texts);
-                    ui.allocate_ui_at_rect(heading_rect, |ui| {
+                    ui.scope_builder(egui::UiBuilder::new().max_rect(heading_rect), |ui| {
                         for rt in rich_texts {
                             ui.label(rt);
                         }
@@ -2130,7 +2130,7 @@ impl CommonMarkViewerInternal {
         let mut table_scope_rect = ui.cursor();
         table_scope_rect.max.x = table_scope_rect.min.x + table_bound;
         table_scope_rect.max.y = ui.max_rect().bottom();
-        let scroll_out = ui
+        let _ = ui
             .scope_builder(egui::UiBuilder::new().max_rect(table_scope_rect), |ui| {
                 let mut scroll_out = egui::ScrollArea::horizontal()
                     .id_salt(id.with("_scroll"))

--- a/crates/egui_commonmark/egui_commonmark_backend/src/elements.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/elements.rs
@@ -82,7 +82,7 @@ pub fn bullet_point_hollow(ui: &mut Ui, row_height: f32) {
         marker_center(rect, raw),
         raw / 6.0,
         egui::Color32::TRANSPARENT,
-        egui::Stroke::new(0.6, ui.visuals().strong_text_color()),
+        egui::Stroke::new(0.6_f32, ui.visuals().strong_text_color()),
     );
 }
 
@@ -139,7 +139,13 @@ fn width_body_space(ui: &Ui) -> f32 {
 
 /// Enhanced/specialized version of egui's code blocks. This one features copy button and borders.
 /// Uses selectable Label instead of TextEdit to allow text selection across code block boundaries.
-pub fn code_block(ui: &mut Ui, text: &str, layout_job: egui::text::LayoutJob, max_width: f32, id: egui::Id) {
+pub fn code_block(
+    ui: &mut Ui,
+    text: &str,
+    layout_job: egui::text::LayoutJob,
+    _max_width: f32,
+    id: egui::Id,
+) {
     let text = text.strip_suffix('\n').unwrap_or(text);
 
     // Reserve space for background drawing
@@ -298,7 +304,7 @@ pub fn blockquote(ui: &mut Ui, accent: egui::Color32, add_contents: impl FnOnce(
                     response.rect.left_bottom().y - 5.0,
                 ),
             ],
-            egui::Stroke::new(3.0, accent),
+            egui::Stroke::new(3.0_f32, accent),
         ),
     );
 }

--- a/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
@@ -567,7 +567,7 @@ impl Link {
         // Apply underline and hyperlink color to all sections for better visibility
         let link_color = ui.visuals().hyperlink_color;
         for section in &mut layout_job.sections {
-            section.format.underline = egui::Stroke::new(1.0, link_color);
+            section.format.underline = egui::Stroke::new(1.0_f32, link_color);
             section.format.color = link_color;
             // Remove extra line height to bring underline closer to text
             section.format.line_height = None;


### PR DESCRIPTION
## Summary
- make f32 stroke widths explicit for compatibility with the new future-incompatible lint
- mark the retained public code-block width parameter as intentionally unused
- discard unused table scope responses explicitly
- replace the deprecated heading child-UI helper with its exact scope_builder equivalent
- remove the unused parser_options_math helper left behind after parser integration

The parser helper is not referenced by #96 or the current renderer. Removing it is independent of viewport clipping and prevents the dead-code warning from returning after the rest of this cleanup.

## Validation
- root locked cargo check passed without source warnings
- egui_commonmark library tests with math enabled: 43 passed
- formatting and diff checks passed

Default-feature workspace tests currently hit the pre-existing missing math test guards fixed separately in #103; all-features also enables the nightly-only feature on stable.