### PR TITLE
Make tables follow the Full Width setting

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -346,6 +346,22 @@ fn fit_column_widths(desired: &[f32], available: f32, minimum: f32) -> Vec<f32> 
     desired.into_iter().map(|width| width.min(low)).collect()
 }
 
+/// Remember the width contract used to initialize a resizable table.
+///
+/// `egui_extras::TableBuilder` deliberately keeps user-resized column widths,
+/// which also means later `Column::initial` values are ignored. Invalidate that
+/// cached state only when the table's layout bound changes; while the bound is
+/// stable, manual column resizing remains intact.
+fn table_layout_bound_changed(ui: &Ui, table_id: Id, table_bound: f32) -> bool {
+    let state_id = table_id.with("_layout_bound");
+    let current = table_bound.max(0.0).round() as usize;
+    ui.data_mut(|data| {
+        let previous = data.get_temp::<usize>(state_id);
+        data.insert_temp(state_id, current);
+        previous.is_some_and(|previous| previous != current)
+    })
+}
+
 /// Redirect Shift+vertical-wheel over a hovered wide-table into its inner
 /// horizontal scroll offset. Plain vertical wheel is left untouched so the
 /// outer document scroller keeps scrolling the page (this is the behavior
@@ -1301,10 +1317,9 @@ impl CommonMarkViewerInternal {
             // flow Ui from the markdown renderer. Without the vertical scope the
             // body's first row overlaps the header row.
             //
-            // The bound is `table_max_width` rather than the prose `max_width` so a
-            // wide table spreads over the whole content pane even in reading mode,
-            // instead of being clipped at the reading column with its right side
-            // unreachable (#64).
+            // The caller chooses whether `table_max_width` is the capped reading
+            // width or the full content pane. Horizontal scrolling keeps columns
+            // reachable when their minimum widths exceed that bound (#64, #110).
             let table_bound = options
                 .table_max_width
                 .map(|w| w as f32)
@@ -1345,6 +1360,8 @@ impl CommonMarkViewerInternal {
                         .show(ui, |ui| {
                             ui.vertical(|ui| {
                                 egui::Frame::group(ui.style()).show(ui, |ui| {
+                                    let reset_column_widths =
+                                        table_layout_bound_changed(ui, id, table_bound);
                                     let mut builder = egui_extras::TableBuilder::new(ui)
                                         .id_salt(id.with("_wrapped"))
                                         .striped(true)
@@ -1366,6 +1383,9 @@ impl CommonMarkViewerInternal {
                                                 .clip(true)
                                                 .at_least(40.0),
                                         );
+                                    }
+                                    if reset_column_widths {
+                                        builder.reset();
                                     }
                                     builder.body(|mut body| {
                                         let widths = body.widths().to_vec();
@@ -2176,6 +2196,8 @@ impl CommonMarkViewerInternal {
                     .show(ui, |ui| {
                 ui.vertical(|ui| {
                     egui::Frame::group(ui.style()).show(ui, |ui| {
+                        let reset_column_widths =
+                            table_layout_bound_changed(ui, id, table_bound);
                         let mut builder = egui_extras::TableBuilder::new(ui)
                             .id_salt(id.with("_wrapped"))
                             .striped(true)
@@ -2193,6 +2215,10 @@ impl CommonMarkViewerInternal {
                                     .clip(true)
                                     .at_least(40.0),
                             );
+                        }
+
+                        if reset_column_widths {
+                            builder.reset();
                         }
 
                         let render_cell_strong = |ui: &mut Ui, cell: &str| {
@@ -2327,6 +2353,58 @@ mod tests {
                 table_cell_height(&cell, line_height, &cache, ui, 120.0) >= line_height * 2.0
             );
         });
+    }
+
+    fn render_resizable_table_widths(
+        ctx: &egui::Context,
+        table_id: Id,
+        table_bound: f32,
+        initial_widths: &[f32],
+    ) -> Vec<f32> {
+        ctx.begin_pass(egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(640.0, 240.0),
+            )),
+            ..Default::default()
+        });
+        let mut rendered_widths = Vec::new();
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.set_width(table_bound);
+            ui.set_max_width(table_bound);
+            let reset_column_widths = table_layout_bound_changed(ui, table_id, table_bound);
+            let mut builder = egui_extras::TableBuilder::new(ui)
+                .id_salt(table_id.with("_wrapped"))
+                .resizable(true);
+            for width in initial_widths {
+                builder = builder.column(
+                    egui_extras::Column::initial(*width)
+                        .resizable(true)
+                        .at_least(40.0),
+                );
+            }
+            if reset_column_widths {
+                builder.reset();
+            }
+            builder.body(|body| rendered_widths = body.widths().to_vec());
+        });
+        let _ = ctx.end_pass();
+        rendered_widths
+    }
+
+    #[test]
+    fn resizable_table_state_reflows_when_its_bound_changes() {
+        let ctx = egui::Context::default();
+        let table_id = Id::new("responsive-table");
+        let initial = render_resizable_table_widths(&ctx, table_id, 180.0, &[60.0, 80.0]);
+        let same_bound = render_resizable_table_widths(&ctx, table_id, 180.0, &[90.0, 110.0]);
+        assert_eq!(same_bound, initial, "stable bounds must retain cached widths");
+
+        let wider = render_resizable_table_widths(&ctx, table_id, 360.0, &[120.0, 160.0]);
+        assert!(wider[0] > initial[0] && wider[1] > initial[1]);
+
+        let narrower = render_resizable_table_widths(&ctx, table_id, 140.0, &[40.0, 60.0]);
+        assert!(narrower[0] < wider[0] && narrower[1] < wider[1]);
     }
 
     #[test]

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -346,6 +346,21 @@ fn fit_column_widths(desired: &[f32], available: f32, minimum: f32) -> Vec<f32> 
     desired.into_iter().map(|width| width.min(low)).collect()
 }
 
+/// Fit columns inside the table's outer width contract.
+///
+/// The group frame contributes padding and a stroke on both sides. Those are
+/// part of the table's visible width, so only the remaining space belongs to
+/// columns and their separators.
+fn framed_table_widths(ui: &Ui, desired: &[f32], table_bound: f32) -> (egui::Frame, Vec<f32>) {
+    let frame = egui::Frame::group(ui.style());
+    let column_space =
+        ui.spacing().item_spacing.x * desired.len().saturating_sub(1) as f32;
+    let frame_width = frame.total_margin().sum().x;
+    let column_budget = (table_bound - frame_width - column_space).max(0.0);
+    let widths = fit_column_widths(desired, column_budget, 40.0);
+    (frame, widths)
+}
+
 /// Remember the width contract used to initialize a resizable table.
 ///
 /// `egui_extras::TableBuilder` deliberately keeps user-resized column widths,
@@ -1338,9 +1353,8 @@ impl CommonMarkViewerInternal {
                         .fold(40.0, f32::max)
                 })
                 .collect();
-            let column_space = ui.spacing().item_spacing.x * num_cols.saturating_sub(1) as f32;
-            let initial_widths =
-                fit_column_widths(&desired_widths, (table_bound - column_space).max(0.0), 40.0);
+            let (table_frame, initial_widths) =
+                framed_table_widths(ui, &desired_widths, table_bound);
             // The document ui is allocated at the prose width, and a child ui
             // can never exceed its parent's allocation — so a wider viewport
             // must be carved out explicitly. egui does not clamp an explicit
@@ -1359,7 +1373,7 @@ impl CommonMarkViewerInternal {
                         .auto_shrink([false, true])
                         .show(ui, |ui| {
                             ui.vertical(|ui| {
-                                egui::Frame::group(ui.style()).show(ui, |ui| {
+                                table_frame.show(ui, |ui| {
                                     let reset_column_widths =
                                         table_layout_bound_changed(ui, id, table_bound);
                                     let mut builder = egui_extras::TableBuilder::new(ui)
@@ -2179,9 +2193,8 @@ impl CommonMarkViewerInternal {
                     .fold(40.0, f32::max)
             })
             .collect();
-        let column_space = ui.spacing().item_spacing.x * num_cols.saturating_sub(1) as f32;
-        let initial_widths =
-            fit_column_widths(&desired_widths, (table_bound - column_space).max(0.0), 40.0);
+        let (table_frame, initial_widths) =
+            framed_table_widths(ui, &desired_widths, table_bound);
         // Same reading-column escape as markdown tables (#64): carve out a
         // scope wider than the prose allocation, anchored at the cursor.
         let mut table_scope_rect = ui.cursor();
@@ -2195,7 +2208,7 @@ impl CommonMarkViewerInternal {
                     .auto_shrink([false, true])
                     .show(ui, |ui| {
                 ui.vertical(|ui| {
-                    egui::Frame::group(ui.style()).show(ui, |ui| {
+                    table_frame.show(ui, |ui| {
                         let reset_column_widths =
                             table_layout_bound_changed(ui, id, table_bound);
                         let mut builder = egui_extras::TableBuilder::new(ui)
@@ -2352,6 +2365,21 @@ mod tests {
             assert!(
                 table_cell_height(&cell, line_height, &cache, ui, 120.0) >= line_height * 2.0
             );
+        });
+    }
+
+    #[test]
+    fn fitted_columns_leave_room_for_the_visible_table_frame() {
+        egui::__run_test_ui(|ui| {
+            let table_bound = 360.0;
+            let desired = [400.0, 500.0, 600.0];
+            let (frame, widths) = framed_table_widths(ui, &desired, table_bound);
+            let column_space =
+                ui.spacing().item_spacing.x * desired.len().saturating_sub(1) as f32;
+            let visible_width =
+                widths.iter().sum::<f32>() + column_space + frame.total_margin().sum().x;
+
+            assert!((visible_width - table_bound).abs() < 0.01);
         });
     }
 

--- a/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
+++ b/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
@@ -176,6 +176,63 @@ fn long_html_table_text_wraps_and_expands_its_row() {
     assert!(cell.bottom() <= after.top(), "wrapped row clipped/overlapped: {cell:?} {after:?}");
 }
 
+fn table_cell_height_after_widths(markdown: &str, widths: &[f32], marker: &str) -> Vec<f32> {
+    let ctx = Context::default();
+    let mut cache = CommonMarkCache::default();
+    let mut heights = Vec::new();
+
+    for &width in widths {
+        // Render twice at each width so the assertion observes settled egui
+        // table state rather than the frame that invalidated it.
+        for pass in 0..2 {
+            ctx.begin_pass(Default::default());
+            egui::CentralPanel::default().show(&ctx, |ui| {
+                ui.set_width(width);
+                CommonMarkViewer::new()
+                    .default_width(Some(width as usize))
+                    .table_max_width(Some(width as usize))
+                    .show(ui, &mut cache, markdown);
+            });
+            let output = ctx.end_pass();
+            if pass == 1 {
+                let mut painted = Vec::new();
+                for clipped in output.shapes {
+                    collect_painted_text(&clipped.shape, &mut painted);
+                }
+                heights.push(text_rect(&painted, marker).height());
+            }
+        }
+    }
+    heights
+}
+
+#[test]
+fn markdown_table_reflows_after_panel_width_changes() {
+    let prose = "MARKDOWN_REFLOW_CELL ".repeat(16);
+    let markdown = format!("| Key | Description |\n|---|---|\n| signal | {prose} |");
+    let heights = table_cell_height_after_widths(
+        &markdown,
+        &[220.0, 560.0, 180.0],
+        "MARKDOWN_REFLOW_CELL",
+    );
+
+    assert!(heights[1] < heights[0], "table did not widen: {heights:?}");
+    assert!(heights[2] > heights[1], "table did not narrow: {heights:?}");
+}
+
+#[test]
+fn html_table_reflows_after_panel_width_changes() {
+    let prose = "HTML_REFLOW_CELL ".repeat(16);
+    let markdown = format!(
+        "<table><tr><th>Key</th><th>Description</th></tr><tr><td>signal</td><td>{prose}</td></tr></table>"
+    );
+    let heights =
+        table_cell_height_after_widths(&markdown, &[220.0, 560.0, 180.0], "HTML_REFLOW_CELL");
+
+    assert!(heights[1] < heights[0], "table did not widen: {heights:?}");
+    assert!(heights[2] > heights[1], "table did not narrow: {heights:?}");
+}
+
 // ---------------------------------------------------------------------------
 // Nested-list regression coverage (devlog/027).
 //

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,12 @@ fn content_default_width(full_width_content: bool) -> Option<usize> {
     }
 }
 
+fn content_width_limit(full_width_content: bool, available_width: f32) -> usize {
+    let available_width = available_width.max(0.0) as usize;
+    content_default_width(full_width_content)
+        .map_or(available_width, |preferred| preferred.min(available_width))
+}
+
 /// Check whether the desktop portal exposes the interface used by rfd's
 /// Linux folder picker. Calling rfd without this interface fails like a user
 /// cancellation, so checking first lets us distinguish that case and use a
@@ -3326,14 +3332,17 @@ impl MarkdownApp {
                 // selection-preserving wheel hack below.
                 let pending = tab.pending_scroll_offset.take();
                 let default_width = content_default_width(self.full_width_content);
+                let content_width =
+                    content_width_limit(self.full_width_content, content_rect.width());
                 let mut scroll_output = CommonMarkViewer::new()
                     .default_implicit_uri_scheme(&tab.base_uri)
                     .max_image_width(Some(800))
                     .default_width(default_width)
-                    // Tables are not bound by the reading column (#64): a wide
-                    // table spans the whole content pane and scrolls there,
-                    // while prose keeps the reading width.
-                    .table_max_width(Some(content_rect.width() as usize))
+                    // Full Width governs the complete document layout. With
+                    // the reading cap active, tables reflow within it; their
+                    // horizontal scroller still handles minimum-width or
+                    // user-resized overflow (#110).
+                    .table_max_width(Some(content_width))
                     .indentation_spaces(2)
                     .use_strong_font_family(true)
                     .show_alt_text_on_hover(true)
@@ -5035,6 +5044,17 @@ mod tests {
     #[test]
     fn full_width_content_uses_available_width() {
         assert_eq!(content_default_width(true), None);
+    }
+
+    #[test]
+    fn capped_content_applies_the_same_limit_to_tables() {
+        assert_eq!(content_width_limit(false, 900.0), 600);
+        assert_eq!(content_width_limit(false, 480.0), 480);
+    }
+
+    #[test]
+    fn full_width_tables_use_the_available_content_width() {
+        assert_eq!(content_width_limit(true, 900.0), 900);
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

- apply the same reading-width cap to prose and Markdown/HTML tables when Full Width is disabled
- let prose and tables use the available center-pane width when Full Width is enabled
- keep the visible table frame inside that width by deriving its padding/stroke budget from `Frame::total_margin()`
- reset cached resizable column widths when the table layout bound changes, so tables reflow in both directions while stable bounds retain manual resizing
- retain horizontal table scrolling for hard-minimum or user-resized overflow

## Testing

- root cargo test: 58 passed, 1 ignored (installed-font integration test)
- vendored renderer: 48 library tests and 18 wrapping tests passed
- production-path multi-frame tests cover Markdown and HTML tables at 220 → 560 → 180 px
- frame-budget regression verifies columns, separators, padding, and stroke fit the outer table bound
- verified integration with #113, #115, and #116 without text conflicts

## Dependency

Please merge #113 before this PR. Its source-position-based Markdown table IDs keep resizable state and layout-bound tracking stable across documents and viewport slices.

Fixes #110
