### PR TITLE
Fix viewport slice consistency for tables and navigation

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/lib.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/lib.rs
@@ -120,6 +120,9 @@ pub struct CommonMarkViewer<'f> {
     /// owns the ScrollArea (via `show_scrollable`) the caller can no longer
     /// configure it directly.
     pending_scroll_offset: Option<f32>,
+    /// Whether this frame must paint the complete document instead of a
+    /// viewport slice. Navigation to an already measured Y does not need it.
+    force_full_render: bool,
     /// Scroll source config for the renderer-owned ScrollArea. Useful when
     /// the caller needs to disable drag-scroll (e.g. to keep text selection
     /// working) while preserving wheel-scroll.
@@ -440,6 +443,13 @@ impl<'f> CommonMarkViewer<'f> {
         self
     }
 
+    /// Paint the complete document this frame so off-screen target positions
+    /// can be measured. Keep this disabled for scrolling to a cached position.
+    pub fn force_full_render(mut self, force: bool) -> Self {
+        self.force_full_render = force;
+        self
+    }
+
     /// Configure which scroll inputs the renderer-owned ScrollArea reacts to.
     ///
     /// Default is whatever `egui::ScrollArea::vertical()` provides. Callers
@@ -538,6 +548,7 @@ impl<'f> CommonMarkViewer<'f> {
             text,
             self.content_version,
             self.pending_scroll_offset,
+            self.force_full_render,
             self.scroll_source,
         )
     }

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -744,6 +744,7 @@ impl CommonMarkViewerInternal {
             let events_data = cache.get_cached_events(content_hash)
                 .expect("events just cached")
                 .to_vec();
+            let event_count = events_data.len();
             let mut events = events_data
                 .into_iter()
                 .enumerate()
@@ -762,6 +763,14 @@ impl CommonMarkViewerInternal {
                     &e,
                     pulldown_cmark::Event::End(end) if is_block_end_tag(end)
                 );
+                // `table()` consumes the complete table, including its End
+                // event, from `events`. The outer loop therefore never sees
+                // TagEnd::Table and must record that block boundary from its
+                // Start event after processing finishes.
+                let is_atomic_table = matches!(
+                    &e,
+                    pulldown_cmark::Event::Start(pulldown_cmark::Tag::Table(_))
+                );
 
                 if events.peek().is_none() {
                     self.line.should_end_newline_forced = false;
@@ -770,8 +779,9 @@ impl CommonMarkViewerInternal {
                 self.process_event(ui, &mut events, e, src_span, cache, options, max_width);
 
                 // Defense in depth: only add a split point when we're at a
-                // block end AND outside any stateful container (list, table,
-                // blockquote). The viewport-skip path in `show_scrollable`
+                // block end (or just consumed an atomic table) AND outside any
+                // stateful container (list, table, blockquote). The
+                // viewport-skip path in `show_scrollable`
                 // recreates the renderer with `CommonMarkViewerInternal::new`
                 // each frame, so the transient state of `self.list`,
                 // `self.is_table`, and `self.is_blockquote` is *not* replayed
@@ -784,7 +794,7 @@ impl CommonMarkViewerInternal {
                 // check below must run after `process_event` (above) since
                 // that's where the start/end of these containers updates
                 // `self.list` / `self.is_table` / `self.is_blockquote`.
-                let safe_for_split = is_block_end
+                let safe_for_split = (is_block_end || is_atomic_table)
                     && !self.list.is_inside_a_list()
                     && !self.is_table
                     && !self.is_blockquote;
@@ -794,7 +804,14 @@ impl CommonMarkViewerInternal {
                         let scroll_cache = scroll_cache(cache, &source_id);
                         let end_position = ui.next_widget_position();
 
-                        let split_index = index.saturating_add(1);
+                        let split_index = if is_atomic_table {
+                            events
+                                .peek()
+                                .map(|(next_index, _)| *next_index)
+                                .unwrap_or(event_count)
+                        } else {
+                            index.saturating_add(1)
+                        };
                         let split_point_exists = scroll_cache
                             .split_points
                             .iter()
@@ -995,13 +1012,15 @@ impl CommonMarkViewerInternal {
             let (first_event_index, first_end_y, events_range) = {
                 let scroll_cache = scroll_cache(cache, &source_id);
 
-                // Keep one complete block of safety margin on both sides of
-                // the viewport, and only resume after a complete block.
+                // Resume after the last complete block above the viewport.
+                // Re-rendering an additional fully off-screen table here is
+                // unsafe: egui_extras virtualizes all of its heterogeneous
+                // rows and can report a collapsed height for that table.
                 let above = scroll_cache
                     .split_points
                     .partition_point(|(_, _, end)| end.y < viewport.min.y);
-                let (first_event_index, _, first_end_position) = if above >= 2 {
-                    scroll_cache.split_points[above - 2]
+                let (first_event_index, _, first_end_position) = if above >= 1 {
+                    scroll_cache.split_points[above - 1]
                 } else {
                     (0, Pos2::ZERO, Pos2::ZERO)
                 };
@@ -2384,6 +2403,17 @@ mod tests {
                     );
                 }
             }
+            let table_end_index = sc
+                .events
+                .iter()
+                .position(|(event, _)| matches!(event, Event::End(pulldown_cmark::TagEnd::Table)))
+                .expect("fixture contains a table end");
+            assert!(
+                sc.split_points
+                    .iter()
+                    .any(|(index, _, _)| *index == table_end_index + 1),
+                "atomic table must leave a safe resume point after its consumed End event"
+            );
 
             CommonMarkViewerInternal::new().show_scrollable(
                 source_id,

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -317,6 +317,10 @@ fn wrapped_text_height(ui: &Ui, text: &str, column_width: f32, line_height: f32)
     line_height * 1.5 * galley.rows.len().max(1) as f32
 }
 
+fn content_relative_y(screen_y: f32, render_origin_y: f32, slice_start_y: f32) -> f32 {
+    slice_start_y + screen_y - render_origin_y
+}
+
 /// Preserve naturally narrow columns while sharing the remaining width among
 /// wider columns. If even the minimum widths do not fit, horizontal scrolling
 /// remains available.
@@ -470,6 +474,8 @@ pub struct CommonMarkViewerInternal {
     current_heading_text: String,
     /// Accumulate heading RichText fragments for single render at end
     current_heading_rich_texts: Vec<egui::RichText>,
+    /// Content-space Y of the first event rendered by the current slice.
+    slice_start_y: f32,
 }
 
 pub(crate) struct CheckboxClickEvent {
@@ -498,6 +504,7 @@ impl CommonMarkViewerInternal {
             current_heading_source_start: None,
             current_heading_text: String::new(),
             current_heading_rich_texts: Vec::new(),
+            slice_start_y: 0.0,
         }
     }
 }
@@ -713,6 +720,7 @@ impl CommonMarkViewerInternal {
         text: &str,
         split_points_id: Option<Id>,
     ) -> (egui::InnerResponse<()>, Vec<CheckboxClickEvent>) {
+        self.slice_start_y = 0.0;
         let max_width = options.max_width(ui);
         let layout = egui::Layout::left_to_right(egui::Align::BOTTOM).with_main_wrap(true);
 
@@ -868,6 +876,7 @@ impl CommonMarkViewerInternal {
         text: &str,
         content_version: Option<u64>,
         pending_scroll_offset: Option<f32>,
+        force_full_render: bool,
         scroll_source: Option<egui::scroll_area::ScrollSource>,
     ) -> egui::scroll_area::ScrollAreaOutput<()> {
         let available_size = ui.available_size();
@@ -927,21 +936,17 @@ impl CommonMarkViewerInternal {
                 sc.page_size = None;
                 sc.split_points.clear();
             }
-            // When the caller wants to jump to a specific scroll position
-            // (outline click, search-jump), we must paint *every* event
-            // this frame — not just the viewport-clipped subset. Otherwise
-            // a far target's block doesn't paint, the cache.active_search_y
-            // / header_position never gets recorded, and the two-stage
-            // corrective scroll (src/main.rs:scroll_to_active_match) can't
-            // snap to the precise y. Forcing the bootstrap branch costs one
-            // full-paint frame (~100 ms at 100k lines) per jump, which is
-            // acceptable for a one-off action.
+            // An unknown navigation target may require painting every event
+            // so its precise position can be measured. Scrolling to an
+            // already cached Y must not take this path: nested virtualized
+            // widgets can report different off-screen heights during a
+            // nonzero-offset full paint and overwrite valid coordinates.
             //
             // Keep the already-valid split points: this bootstrap is needed
             // to paint every event for the jump, not to recompute geometry.
             // The push site deduplicates by event index, so the full render
             // can still refresh page_size without rebuilding the split list.
-            if pending_scroll_offset.is_some() {
+            if force_full_render {
                 sc.page_size = None;
             }
         }
@@ -1062,6 +1067,7 @@ impl CommonMarkViewerInternal {
             ui.scope_builder(
                 egui::UiBuilder::new().max_rect(slice_rect).layout(layout),
                 |ui| {
+                    self.slice_start_y = first_end_y;
                     ui.spacing_mut().item_spacing.x = 0.0;
                     ui.set_row_height(ui.text_style_height(&TextStyle::Body));
 
@@ -1991,8 +1997,9 @@ impl CommonMarkViewerInternal {
                         // closure's ui top-left, which tracks the current
                         // scroll offset (it shifts up as the user scrolls).
                         // The subtraction cancels out both the panel chrome
-                        // AND any active scroll offset, leaving a pure
-                        // content-y that's invariant across scroll positions.
+                        // and any active scroll offset. A viewport slice starts
+                        // at `slice_start_y` rather than document y=0, so add
+                        // that origin back before updating the shared cache.
                         //
                         // Empirical verification on Recent-Changes.md:
                         // - At scroll=0: title cursor=323, min_rect.top()=44
@@ -2004,7 +2011,11 @@ impl CommonMarkViewerInternal {
                         // Previously stored `cur_offset + cursor.y` which gave
                         // 323 (off by 44 = panel chrome height), so scrolling
                         // to (323-50)=273 landed 44 px past the heading.
-                        let content_y = y - ui.min_rect().top();
+                        let content_y = content_relative_y(
+                            y,
+                            ui.min_rect().top(),
+                            self.slice_start_y,
+                        );
                         // Always refresh with current layout, not first-paint
                         // value. First-paint pinning produced increasing
                         // overshoot for deeper headers — the first frame
@@ -2390,6 +2401,7 @@ mod tests {
                 markdown,
                 Some(1),
                 None,
+                false,
                 None,
             );
             let sc = scroll_cache(&mut cache, &source_id);
@@ -2423,6 +2435,7 @@ mod tests {
                 markdown,
                 Some(1),
                 None,
+                false,
                 None,
             );
         });
@@ -2755,6 +2768,12 @@ mod tests {
             assert!(cache.get_header_position("heading-source:0").is_some());
             assert!(cache.get_header_position("heading-source:20").is_some());
         });
+    }
+
+    #[test]
+    fn sliced_heading_position_includes_the_slice_origin() {
+        assert_eq!(content_relative_y(50.0, -229.0, 0.0), 279.0);
+        assert_eq!(content_relative_y(120.0, 80.0, 1_976.0), 2_016.0);
     }
 
     #[test]

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -317,10 +317,6 @@ fn wrapped_text_height(ui: &Ui, text: &str, column_width: f32, line_height: f32)
     line_height * 1.5 * galley.rows.len().max(1) as f32
 }
 
-fn content_relative_y(screen_y: f32, render_origin_y: f32, slice_start_y: f32) -> f32 {
-    slice_start_y + screen_y - render_origin_y
-}
-
 /// Preserve naturally narrow columns while sharing the remaining width among
 /// wider columns. If even the minimum widths do not fit, horizontal scrolling
 /// remains available.
@@ -394,6 +390,14 @@ fn forward_shift_wheel_to_horizontal_scroll<R>(
     }
 }
 
+fn markdown_table_id(source_id: Id, source_start: usize) -> Id {
+    source_id.with("_markdown_table").with(source_start)
+}
+
+fn content_relative_y(screen_y: f32, render_origin_y: f32, slice_start_y: f32) -> f32 {
+    slice_start_y + screen_y - render_origin_y
+}
+
 /// Newline logic is constructed by the following:
 /// All elements try to insert a newline before them (if they are allowed)
 /// and end their own line.
@@ -453,6 +457,7 @@ struct DefinitionList {
 pub struct CommonMarkViewerInternal {
     curr_table: usize,
     curr_code_block: usize,
+    source_id: Option<Id>,
     text_style: Style,
     list: List,
     link: Option<Link>,
@@ -488,6 +493,7 @@ impl CommonMarkViewerInternal {
         Self {
             curr_table: 0,
             curr_code_block: 0,
+            source_id: None,
             text_style: Style::default(),
             list: List::default(),
             link: None,
@@ -879,6 +885,7 @@ impl CommonMarkViewerInternal {
         force_full_render: bool,
         scroll_source: Option<egui::scroll_area::ScrollSource>,
     ) -> egui::scroll_area::ScrollAreaOutput<()> {
+        self.source_id = Some(source_id);
         let available_size = ui.available_size();
         let scroll_id = source_id.with("_scroll_area");
         let layout_sig = compute_layout_signature(ui, options);
@@ -1135,11 +1142,23 @@ impl CommonMarkViewerInternal {
         options: &CommonMarkOptions,
         max_width: f32,
     ) {
+        let table_source_start = matches!(
+            &event,
+            pulldown_cmark::Event::Start(pulldown_cmark::Tag::Table(_))
+        )
+        .then_some(src_span.start);
         self.event(ui, event, src_span, cache, options, max_width);
 
         self.def_list_def_wrapping(events, max_width, cache, options, ui);
         self.item_list_wrapping(events, max_width, cache, options, ui);
-        self.table(events, cache, options, ui, max_width);
+        self.table(
+            events,
+            cache,
+            options,
+            ui,
+            max_width,
+            table_source_start,
+        );
         self.blockquote(events, max_width, cache, options, ui);
     }
 
@@ -1286,11 +1305,15 @@ impl CommonMarkViewerInternal {
         options: &CommonMarkOptions,
         ui: &mut Ui,
         max_width: f32,
+        source_start: Option<usize>,
     ) {
         if self.is_table {
             self.line.try_insert_start(ui);
 
-            let id = ui.id().with("_table").with(self.curr_table);
+            let id = markdown_table_id(
+                self.source_id.unwrap_or_else(|| ui.id()),
+                source_start.unwrap_or(self.curr_table),
+            );
             self.curr_table += 1;
 
             // Consume events into header/rows up front so we know the column count
@@ -2774,6 +2797,24 @@ mod tests {
     fn sliced_heading_position_includes_the_slice_origin() {
         assert_eq!(content_relative_y(50.0, -229.0, 0.0), 279.0);
         assert_eq!(content_relative_y(120.0, 80.0, 1_976.0), 2_016.0);
+    }
+
+    #[test]
+    fn markdown_table_identity_uses_document_and_source_position() {
+        let document = Id::new("document-a");
+
+        assert_eq!(
+            markdown_table_id(document, 120),
+            markdown_table_id(document, 120)
+        );
+        assert_ne!(
+            markdown_table_id(document, 120),
+            markdown_table_id(document, 240)
+        );
+        assert_ne!(
+            markdown_table_id(document, 120),
+            markdown_table_id(Id::new("document-b"), 120)
+        );
     }
 
     #[test]

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -398,6 +398,19 @@ fn content_relative_y(screen_y: f32, render_origin_y: f32, slice_start_y: f32) -
     slice_start_y + screen_y - render_origin_y
 }
 
+fn record_active_search_content_y(
+    cache: &mut CommonMarkCache,
+    screen_y: f32,
+    render_origin_y: f32,
+    slice_start_y: f32,
+) {
+    cache.record_active_search_content_y(content_relative_y(
+        screen_y,
+        render_origin_y,
+        slice_start_y,
+    ));
+}
+
 /// Newline logic is constructed by the following:
 /// All elements try to insert a newline before them (if they are allowed)
 /// and end their own line.
@@ -481,6 +494,10 @@ pub struct CommonMarkViewerInternal {
     current_heading_rich_texts: Vec<egui::RichText>,
     /// Content-space Y of the first event rendered by the current slice.
     slice_start_y: f32,
+    /// Screen-space Y of the root UI for the current full or sliced render.
+    /// Nested table/list/blockquote UIs must not replace this origin when
+    /// converting navigation positions into document coordinates.
+    render_origin_y: f32,
 }
 
 pub(crate) struct CheckboxClickEvent {
@@ -511,6 +528,7 @@ impl CommonMarkViewerInternal {
             current_heading_text: String::new(),
             current_heading_rich_texts: Vec::new(),
             slice_start_y: 0.0,
+            render_origin_y: 0.0,
         }
     }
 }
@@ -752,6 +770,7 @@ impl CommonMarkViewerInternal {
             ui.set_row_height(height);
             let content_origin_y = ui.next_widget_position().y;
             let content_origin_x = ui.max_rect().left();
+            self.render_origin_y = content_origin_y;
 
             // Use cached events — clone the Vec reference data for iteration
             // (events are 'static so this is cheap pointer copies, not re-parsing)
@@ -1075,6 +1094,7 @@ impl CommonMarkViewerInternal {
                 egui::UiBuilder::new().max_rect(slice_rect).layout(layout),
                 |ui| {
                     self.slice_start_y = first_end_y;
+                    self.render_origin_y = ui.min_rect().top();
                     ui.spacing_mut().item_spacing.x = 0.0;
                     ui.set_row_height(ui.text_style_height(&TextStyle::Body));
 
@@ -1722,7 +1742,7 @@ impl CommonMarkViewerInternal {
             },
         );
         if let Some(y) = active_y {
-            cache.record_active_search_y_viewport(y);
+            record_active_search_content_y(cache, y, self.render_origin_y, self.slice_start_y);
         }
     }
 
@@ -1837,7 +1857,7 @@ impl CommonMarkViewerInternal {
             );
         });
         if let Some(y) = active_y {
-            cache.record_active_search_y_viewport(y);
+            record_active_search_content_y(cache, y, self.render_origin_y, self.slice_start_y);
         }
     }
 
@@ -2015,20 +2035,19 @@ impl CommonMarkViewerInternal {
                         // SCREEN-y coordinate. The click handler uses the
                         // cached value with `ScrollArea::vertical_scroll_offset(N)`,
                         // which interprets N as a CONTENT-y (where 0 is the
-                        // top of the ScrollArea's content layout). Subtract
-                        // `ui.min_rect().top()` — that's the screen y of the
-                        // closure's ui top-left, which tracks the current
-                        // scroll offset (it shifts up as the user scrolls).
-                        // The subtraction cancels out both the panel chrome
-                        // and any active scroll offset. A viewport slice starts
-                        // at `slice_start_y` rather than document y=0, so add
-                        // that origin back before updating the shared cache.
+                        // top of the ScrollArea's content layout). Subtract the
+                        // root render origin, which tracks the current scroll
+                        // offset but stays stable across nested table, list,
+                        // and blockquote UIs. This cancels out both the panel
+                        // chrome and any active scroll offset. A viewport slice
+                        // starts at `slice_start_y` rather than document y=0,
+                        // so add that origin back before updating the cache.
                         //
                         // Empirical verification on Recent-Changes.md:
-                        // - At scroll=0: title cursor=323, min_rect.top()=44
+                        // - At scroll=0: title cursor=323, render origin=44
                         //   → content_y = 279
                         // - After click to scroll=273: cursor=50,
-                        //   min_rect.top()=-229 → content_y = 279
+                        //   render origin=-229 → content_y = 279
                         // - Same heading, same content_y, regardless of scroll
                         //
                         // Previously stored `cur_offset + cursor.y` which gave
@@ -2036,7 +2055,7 @@ impl CommonMarkViewerInternal {
                         // to (323-50)=273 landed 44 px past the heading.
                         let content_y = content_relative_y(
                             y,
-                            ui.min_rect().top(),
+                            self.render_origin_y,
                             self.slice_start_y,
                         );
                         // Always refresh with current layout, not first-paint
@@ -2797,6 +2816,72 @@ mod tests {
     fn sliced_heading_position_includes_the_slice_origin() {
         assert_eq!(content_relative_y(50.0, -229.0, 0.0), 279.0);
         assert_eq!(content_relative_y(120.0, 80.0, 1_976.0), 2_016.0);
+    }
+
+    #[test]
+    fn sliced_search_position_includes_origin_and_excludes_chrome() {
+        let mut cache = CommonMarkCache::default();
+
+        record_active_search_content_y(&mut cache, 120.0, 80.0, 1_976.0);
+
+        assert_eq!(cache.active_search_y(), Some(2_016.0));
+    }
+
+    #[test]
+    fn nested_navigation_positions_keep_the_root_render_origin() {
+        let markdown = concat!(
+            "Paragraph one.\n\n",
+            "Paragraph two.\n\n",
+            "Paragraph three.\n\n",
+            "Paragraph four.\n\n",
+            "> ## Nested heading\n",
+            "> quoted text\n\n",
+            "| Key | Value |\n",
+            "|---|---|\n",
+            "| row | ACTIVE_TABLE_MATCH |\n",
+        );
+        let active_start = markdown.find("ACTIVE_TABLE_MATCH").unwrap();
+        let active_range = active_start..active_start + "ACTIVE_TABLE_MATCH".len();
+        let heading_source_start = crate::parsers::latex_delimiters::parse_events(markdown, false)
+            .into_iter()
+            .find_map(|(event, range)| {
+                matches!(event, Event::Start(Tag::Heading { .. })).then_some(range.start)
+            })
+            .expect("fixture contains a nested heading");
+        let heading_key = crate::header_position_key(heading_source_start);
+        let mut cache = CommonMarkCache::default();
+        cache.set_search_ranges(vec![active_range.clone()]);
+        cache.set_active_search_range(Some(active_range));
+        let ctx = egui::Context::default();
+        let mut minimum_nested_y = 0.0;
+
+        ctx.begin_pass(Default::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            ui.set_width(400.0);
+            let line_height = ui.text_style_height(&egui::TextStyle::Body);
+            minimum_nested_y = line_height * 4.0;
+            CommonMarkViewerInternal::new().show(
+                ui,
+                &mut cache,
+                &CommonMarkOptions::default(),
+                markdown,
+                None,
+            );
+        });
+        let _ = ctx.end_pass();
+
+        assert!(
+            cache
+                .get_header_position(&heading_key)
+                .is_some_and(|y| y > minimum_nested_y),
+            "nested heading lost the preceding document height"
+        );
+        assert!(
+            cache
+                .active_search_y()
+                .is_some_and(|y| y > minimum_nested_y),
+            "table-cell search match lost the preceding document height"
+        );
     }
 
     #[test]

--- a/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
@@ -2474,6 +2474,11 @@ impl CommonMarkCache {
         self.active_search_y = Some(self.current_scroll_offset + viewport_y);
     }
 
+    /// Record an active search position already expressed in document space.
+    pub fn record_active_search_content_y(&mut self, content_y: f32) {
+        self.active_search_y = Some(content_y);
+    }
+
     /// Get the recorded content-relative y of the active match, if it has rendered
     /// at least once since the active range was set. Used for precise scroll-into-view.
     pub fn active_search_y(&self) -> Option<f32> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1437,6 +1437,10 @@ fn find_matches(content: &str, query: &str) -> Vec<SearchMatch> {
     matches
 }
 
+fn take_search_correction_request(pending: &mut bool) -> bool {
+    std::mem::take(pending)
+}
+
 /// Check if header at `index` should be hidden because an ancestor is collapsed
 fn header_is_hidden(headers: &[Header], index: usize, collapsed: &HashSet<usize>) -> bool {
     if index == 0 || index >= headers.len() {
@@ -2713,10 +2717,9 @@ impl MarkdownApp {
             100.0
         };
         tab.pending_scroll_offset = Some((estimated_y - margin).max(0.0));
-        // Grant the post-render corrective block one frame of permission to
-        // snap to the renderer-recorded `active_search_y`. The block clears
-        // the flag after it runs, so subsequent frames (e.g. user wheeling
-        // away from the match) won't re-trigger snap-back. See Tab field doc.
+        // Grant the next render one full-paint attempt to record an exact Y.
+        // The request is consumed before that render even when the source
+        // match has no visible glyph, so later frames return to clipping.
         tab.correct_active_search_pending = true;
     }
 
@@ -3305,6 +3308,13 @@ impl MarkdownApp {
             tab.cache.clear_search_ranges();
         }
 
+        // A search correction grants exactly one full-paint attempt. Some
+        // source matches (for example Markdown syntax markers) have no
+        // rendered glyph and therefore never record a Y; do not let those
+        // matches disable viewport clipping forever.
+        let correct_search_this_frame =
+            take_search_correction_request(&mut tab.correct_active_search_pending);
+
         // Content area (no inner CentralPanel needed - we're already in one)
         // Left margin for breathing room, right margin prevents scrollbar/resize-handle overlap jitter
         egui::Frame::NONE
@@ -3324,7 +3334,7 @@ impl MarkdownApp {
                 // exposes state.offset and inner_rect for the post-render
                 // selection-preserving wheel hack below.
                 let force_full_render =
-                    tab.pending_header_click_key.is_some() || tab.correct_active_search_pending;
+                    tab.pending_header_click_key.is_some() || correct_search_this_frame;
                 let pending = tab.pending_scroll_offset.take();
                 let default_width = content_default_width(self.full_width_content);
                 let mut scroll_output = CommonMarkViewer::new()
@@ -3369,7 +3379,7 @@ impl MarkdownApp {
                 // jump — without this gate the block would re-trigger every
                 // frame the active match is off-screen, fighting the user's
                 // wheel input and locking the view (issue #19).
-                if tab.correct_active_search_pending {
+                if correct_search_this_frame {
                     if let Some(actual_y) = tab.cache.active_search_y() {
                         let current_scroll = scroll_output.state.offset.y;
                         let viewport_top = current_scroll;
@@ -3387,9 +3397,6 @@ impl MarkdownApp {
                                 tab.pending_scroll_offset = Some(want_scroll);
                             }
                         }
-                        // Clear the one-shot regardless of which branch ran;
-                        // the corrective block has now had its chance to snap.
-                        tab.correct_active_search_pending = false;
                     }
                 }
 
@@ -5063,6 +5070,15 @@ mod tests {
             path_from_picker_output(bytes),
             Some(PathBuf::from("/tmp/example folder"))
         );
+    }
+
+    #[test]
+    fn search_correction_request_is_consumed_even_without_a_rendered_match() {
+        let mut pending = true;
+
+        assert!(take_search_correction_request(&mut pending));
+        assert!(!pending);
+        assert!(!take_search_correction_request(&mut pending));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3133,11 +3133,10 @@ impl MarkdownApp {
                     let estimated_y = (header.line_number as f32 / tab.content_lines as f32)
                         * tab.last_content_height;
                     tab.pending_scroll_offset = Some((estimated_y - 50.0).max(0.0));
+                    // The estimate only gets us near the target. Request one
+                    // complete paint so the corrective pass can measure it.
+                    tab.pending_header_click_key = Some(key);
                 }
-                // Remember the click target — once the bootstrap full paint
-                // triggered by `pending_scroll_offset` populates the cache, the
-                // corrective step in `render_tab_content` snaps to the precise y.
-                tab.pending_header_click_key = Some(key);
             }
         }
     }
@@ -3324,6 +3323,8 @@ impl MarkdownApp {
                 // version through builder methods. The returned ScrollAreaOutput
                 // exposes state.offset and inner_rect for the post-render
                 // selection-preserving wheel hack below.
+                let force_full_render =
+                    tab.pending_header_click_key.is_some() || tab.correct_active_search_pending;
                 let pending = tab.pending_scroll_offset.take();
                 let default_width = content_default_width(self.full_width_content);
                 let mut scroll_output = CommonMarkViewer::new()
@@ -3346,6 +3347,7 @@ impl MarkdownApp {
                     .heading_spacing_below(0.75)
                     .content_version(tab.content_version)
                     .pending_scroll_offset(pending)
+                    .force_full_render(force_full_render)
                     .scroll_source(egui::scroll_area::ScrollSource {
                         scroll_bar: true,
                         drag: false,


### PR DESCRIPTION
## Summary

- resume viewport rendering only after complete blocks, including atomically consumed Markdown tables
- keep heading and active-search positions document-relative across sliced renders and nested UIs
- derive Markdown table identity from the document and source position so column state remains stable
- consume search correction as a one-frame full-render request so invisible source matches cannot disable clipping indefinitely

## Testing

- root cargo test: 59 passed, 1 ignored (installed-font integration test)
- egui_commonmark library tests: 50 passed on this branch
- regression coverage includes post-table split points, sliced coordinates, nested heading/table search positions, stable table identity, and one-shot search correction

Fixes #111