### PR TITLE
Fix wrapping and row heights for mixed table content

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -311,11 +311,10 @@ fn inline_code_wrap_segments(text: &str) -> Vec<String> {
     segments
 }
 
-/// Measure a table cell's visible labels in their rendering order. Each label
-/// is laid out against the width left by earlier labels in the current row;
-/// this matters when a wider monospace label follows proportional text. Long
-/// code chunks call `ui.end_row()` in production, so they also finish a
-/// measurement group here.
+/// Measure a table cell's visible labels in their rendering order. The cell
+/// uses a wrapping horizontal layout: every label continues the current row,
+/// then uses the full column width for subsequent rows. Long code chunks call
+/// `ui.end_row()` in production, so they also finish a measurement row here.
 fn cell_visual_lines(
     cell: &[(pulldown_cmark::Event, Range<usize>)],
     ui: &Ui,
@@ -329,31 +328,33 @@ fn cell_visual_lines(
     let wrap_width = (column_width - 8.0).max(1.0);
     let item_spacing = ui.spacing().item_spacing.x;
     let mut remaining_width = wrap_width;
-    let mut group_lines = 0usize;
-    let mut visual_lines = 0usize;
-    let measure_label = |text: &str, font_id: &egui::FontId, available: f32| {
-        ui.painter().layout(
+    let mut completed_lines = 0usize;
+    let measure_label = |text: &str, font_id: &egui::FontId, used_width: f32| {
+        let mut job = egui::text::LayoutJob::simple(
             text.to_owned(),
             font_id.clone(),
             egui::Color32::WHITE,
-            available.max(1.0),
-        )
+            wrap_width,
+        );
+        if let Some(first_section) = job.sections.first_mut() {
+            first_section.leading_space = used_width;
+        }
+        ui.fonts_mut(|fonts| fonts.layout_job(job))
     };
 
     let add_label = |text: &str,
                      font_id: &egui::FontId,
                      remaining_width: &mut f32,
-                     group_lines: &mut usize| {
-        let galley = measure_label(text, font_id, *remaining_width);
-        let lines = galley.rows.len().max(1);
-        *group_lines = (*group_lines).max(lines);
-        // A wrapped Label consumes the available horizontal slot. A one-line
-        // Label advances only by its actual width plus inter-widget spacing.
-        if lines > 1 {
-            *remaining_width = 1.0;
-        } else {
-            *remaining_width = (*remaining_width - galley.size().x - item_spacing).max(1.0);
-        }
+                     completed_lines: &mut usize| {
+        let used_width = wrap_width - *remaining_width;
+        let galley = measure_label(text, font_id, used_width);
+        *completed_lines += galley.rows.len().saturating_sub(1);
+        let last_row_width = galley
+            .rows
+            .last()
+            .map_or(0.0, |row| row.rect().width())
+            .min(wrap_width);
+        *remaining_width = (wrap_width - last_row_width - item_spacing).max(0.0);
     };
 
     for (event, _) in cell {
@@ -362,7 +363,7 @@ fn cell_visual_lines(
             | pulldown_cmark::Event::InlineHtml(text)
             | pulldown_cmark::Event::Html(text)
             | pulldown_cmark::Event::FootnoteReference(text) => {
-                add_label(text, &body_font, &mut remaining_width, &mut group_lines);
+                add_label(text, &body_font, &mut remaining_width, &mut completed_lines);
             }
             pulldown_cmark::Event::Code(code) => {
                 let segments = inline_code_wrap_segments(code);
@@ -372,31 +373,30 @@ fn cell_visual_lines(
                         &segment,
                         &code_font,
                         &mut remaining_width,
-                        &mut group_lines,
+                        &mut completed_lines,
                     );
                     if force_rows {
-                        visual_lines += group_lines;
-                        group_lines = 0;
+                        completed_lines += 1;
                         remaining_width = wrap_width;
                     }
                 }
             }
             pulldown_cmark::Event::SoftBreak | pulldown_cmark::Event::HardBreak => {
-                add_label(" ", &body_font, &mut remaining_width, &mut group_lines);
+                add_label(" ", &body_font, &mut remaining_width, &mut completed_lines);
             }
             pulldown_cmark::Event::TaskListMarker(checked) => {
                 add_label(
                     if *checked { "[x] " } else { "[ ] " },
                     &body_font,
                     &mut remaining_width,
-                    &mut group_lines,
+                    &mut completed_lines,
                 );
             }
             _ => {}
         }
     }
 
-    (visual_lines + group_lines).max(1)
+    (completed_lines + usize::from(remaining_width < wrap_width)).max(1)
 }
 
 fn table_cell_height(
@@ -409,8 +409,22 @@ fn table_cell_height(
 ) -> f32 {
     let text = markdown_cell_text(cell);
     let mut height = wrapped_text_height(ui, &text, column_width, line_height).max(
-        line_height * 1.5 * cell_visual_lines(cell, ui, column_width) as f32,
+        line_height * cell_visual_lines(cell, ui, column_width) as f32
+            + ui.spacing().item_spacing.y,
     );
+    let has_visible_text = cell.iter().any(|(event, _)| {
+        matches!(
+            event,
+            pulldown_cmark::Event::Text(_)
+                | pulldown_cmark::Event::Code(_)
+                | pulldown_cmark::Event::InlineHtml(_)
+                | pulldown_cmark::Event::Html(_)
+                | pulldown_cmark::Event::FootnoteReference(_)
+                | pulldown_cmark::Event::TaskListMarker(_)
+        )
+    });
+    let mut inline_math_height = 0.0;
+    let mut inline_math_count = 0usize;
     for (event, _) in cell {
         // Images contribute their painted height. The URI has to be resolved
         // exactly the way the painting path does it (`Image::new` applies the
@@ -444,8 +458,19 @@ fn table_cell_height(
                 let _ = (cache, ui, options);
                 conservative
             };
-            height = height.max(formula_height);
+            inline_math_height += formula_height;
+            inline_math_count += 1;
         }
+    }
+    if inline_math_count == 1 && !has_visible_text {
+        height = height.max(inline_math_height);
+    } else if inline_math_count > 0 {
+        // Formula widgets participate in the same horizontal wrapping flow as
+        // labels. Without cached formula widths we cannot know whether each
+        // formula shares a row, so reserve their heights cumulatively whenever
+        // other visible content (or another formula) can force a row break.
+        height += inline_math_height
+            + (ui.spacing().item_spacing.y + 1.0) * inline_math_count as f32;
     }
     height
 }
@@ -504,7 +529,20 @@ fn wrapped_text_height(ui: &Ui, text: &str, column_width: f32, line_height: f32)
         egui::Color32::WHITE,
         (column_width - 8.0).max(1.0),
     );
-    line_height * 1.5 * galley.rows.len().max(1) as f32
+    line_height * galley.rows.len().max(1) as f32
+}
+
+fn body_line_height(ui: &Ui, options: &CommonMarkOptions) -> f32 {
+    let font = egui::TextStyle::Body.resolve(ui.style());
+    let natural = ui
+        .text_style_height(&egui::TextStyle::Body)
+        .max(font.size);
+    options
+        .typography
+        .resolve_line_height(font.size)
+        // A configured line box can be smaller than the glyphs, but a fixed
+        // table row must still reserve their natural painted height.
+        .map_or(natural, |configured| configured.max(natural))
 }
 
 /// Blend max-min fairness with proportional content demand while fitting the
@@ -1623,7 +1661,7 @@ impl CommonMarkViewerInternal {
             } else {
                 rows.first().map(|r| r.len()).unwrap_or(0)
             };
-            let line_h = ui.text_style_height(&egui::TextStyle::Body);
+            let line_h = body_line_height(ui, options);
 
             if num_cols == 0 {
                 self.is_table = false;
@@ -1633,7 +1671,7 @@ impl CommonMarkViewerInternal {
                 self.line.try_insert_end(ui);
                 return;
             }
-            let cell_h = line_h * 1.5;
+            let cell_h = line_h + ui.spacing().item_spacing.y;
             // Outer ScrollArea::horizontal handles the case where columns
             // (auto-sized to content) total wider than the parent ui; without it,
             // narrow windows clip the rightmost columns. Plain vertical wheel
@@ -1791,27 +1829,34 @@ impl CommonMarkViewerInternal {
                                                             Some(egui::TextWrapMode::Wrap);
                                                         let col_w = ui.max_rect().width();
                                                         ui.set_width(col_w);
-                                                        for (e, src_span) in col {
-                                                            let tmp_start = std::mem::replace(
-                                                                &mut self.line.should_start_newline,
-                                                                false,
-                                                            );
-                                                            let tmp_end = std::mem::replace(
-                                                                &mut self.line.should_end_newline,
-                                                                false,
-                                                            );
-                                                            self.event(
-                                                                ui,
-                                                                e.clone(),
-                                                                src_span.clone(),
-                                                                cache,
-                                                                options,
-                                                                col_w,
-                                                            );
-                                                            self.line.should_start_newline =
-                                                                tmp_start;
-                                                            self.line.should_end_newline = tmp_end;
-                                                        }
+                                                        // Isolate the wrapping cursor from the
+                                                        // preallocated TableBuilder row height.
+                                                        // Otherwise egui uses that entire height as
+                                                        // the first text line's minimum height and
+                                                        // later inline widgets overflow the row.
+                                                        ui.horizontal_wrapped(|ui| {
+                                                            for (e, src_span) in col {
+                                                                let tmp_start = std::mem::replace(
+                                                                    &mut self.line.should_start_newline,
+                                                                    false,
+                                                                );
+                                                                let tmp_end = std::mem::replace(
+                                                                    &mut self.line.should_end_newline,
+                                                                    false,
+                                                                );
+                                                                self.event(
+                                                                    ui,
+                                                                    e.clone(),
+                                                                    src_span.clone(),
+                                                                    cache,
+                                                                    options,
+                                                                    col_w,
+                                                                );
+                                                                self.line.should_start_newline =
+                                                                    tmp_start;
+                                                                self.line.should_end_newline = tmp_end;
+                                                            }
+                                                        });
                                                     });
                                                 }
                                         });
@@ -2536,8 +2581,8 @@ impl CommonMarkViewerInternal {
             .map(|r| r.len())
             .unwrap_or(0);
 
-        let line_h = ui.text_style_height(&egui::TextStyle::Body);
-        let cell_h = line_h * 1.5;
+        let line_h = body_line_height(ui, options);
+        let cell_h = line_h + ui.spacing().item_spacing.y;
 
         if num_cols == 0 {
             self.line.try_insert_end(ui);
@@ -2846,6 +2891,34 @@ mod tests {
             );
         });
         let _ = ctx.end_pass();
+    }
+
+    #[test]
+    fn table_body_line_height_respects_typography_configuration() {
+        use egui_commonmark_backend_extended::typography::Measurement;
+
+        egui::__run_test_ui(|ui| {
+            let font = egui::TextStyle::Body.resolve(ui.style());
+            let natural = ui
+                .text_style_height(&egui::TextStyle::Body)
+                .max(font.size);
+            let mut options = CommonMarkOptions::default();
+
+            assert!((body_line_height(ui, &options) - natural).abs() < 0.01);
+
+            options.typography.line_height = Some(Measurement::Multiplier(1.5));
+            assert!((body_line_height(ui, &options) - font.size * 1.5).abs() < 0.01);
+
+            options.typography.line_height = Some(Measurement::Pixels(27.0));
+            assert!((body_line_height(ui, &options) - 27.0).abs() < 0.01);
+
+            options.typography.line_height = Some(Measurement::Pixels(1.0));
+            let clamped = body_line_height(ui, &options);
+            assert!(
+                (clamped - natural).abs() < 0.01,
+                "configured={clamped} natural={natural}"
+            );
+        });
     }
 
     #[test]

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -311,22 +311,92 @@ fn inline_code_wrap_segments(text: &str) -> Vec<String> {
     segments
 }
 
-/// Count the visual lines a markdown table cell will occupy when rendered.
-/// Used by the `fn table` renderer to compute heterogeneous row heights so
-/// long inline-code paths (chunked by `inline_code_wrap_segments`) don't get
-/// clipped by a fixed row height. Only `Event::Code` chunking adds visual
-/// lines today; other inline events flow on a single line within a cell.
-fn cell_visual_lines(cell: &[(pulldown_cmark::Event, Range<usize>)]) -> usize {
-    let mut max_lines = 1usize;
+/// Measure a table cell's visible labels in their rendering order. Each label
+/// is laid out against the width left by earlier labels in the current row;
+/// this matters when a wider monospace label follows proportional text. Long
+/// code chunks call `ui.end_row()` in production, so they also finish a
+/// measurement group here.
+fn cell_visual_lines(
+    cell: &[(pulldown_cmark::Event, Range<usize>)],
+    ui: &Ui,
+    column_width: f32,
+) -> usize {
+    // `RichText::code().size(selected_font_size)` renders code with the body
+    // size and monospace family, not with the (usually smaller) Monospace text
+    // style. Keep measurement on that exact font-size path.
+    let body_font = egui::TextStyle::Body.resolve(ui.style());
+    let code_font = egui::FontId::new(body_font.size, egui::FontFamily::Monospace);
+    let wrap_width = (column_width - 8.0).max(1.0);
+    let item_spacing = ui.spacing().item_spacing.x;
+    let mut remaining_width = wrap_width;
+    let mut group_lines = 0usize;
+    let mut visual_lines = 0usize;
+    let measure_label = |text: &str, font_id: &egui::FontId, available: f32| {
+        ui.painter().layout(
+            text.to_owned(),
+            font_id.clone(),
+            egui::Color32::WHITE,
+            available.max(1.0),
+        )
+    };
+
+    let add_label = |text: &str,
+                     font_id: &egui::FontId,
+                     remaining_width: &mut f32,
+                     group_lines: &mut usize| {
+        let galley = measure_label(text, font_id, *remaining_width);
+        let lines = galley.rows.len().max(1);
+        *group_lines = (*group_lines).max(lines);
+        // A wrapped Label consumes the available horizontal slot. A one-line
+        // Label advances only by its actual width plus inter-widget spacing.
+        if lines > 1 {
+            *remaining_width = 1.0;
+        } else {
+            *remaining_width = (*remaining_width - galley.size().x - item_spacing).max(1.0);
+        }
+    };
+
     for (event, _) in cell {
-        if let pulldown_cmark::Event::Code(text) = event {
-            let chunks = inline_code_wrap_segments(text).len();
-            if chunks > max_lines {
-                max_lines = chunks;
+        match event {
+            pulldown_cmark::Event::Text(text)
+            | pulldown_cmark::Event::InlineHtml(text)
+            | pulldown_cmark::Event::Html(text)
+            | pulldown_cmark::Event::FootnoteReference(text) => {
+                add_label(text, &body_font, &mut remaining_width, &mut group_lines);
             }
+            pulldown_cmark::Event::Code(code) => {
+                let segments = inline_code_wrap_segments(code);
+                let force_rows = segments.len() > 1;
+                for segment in segments {
+                    add_label(
+                        &segment,
+                        &code_font,
+                        &mut remaining_width,
+                        &mut group_lines,
+                    );
+                    if force_rows {
+                        visual_lines += group_lines;
+                        group_lines = 0;
+                        remaining_width = wrap_width;
+                    }
+                }
+            }
+            pulldown_cmark::Event::SoftBreak | pulldown_cmark::Event::HardBreak => {
+                add_label(" ", &body_font, &mut remaining_width, &mut group_lines);
+            }
+            pulldown_cmark::Event::TaskListMarker(checked) => {
+                add_label(
+                    if *checked { "[x] " } else { "[ ] " },
+                    &body_font,
+                    &mut remaining_width,
+                    &mut group_lines,
+                );
+            }
+            _ => {}
         }
     }
-    max_lines
+
+    (visual_lines + group_lines).max(1)
 }
 
 fn table_cell_height(
@@ -338,8 +408,9 @@ fn table_cell_height(
     options: &CommonMarkOptions,
 ) -> f32 {
     let text = markdown_cell_text(cell);
-    let mut height = wrapped_text_height(ui, &text, column_width, line_height)
-        .max(line_height * 1.5 * cell_visual_lines(cell) as f32);
+    let mut height = wrapped_text_height(ui, &text, column_width, line_height).max(
+        line_height * 1.5 * cell_visual_lines(cell, ui, column_width) as f32,
+    );
     for (event, _) in cell {
         // Images contribute their painted height. The URI has to be resolved
         // exactly the way the painting path does it (`Image::new` applies the
@@ -2724,6 +2795,124 @@ mod tests {
             }
         }
         visible
+    }
+
+    #[test]
+    fn table_cells_measure_inline_code_with_the_monospace_font() {
+        let ctx = egui::Context::default();
+        ctx.begin_pass(Default::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            let mut style = ui.style().as_ref().clone();
+            style
+                .text_styles
+                .insert(egui::TextStyle::Body, egui::FontId::proportional(16.0));
+            style
+                .text_styles
+                .insert(egui::TextStyle::Monospace, egui::FontId::monospace(14.0));
+            ui.set_style(style);
+            let cache = CommonMarkCache::default();
+            let line_height = ui.text_style_height(&egui::TextStyle::Body);
+            let code = "iiiiiiiiiiiiiiiiiiiiiiii";
+            let body_font = egui::TextStyle::Body.resolve(ui.style());
+            let mono_font = egui::FontId::new(body_font.size, egui::FontFamily::Monospace);
+            let body_width = ui
+                .painter()
+                .layout_no_wrap(code.to_owned(), body_font, egui::Color32::WHITE)
+                .size()
+                .x;
+            let mono_width = ui
+                .painter()
+                .layout_no_wrap(code.to_owned(), mono_font, egui::Color32::WHITE)
+                .size()
+                .x;
+            assert!(
+                mono_width > body_width,
+                "expected monospace code to be wider: body={body_width} mono={mono_width}"
+            );
+
+            // `wrapped_text_height` subtracts 8 px before layout. Choose a
+            // width where Body still fits but the rendered monospace code
+            // must wrap, exposing the old one-line row-height estimate.
+            let column_width = (body_width + mono_width) * 0.5 + 8.0;
+            let cell = vec![(Event::Code(code.into()), 0..code.len())];
+            let options = CommonMarkOptions::default();
+
+            let height =
+                table_cell_height(&cell, line_height, &cache, ui, column_width, &options);
+            assert!(height >= line_height * 2.0);
+            assert!(
+                height < line_height * 3.0,
+                "two visual lines should not reserve a third: {height}"
+            );
+        });
+        let _ = ctx.end_pass();
+    }
+
+    #[test]
+    fn table_cells_accumulate_rows_from_multiple_chunked_code_events() {
+        egui::__run_test_ui(|ui| {
+            let first = "a".repeat(60);
+            let second = "b".repeat(60);
+            let cell = vec![
+                (Event::Code(first.into()), 0..60),
+                (Event::Text(" between ".into()), 60..69),
+                (Event::Code(second.into()), 69..129),
+            ];
+
+            assert_eq!(cell_visual_lines(&cell, ui, 2_000.0), 4);
+        });
+    }
+
+    #[test]
+    fn table_cells_measure_short_code_with_the_width_left_by_text() {
+        let ctx = egui::Context::default();
+        ctx.begin_pass(Default::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            let mut style = ui.style().as_ref().clone();
+            style
+                .text_styles
+                .insert(egui::TextStyle::Body, egui::FontId::proportional(16.0));
+            style
+                .text_styles
+                .insert(egui::TextStyle::Monospace, egui::FontId::monospace(14.0));
+            ui.set_style(style);
+            let plain = "iiiiiiiiiiii";
+            let code = "iiiiiiiiiiii";
+            let body_font = egui::TextStyle::Body.resolve(ui.style());
+            let code_font = egui::FontId::new(body_font.size, egui::FontFamily::Monospace);
+            let plain_width = ui
+                .painter()
+                .layout_no_wrap(plain.to_owned(), body_font.clone(), egui::Color32::WHITE)
+                .size()
+                .x;
+            let code_as_body_width = ui
+                .painter()
+                .layout_no_wrap(code.to_owned(), body_font, egui::Color32::WHITE)
+                .size()
+                .x;
+            let code_width = ui
+                .painter()
+                .layout_no_wrap(code.to_owned(), code_font, egui::Color32::WHITE)
+                .size()
+                .x;
+            assert!(
+                code_width > code_as_body_width,
+                "expected code to be wider: body={code_as_body_width} code={code_width}"
+            );
+
+            // Body-only estimation fits, and either run fits alone, but the
+            // real mixed-font line does not.
+            let body_total = plain_width + code_as_body_width;
+            let mixed_total = plain_width + code_width;
+            let column_width = (body_total + mixed_total) * 0.5 + 8.0;
+            let cell = vec![
+                (Event::Text(plain.into()), 0..plain.len()),
+                (Event::Code(code.into()), plain.len()..plain.len() + code.len()),
+            ];
+
+            assert_eq!(cell_visual_lines(&cell, ui, column_width), 2);
+        });
+        let _ = ctx.end_pass();
     }
 
     #[test]

--- a/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
+++ b/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
@@ -11,16 +11,18 @@ struct PaintedText {
     text: String,
     rect: Rect,
     rows: usize,
+    clip_rect: Rect,
     underlined: bool,
 }
 
-fn collect_painted_text(shape: &Shape, painted: &mut Vec<PaintedText>) {
+fn collect_painted_text(shape: &Shape, clip_rect: Rect, painted: &mut Vec<PaintedText>) {
     // Text can be emitted directly or nested in a grouped Shape::Vec.
     match shape {
         Shape::Text(text) => painted.push(PaintedText {
             text: text.galley.job.text.clone(),
             rect: text.galley.rect.translate(text.pos.to_vec2()),
             rows: text.galley.rows.len(),
+            clip_rect,
             underlined: text
                 .galley
                 .job
@@ -30,7 +32,7 @@ fn collect_painted_text(shape: &Shape, painted: &mut Vec<PaintedText>) {
         }),
         Shape::Vec(shapes) => {
             for shape in shapes {
-                collect_painted_text(shape, painted);
+                collect_painted_text(shape, clip_rect, painted);
             }
         }
         _ => {}
@@ -78,6 +80,7 @@ fn render_geometry_with_body_size(
             let response = CommonMarkViewer::new()
                 .default_width(Some(width as usize))
                 .table_max_width(Some(width as usize))
+                .line_height(1.5)
                 .show(ui, &mut cache, markdown);
             body_rect = response.response.rect;
         });
@@ -86,7 +89,7 @@ fn render_geometry_with_body_size(
         // Only final-pass positions represent the settled layout.
         if pass == 1 {
             for clipped in output.shapes {
-                collect_painted_text(&clipped.shape, &mut painted);
+                collect_painted_text(&clipped.shape, clipped.clip_rect, &mut painted);
             }
         }
     }
@@ -123,6 +126,21 @@ fn text_rect(painted: &[PaintedText], marker: &str) -> Rect {
         .find(|entry| entry.text.contains(marker))
         .unwrap_or_else(|| panic!("missing painted marker {marker:?}: {painted:#?}"))
         .rect
+}
+
+fn assert_text_fully_visible(painted: &[PaintedText], marker: &str) {
+    let entry = painted
+        .iter()
+        .find(|entry| entry.text.contains(marker))
+        .unwrap_or_else(|| panic!("missing painted marker {marker:?}: {painted:#?}"));
+    let tolerance = 0.5;
+    assert!(
+        entry.rect.left() >= entry.clip_rect.left() - tolerance
+            && entry.rect.right() <= entry.clip_rect.right() + tolerance
+            && entry.rect.top() >= entry.clip_rect.top() - tolerance
+            && entry.rect.bottom() <= entry.clip_rect.bottom() + tolerance,
+        "marker {marker:?} is clipped: entry={entry:?}"
+    );
 }
 
 fn assert_vertical_order(painted: &[PaintedText], markers: &[&str]) {
@@ -231,7 +249,7 @@ fn table_cell_height_after_widths(markdown: &str, widths: &[f32], marker: &str) 
             if pass == 1 {
                 let mut painted = Vec::new();
                 for clipped in output.shapes {
-                    collect_painted_text(&clipped.shape, &mut painted);
+                    collect_painted_text(&clipped.shape, clipped.clip_rect, &mut painted);
                 }
                 heights.push(text_rect(&painted, marker).height());
             }
@@ -265,6 +283,59 @@ fn html_table_reflows_after_panel_width_changes() {
 
     assert!(heights[1] < heights[0], "table did not widen: {heights:?}");
     assert!(heights[2] > heights[1], "table did not narrow: {heights:?}");
+}
+
+#[test]
+fn markdown_table_wraps_multiple_links_inside_their_cell() {
+    let markdown = "\
+| Signal | Reports |
+|---|---|
+| selected | [REPORT_IF](https://example.test/if) / [REPORT_IH](https://example.test/ih) / [REPORT_IC](https://example.test/ic) / [REPORT_IM](https://example.test/im) |
+
+AFTER_LINK_TABLE";
+    let (_, _, painted) = render_geometry(markdown, 280.0);
+
+    for marker in ["REPORT_IF", "REPORT_IH", "REPORT_IC", "REPORT_IM"] {
+        assert_text_fully_visible(&painted, marker);
+    }
+    let link_tops: std::collections::BTreeSet<_> = painted
+        .iter()
+        .filter(|entry| entry.underlined && entry.text.starts_with("REPORT_"))
+        .map(|entry| entry.rect.top().round() as i32)
+        .collect();
+    assert!(link_tops.len() > 1, "links did not wrap: {painted:#?}");
+    assert_vertical_order(&painted, &["REPORT_IM", "AFTER_LINK_TABLE"]);
+}
+
+#[test]
+fn markdown_table_wraps_mixed_prose_and_inline_code_without_clipping() {
+    let markdown = "\
+| Field | Requirement |
+|---|---|
+| `raw_formula` | 实际研究的原始公式；不得只保存名称、摘要或 `hash`；仅 `formula_status=unclear` 时可为空，并须说明缺失原因 |
+
+AFTER_MIXED_TABLE";
+    let (_, _, painted) = render_geometry(markdown, 320.0);
+
+    for marker in ["raw_formula", "hash", "formula_status=unclear"] {
+        assert_text_fully_visible(&painted, marker);
+    }
+    assert_vertical_order(&painted, &["formula_status=unclear", "AFTER_MIXED_TABLE"]);
+}
+
+#[test]
+#[cfg(feature = "math")]
+fn markdown_table_wraps_text_around_inline_math_without_clipping() {
+    let markdown = "\
+| Field | Requirement |
+|---|---|
+| value | PREFIX_MATH_TEXT with enough words to use the first line $\\frac{a+b}{c+d}$ TAIL_AFTER_MATH |
+
+AFTER_MATH_TABLE";
+    let (_, _, painted) = render_geometry(markdown, 300.0);
+
+    assert_text_fully_visible(&painted, "TAIL_AFTER_MATH");
+    assert_vertical_order(&painted, &["TAIL_AFTER_MATH", "AFTER_MATH_TABLE"]);
 }
 
 // ---------------------------------------------------------------------------
@@ -398,7 +469,7 @@ fn deep_scroll_keeps_content_extent_and_paints_visible_text() {
             let mut visible_text = 0;
             for clipped in output.shapes {
                 let mut painted = Vec::new();
-                collect_painted_text(&clipped.shape, &mut painted);
+                collect_painted_text(&clipped.shape, clipped.clip_rect, &mut painted);
                 visible_text += painted
                     .iter()
                     .filter(|text| text.rect.intersects(clipped.clip_rect))

--- a/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
+++ b/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
@@ -324,6 +324,23 @@ AFTER_MIXED_TABLE";
 }
 
 #[test]
+fn selected_family_style_table_has_no_vertically_clipped_text() {
+    let table = "\
+| a | b | c | d | e | f | g | h | i | j | k | l | m |
+|---:|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| 1 | `ccofi_anchor_queue_alignment` | snapshot5_cross20_broad10 | 0.026103 | 0.535295 | 0.464705 | 0.940817 | +0.000075270 ([+0.000034283, +0.000116016]) | +0.000033623 | +0.000151384 | 0.131561 | 0.074240/0.009615/0.192383 | [IF](if) / [IH](ih) / [IC](ic) / [IM](im) |";
+    let (_, _, painted) = render_geometry(table, 640.0);
+    let clipped: Vec<_> = painted
+        .iter()
+        .filter(|entry| {
+            entry.rect.top() < entry.clip_rect.top() - 0.5
+                || entry.rect.bottom() > entry.clip_rect.bottom() + 0.5
+        })
+        .collect();
+    assert!(clipped.is_empty(), "{clipped:#?}");
+}
+
+#[test]
 #[cfg(feature = "math")]
 fn markdown_table_wraps_text_around_inline_math_without_clipping() {
     let markdown = "\

--- a/crates/egui_commonmark/egui_commonmark_backend/src/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/pulldown.rs
@@ -130,6 +130,11 @@ fn parse_row<'e>(
         if let pulldown_cmark::Event::End(pulldown_cmark::TagEnd::TableCell) = e {
             row.push(column);
             column = Vec::new();
+            // The boundary belongs between cells, not at the start of the
+            // following cell. Keeping it in `column` makes the renderer's
+            // TableCell-end handler paint a two-space label before every
+            // column after the first, changing its wrap point and row height.
+            continue;
         }
 
         if let pulldown_cmark::Event::End(pulldown_cmark::TagEnd::TableHead) = e {
@@ -353,5 +358,29 @@ mod tests {
         let mut iter = events.into_iter().enumerate();
         let collected = delayed_events_list_item(&mut iter);
         assert_eq!(collected.len(), 2);
+    }
+
+    #[test]
+    fn parsed_table_cells_do_not_keep_neighbor_boundaries() {
+        let md = "| first | second |\n|---|---|\n| alpha | beta |";
+        let events: Vec<_> = Parser::new_ext(md, parser_options())
+            .into_offset_iter()
+            .map(|(event, range)| (event.into_static(), range))
+            .collect();
+        let table_start = events
+            .iter()
+            .position(|(event, _)| matches!(event, Event::Start(Tag::Table(_))))
+            .expect("table start");
+        let mut iter = events.into_iter().enumerate().skip(table_start + 1);
+        let table = parse_table(&mut iter);
+
+        for cell in table.header.iter().chain(table.rows.iter().flatten()) {
+            assert!(
+                !cell
+                    .iter()
+                    .any(|(event, _)| matches!(event, Event::End(TagEnd::TableCell))),
+                "cell boundary leaked into visible cell events: {cell:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- measure inline code with the Body-sized monospace font used by rendering
- measure text, links, inline HTML, footnote references, and inline code in event order with production-like wrapping
- isolate each cell wrapping cursor from TableBuilder preallocated row height so later inline widgets cannot grow past the row clip
- derive table row height from configured typography instead of a separate hard-coded multiplier
- reserve cumulative height for inline math, images, and mixed content using the current renderer options
- discard structural `End(TableCell)` events instead of painting them as hidden spacing in the next cell

## Regression coverage

Production geometry tests cover:

- multiple links wrapping within one narrow cell, including horizontal and vertical clip bounds and following content
- Chinese prose mixed with `raw_formula`, `hash`, and `formula_status=unclear` inline code
- text before and after inline math with the `math` feature enabled
- a representative 13-column selected-family table
- the application line-height configuration

Additional unit tests cover Body/Monospace width differences, multiple chunked code events, remaining-width wrapping, configured typography resolution, and parsed cell boundaries.

## Rebase integration

Rebased onto current `main` after #115 merged. The conflict resolution preserves:

- #114 table bounds and resize reflow
- #115 header floors and balanced column widths
- #129 image measurement and renderer options
- #131 exact reserved table height

The #129 options adaptation is folded into the first functional commit, leaving three focused commits.

## Testing

- application: 60 passed, 1 environment-dependent font test ignored
- renderer library with math: 74 passed
- renderer slice/wrapping integration with math: 1 + 23 passed
- renderer doctests with math and macros: 16 passed, 1 ignored
- backend with all features: 28 passed, 1 doctest passed
- macros: 4 unit tests and 7 trybuild cases passed; 1 doctest passed, 2 ignored
- `cargo fmt --all -- --check`
- `git diff --check`
- independent high-level review of the final rebased head: no blocker

Follow-up to #71 and #98.