### PR TITLE
chore: clear cross-platform build warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8046,7 +8046,3 @@ dependencies = [
  "syn 3.0.4",
  "winnow 1.0.4",
 ]
-
-[[patch.unused]]
-name = "egui_commonmark_macros_extended"
-version = "0.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,3 @@ codegen-units = 4
 [patch.crates-io]
 egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark", version = "0.27.0" }
 egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend", version = "0.27.0" }
-egui_commonmark_macros_extended = { path = "crates/egui_commonmark/egui_commonmark_macros", version = "0.27.0" }

--- a/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/mime_svg_loader.rs
@@ -133,10 +133,7 @@ fn family_is_loaded(database: &Database, requested: &str) -> bool {
 
 #[cfg(feature = "svg_text")]
 fn fontconfig_sans_serif_family() -> Option<String> {
-    #[cfg(all(
-        unix,
-        not(any(target_os = "macos", target_os = "ios", target_os = "android"))
-    ))]
+    #[cfg(all(unix, not(any(target_vendor = "apple", target_os = "android"))))]
     {
         use std::process::{Command, Stdio};
 
@@ -155,7 +152,11 @@ fn fontconfig_sans_serif_family() -> Option<String> {
     None
 }
 
-#[cfg(feature = "svg_text")]
+#[cfg(all(
+    feature = "svg_text",
+    unix,
+    not(any(target_vendor = "apple", target_os = "android"))
+))]
 fn parse_fontconfig_family(stdout: &[u8]) -> Option<String> {
     let family = String::from_utf8_lossy(stdout);
     let family = family.trim();
@@ -262,7 +263,11 @@ mod tests {
         Color32, ColorImage,
     };
 
-    #[cfg(feature = "svg_text")]
+    #[cfg(all(
+        feature = "svg_text",
+        unix,
+        not(any(target_vendor = "apple", target_os = "android"))
+    ))]
     use super::parse_fontconfig_family;
     use super::{is_svg_mime, trim_svg_cache, MimeSvgLoader, SvgCacheEntry};
 
@@ -274,7 +279,11 @@ mod tests {
         assert!(!is_svg_mime("image/png"));
     }
 
-    #[cfg(feature = "svg_text")]
+    #[cfg(all(
+        feature = "svg_text",
+        unix,
+        not(any(target_vendor = "apple", target_os = "android"))
+    ))]
     #[test]
     fn parses_concrete_fontconfig_family() {
         assert_eq!(


### PR DESCRIPTION
## Summary

- remove the unused root-level `egui_commonmark_macros_extended` patch and its `Cargo.lock` marker; the vendored renderer workspace already resolves that crate through its path dependency
- compile the Fontconfig output parser and its unit test only on Unix targets that can take the `fc-match` path
- exclude every Apple target via `target_vendor = "apple"`, rather than listing only macOS and iOS

## Context

The macOS validation of #107 succeeded, but exposed a `dead_code` warning for `parse_fontconfig_family`. A normal root build also reported that the macros patch was unused. Neither warning represented a runtime bug, but both came from declarations broader than their actual use.

This PR only narrows build configuration and removes redundant dependency metadata; it does not change runtime behavior on supported Fontconfig targets.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check --locked`
- `cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --features svg_text parses_concrete_fontconfig_family`
- `cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_macros_extended`
- standalone rustfmt check for the changed Rust source
- `git diff --check`
