### PR TITLE
docs(linux): explain file dialog dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ curl -fsSL https://raw.githubusercontent.com/aydiler/md-viewer/main/scripts/inst
 
 Supports Linux x86_64 and macOS arm64 (Apple Silicon). Set `INSTALL_DIR=/usr/local/bin` to install elsewhere. Intel Macs need to build from source via `cargo install md-viewer`.
 
+On Linux, **Open File** and **Open Folder** need either a working XDG Desktop
+Portal FileChooser (plus the `gdbus` command used to detect it), or Python 3
+with Tkinter for the fallback dialog. You can check the fallback with
+`python3 -c 'import tkinter'`. Common Tkinter package names are `python3-tk` on
+Debian/Ubuntu, `python3-tkinter` on Fedora/RHEL, and `python` plus `tk` on Arch.
+
 > **macOS Gatekeeper note:** binaries are not yet signed/notarized. If macOS refuses to run the app, run:
 > `xattr -d com.apple.quarantine ~/.local/bin/md-viewer`
 
@@ -219,7 +225,8 @@ sudo pacman -S --needed \
     base-devel clang pkg-config \
     libxcb libxkbcommon openssl \
     gtk3 fontconfig dbus zenity \
-    xdg-desktop-portal xdg-desktop-portal-gtk
+    xdg-desktop-portal xdg-desktop-portal-gtk \
+    python tk
 ```
 
 ## Usage

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,8 +137,8 @@ fn path_from_picker_output(stdout: Vec<u8>) -> Option<PathBuf> {
     }
 }
 
-/// Use Python's standard-library Tk binding as a no-install file picker on
-/// Linux desktops where xdg-desktop-portal is not installed.
+/// Use Python's Tk binding as a fallback file picker on Linux desktops where
+/// xdg-desktop-portal is not available.
 #[cfg(target_os = "linux")]
 fn pick_file_with_tkinter(initial_dir: Option<&Path>) -> Result<Option<PathBuf>, String> {
     const SCRIPT: &str = r#"
@@ -229,9 +229,9 @@ fn pick_file(initial_dir: Option<&Path>) -> Result<Option<PathBuf>, String> {
     }
 }
 
-/// Use Python's standard-library Tk binding as a no-install folder picker on
-/// Linux desktops where xdg-desktop-portal is not installed. The initial
-/// directory is passed as a process argument, never interpolated into Python.
+/// Use Python's Tk binding as a fallback folder picker on Linux desktops where
+/// xdg-desktop-portal is not available. The initial directory is passed as a
+/// process argument, never interpolated into Python.
 #[cfg(target_os = "linux")]
 fn pick_folder_with_tkinter(initial_dir: Option<&Path>) -> Result<Option<PathBuf>, String> {
     const SCRIPT: &str = r#"


### PR DESCRIPTION
## Summary
- document the two Linux file-dialog paths: XDG Desktop Portal with gdbus, or Python 3 with Tkinter
- list common Tkinter package names for Debian/Ubuntu, Fedora/RHEL, and Arch
- include the Arch fallback packages in the existing dependency command
- correct source comments that previously described Tkinter as no-install

## Validation
- verified the documented Tkinter import command locally
- formatting and diff checks passed