### PR TITLE
Add font selection UI for customizable document font

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A fast, lightweight markdown viewer for Linux built with Rust and egui. Designed
 - **Keyboard Scrolling** - Scroll documents with ↑/↓ by line or Page Up/Page Down by page when the find bar is closed
 - **Live Reload** - Auto-refresh on file changes (enabled by default)
 - **Custom Colors** - Customize highlight and link text colors (View → Colors…)
+- **Font Selection** - Browse and apply installed system fonts via View menu (searchable, persistent)
 
 *Full Width, Formula Size and the colour picker all live in the View menu*
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A fast, lightweight markdown viewer for Linux built with Rust and egui. Designed
 - **Live Reload** - Auto-refresh on file changes (enabled by default)
 - **Custom Colors** - Customize highlight and link text colors (View → Colors…)
 - **Font Selection** - Browse and apply installed system fonts via View menu (searchable, persistent)
+- **Smooth Text Rendering** - Optional toggle (View → Smooth Text Rendering) that disables glyph pixel-snapping for less jagged-looking text at fractional zoom levels
 
 *Full Width, Formula Size and the colour picker all live in the View menu*
 

--- a/docs/devlog/056-font-selection.md
+++ b/docs/devlog/056-font-selection.md
@@ -1,0 +1,142 @@
+# Feature: Document Font Selection
+
+**Status:** ✅ Complete
+**Branch:** `feature/font-selection`
+**Date:** 2026-08-31
+**Lines Changed:** +226 / -29 across `src/main.rs` (+134/-24) and `src/system_fonts.rs` (+121/-5)
+
+## Summary
+
+Lets the user pick which installed system font renders the markdown body/heading
+text (the `FontFamily::Proportional` chain), instead of always using the
+auto-detected system sans-serif. Selection persists across sessions. The
+monospace/code font is untouched.
+
+## Features
+
+- [x] `system_fonts::setup_fonts` accepts an optional preferred family name and
+      falls back to today's auto-detected sans-serif chain when unset/not found
+- [x] `setup_fonts` returns the sorted list of installed family names so the UI
+      doesn't need a second `fontique::Collection` scan
+- [x] `View → Font…` opens a searchable picker window (`egui::Window`)
+- [x] Selection persisted in `PersistedState.selected_font_family`
+- [x] Font reload only runs when the selection actually changes (mirrors the
+      existing `last_applied_dark_mode` pattern), not per-frame
+
+## Key Discoveries
+
+### fontique name lookup is case-insensitive and safe to call every time
+
+`Collection::family_id(&mut self, name: &str) -> Option<FamilyId>` matches
+against a lowercased key (`fontique-0.11.1/src/family_name.rs`), so any name
+returned from `family_names()` round-trips through `family_id()` without
+needing exact-case bookkeeping.
+
+### Bold companion resolution needed no changes
+
+`install_strong_font_family` already derives the bold face from whichever
+family was installed as `primary` (looked up by `regular.selected.family_id`),
+regardless of whether that family came from the auto-detect path or a
+user preference. Wiring the preferred family into the *same* `"SystemSans"`
+primary slot in `install_regular_fonts` meant the existing strong-font-family
+and script/generic fallback logic needed zero changes.
+
+## Architecture
+
+### New/Modified Structs
+
+```rust
+// PersistedState
+selected_font_family: Option<String>, // None = system default (auto-detected)
+
+// MarkdownApp
+selected_font_family: Option<String>,
+available_font_families: Vec<String>,   // populated once at startup from setup_fonts()'s return value
+last_applied_font_family: Option<String>,
+show_font_dialog: bool,
+font_filter: String,                    // transient UI-only search text, not persisted
+```
+
+### New Functions
+
+| Function | Purpose |
+|----------|---------|
+| `system_fonts::setup_fonts(ctx, preferred_family: Option<&str>) -> Vec<String>` | Same as before, plus optional named-family preference; now returns the sorted family name list |
+| `MarkdownApp::render_font_settings(&mut self, ctx)` | Renders the `View → Font…` picker window |
+
+## Testing Notes
+
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`
+  (56 passed) all clean.
+- Added two new `system_fonts` tests behind `#[ignore = "requires installed
+  system fonts"]` (matching the existing sibling test's convention, since
+  CI's `ubuntu-latest` image isn't guaranteed to have real fonts installed):
+  `unknown_preferred_family_falls_back_to_auto_detect` and
+  `known_preferred_family_becomes_primary` (the latter is self-consistent —
+  it discovers whatever the auto-detected default sans is, then re-requests
+  it by name, so it doesn't hardcode a font that might not exist on every
+  machine). Ran locally with `cargo test -- --ignored`: both pass, along with
+  the pre-existing ignored coverage test.
+- Manual end-to-end verification via Xvfb + xdotool + ImageMagick `import`
+  (this sandbox had no toolchain or GUI test tools at all going in; installed
+  rustup, Fedora build deps, and the Xvfb/xdotool/ImageMagick stack already
+  used by `scripts/visual-regression.sh`, then drove the real binary):
+  - Opened `View → Font…`, confirmed the picker lists real installed families
+    (Adwaita Sans, Cantarell, Droid Sans, etc.) with "System Default" marked
+    selected.
+  - Typed "Caladea" in the search box — list filtered live to the one match.
+  - Clicked it — **entire UI** (menu bar, sidebar, tabs, document body,
+    heading, and `**bold**` text) switched to the serif face immediately,
+    confirming both the regular and bold-companion face resolution worked.
+  - Closed and relaunched the binary (same `XDG_DATA_HOME`/`XDG_CONFIG_HOME`)
+    — Caladea was still applied on the very first frame, and the View menu
+    correctly read "Font: Caladea…".
+- Known, expected scope: the font choice governs `FontFamily::Proportional`,
+  which is what nearly all egui widgets use by default — so it restyles the
+  whole app's UI text, not just the markdown pane. This matches how the
+  existing dark/light and zoom settings behave (global, not per-document) and
+  was not flagged as a problem during manual testing.
+
+## Future Improvements
+
+- [ ] Separate monospace/code-font picker (explicitly out of scope here per
+      user request, which was about "a font" for the document, not code)
+- [ ] Live preview sample text in the picker window
+
+## Optimization Pass (2026-09-01)
+
+User confirmed the feature worked, then asked for a pass to optimize it.
+Two real (not micro-) issues found by re-reading the diff against
+`docs/EGUI_WORKFLOW.md`'s "never allocate in the render loop" rule and the
+existing `render_outline`/`show_rows` precedent in this same file:
+
+1. **Per-frame allocation while the picker is open.** The filter loop ran
+   `name.to_ascii_lowercase()` for every installed font family (100–300+ on a
+   typical system) on every repaint — and repaints happen on a timer, not
+   just on click/keystroke, because `update()` already schedules periodic
+   `request_repaint_after` while file-watching is on. So this cost was paid
+   repeatedly for as long as the dialog stayed open, not just once.
+   **Fix:** precompute `available_font_families_lower: Vec<String>` once at
+   startup (same one-time-lowercase idiom `find_matches` already uses per
+   `docs/LESSONS.md`'s `to_ascii_lowercase` note), and only build a
+   `Vec<usize>` of matching indices when the search box is non-empty — the
+   common empty-filter case now allocates nothing per frame.
+2. **All matching rows got a widget every frame regardless of scroll
+   position.** Switched `ScrollArea::show` to `ScrollArea::show_rows`,
+   mirroring `render_outline`'s existing virtualization (see
+   `docs/LESSONS.md`, "show_rows for the outline drops O(headers) per frame
+   to O(visible)"). "System Default" is row 0, unconditionally pinned and
+   exempt from filtering (unchanged behavior).
+
+Also dropped an unnecessary `persisted.selected_font_family.clone()` in
+`MarkdownApp::new()` in favor of a plain move — `persisted`'s other fields
+are already partial-moved out field-by-field elsewhere in the same
+constructor (`open_tabs`, `explorer_root`, etc.), so this just matches
+existing style instead of paying for a clone nothing needed.
+
+Re-verified after the change: `cargo fmt --check` / `cargo clippy --all-targets
+-- -D warnings` / `cargo test` (56 passed, 3 ignored) all clean, and a fresh
+Xvfb pass confirmed the unfiltered list, the "sans" search filter, and
+clicking a filtered result (Liberation Sans) all still work identically to
+before — the optimization changed only how the data gets to the screen, not
+what appears.

--- a/docs/devlog/057-smooth-text-rendering.md
+++ b/docs/devlog/057-smooth-text-rendering.md
@@ -1,0 +1,78 @@
+# Feature: Smooth Text Rendering Toggle
+
+**Status:** ✅ Complete
+**Branch:** `feature/font-selection` (folded in alongside the font picker; originally developed on `feature/smooth-text-rendering`)
+**Date:** 2026-09-02
+**Lines Changed:** +~35 in `src/main.rs`, +2 in `README.md`
+
+## Summary
+
+User reported font rendering looked jagged/aliased. Adds a **View → Smooth
+Text Rendering** toggle that disables egui's `round_text_to_pixels`
+tessellation option. Off by default (preserves current behavior); persists
+across restarts.
+
+## Key Discoveries
+
+### `round_text_to_pixels` is the actual knob for "jagged" text, not `feathering`
+
+`epaint::TessellationOptions::feathering` explicitly documents "This setting
+does not affect text" — it only smooths shape edges (rects, lines, circles).
+The relevant option is `round_text_to_pixels` (default `true`): it snaps each
+glyph's position to the physical pixel grid. That's normally what you want
+for crisp text, but this app's zoom levels (`Ctrl+Scroll`, `Ctrl+/-`, 0.5–3.0
+continuous) routinely produce a fractional effective `pixels_per_point`
+(native scale × zoom). Under a fractional ratio, per-glyph rounding makes
+letter spacing land inconsistently between characters, which reads as
+"jagged" rather than crisp. Disabling the snap lets glyphs render at their
+exact sub-pixel position, using epaint's normal alpha-coverage
+anti-aliasing for the edges instead.
+
+### `ctx.tessellation_options_mut()` is not covered by the startup memory-clear
+
+`MarkdownApp::new()` clears `ctx.memory_mut(|mem| mem.data = ...)` at startup
+to drop stale persisted egui widget state (see `docs/ARCHITECTURE.md`).
+Tessellation options live under `ctx.memory().options`, a separate field —
+unaffected by that clear, so no special handling was needed here.
+
+### No last-applied change-gate needed
+
+Every other cross-frame setting in this file (`dark_mode`, `highlight_color`,
+`link_color`) uses a `last_applied_*` field to avoid rebuilding `Visuals`
+every frame. `ctx.tessellation_options_mut()` is a single field write into
+egui's own memory struct — cheaper than the comparison itself would be — so
+it's applied unconditionally every frame, right next to the existing
+unconditional `ctx.set_zoom_factor(self.zoom_level)` call, which follows the
+same "just set it, it's free" precedent already in this codebase.
+
+## Architecture
+
+### New/Modified Fields
+
+```rust
+// PersistedState
+smooth_text_rendering: Option<bool>, // None/Some(false) = pixel-snapped (today's default)
+
+// MarkdownApp
+smooth_text_rendering: bool,
+```
+
+No new functions — this is a straight persisted-bool-toggle following the
+existing `full_width_content` pattern (menu button with a `✓` prefix when on,
+no separate settings window).
+
+## Testing Notes
+
+- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo test`
+  (56 passed, 1 ignored) all clean.
+- Not verified visually in this sandbox (no GUI test tooling installed at the
+  time of writing); logic mirrors the already-shipped `full_width_content`
+  toggle exactly, so the persistence/menu wiring risk is low. Recommend a
+  manual before/after screenshot comparison at a fractional zoom level (e.g.
+  125%) to confirm the visual improvement matches the reported complaint.
+
+## Future Improvements
+
+- [ ] If glyphs still look thin/uneven after this, look at `FontTweak::scale`
+      per-family, or exposing `feathering_size_in_pixels` (shape-only, not
+      text, but worth ruling out for borders/backgrounds around text).

--- a/src/main.rs
+++ b/src/main.rs
@@ -383,6 +383,9 @@ struct PersistedState {
     /// Hyperlink text color override, same premultiplied-RGBA encoding as
     /// `highlight_color`. `None` = current theme default.
     link_color: Option<[u8; 4]>,
+    /// Preferred document body/heading font family name. `None` means use the
+    /// auto-detected system sans-serif (see `system_fonts::setup_fonts`).
+    selected_font_family: Option<String>,
     open_tabs: Option<Vec<PathBuf>>,
     active_tab: Option<usize>,
     // File explorer state
@@ -1904,6 +1907,20 @@ struct MarkdownApp {
     link_color: Option<egui::Color32>,
     last_applied_link_color: Option<egui::Color32>,
     show_color_settings_dialog: bool,
+    // Document body/heading font. `None` = auto-detected system sans-serif.
+    selected_font_family: Option<String>,
+    // All installed system font family names, scanned once at startup.
+    available_font_families: Vec<String>,
+    // Lowercased copy of `available_font_families`, precomputed once so the
+    // font-picker search filter doesn't re-lowercase every name on every
+    // frame it's open (see docs/EGUI_WORKFLOW.md: never allocate in the
+    // render loop what can be cached).
+    available_font_families_lower: Vec<String>,
+    // Mirrors `last_applied_dark_mode`: only reload fonts when this changes.
+    last_applied_font_family: Option<String>,
+    show_font_dialog: bool,
+    // Transient UI-only search text for the font picker (not persisted).
+    font_filter: String,
     watch_enabled: bool,
     error_message: Option<String>,
     is_dragging: bool,
@@ -1956,8 +1973,20 @@ struct MarkdownApp {
 
 impl MarkdownApp {
     fn new(cc: &eframe::CreationContext<'_>, file: Option<PathBuf>, watch: bool) -> Self {
+        // Load persisted state (needed before font setup, which reads the
+        // persisted font preference)
+        let persisted: PersistedState = cc
+            .storage
+            .and_then(|s| eframe::get_value(s, APP_KEY))
+            .unwrap_or_default();
+        let selected_font_family = persisted.selected_font_family;
+
         // Setup fonts with system font fallbacks for Unicode support
-        setup_fonts(&cc.egui_ctx);
+        let available_font_families = setup_fonts(&cc.egui_ctx, selected_font_family.as_deref());
+        let available_font_families_lower: Vec<String> = available_font_families
+            .iter()
+            .map(|name| name.to_ascii_lowercase())
+            .collect();
 
         // Clear stale egui widget data loaded from disk (scroll offsets, panel sizes, etc.)
         // We don't persist egui memory (see persist_egui_memory), but eframe always
@@ -2009,12 +2038,6 @@ impl MarkdownApp {
             // Reduce resize grab radius to prevent overlap with adjacent scrollbars
             style.interaction.resize_grab_radius_side = SIDEBAR_RESIZE_GRAB_RADIUS;
         });
-
-        // Load persisted state
-        let persisted: PersistedState = cc
-            .storage
-            .and_then(|s| eframe::get_value(s, APP_KEY))
-            .unwrap_or_default();
 
         let dark_mode = persisted
             .dark_mode
@@ -2129,6 +2152,14 @@ impl MarkdownApp {
             link_color,
             last_applied_link_color: link_color,
             show_color_settings_dialog: false,
+            // Already applied above via setup_fonts(); last_applied starts in
+            // sync so update() doesn't redundantly reload fonts on frame 1.
+            last_applied_font_family: selected_font_family.clone(),
+            selected_font_family,
+            available_font_families,
+            available_font_families_lower,
+            show_font_dialog: false,
+            font_filter: String::new(),
             watch_enabled: watch,
             error_message: startup_error,
             is_dragging: false,
@@ -4107,6 +4138,102 @@ impl MarkdownApp {
         }
     }
 
+    fn render_font_settings(&mut self, ctx: &egui::Context) {
+        if !self.show_font_dialog {
+            return;
+        }
+
+        let mut open = true;
+        // Set inside the window closure, applied after `.show()` returns —
+        // keeps the closure from needing a second mutable borrow of `self`
+        // beyond the local `open` flag used by `.open(&mut open)`.
+        let mut new_selection: Option<Option<String>> = None;
+
+        egui::Window::new("Document Font")
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(true)
+            .default_width(320.0)
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Search:");
+                    let filter_edit = ui.text_edit_singleline(&mut self.font_filter);
+                    #[cfg(feature = "mcp")]
+                    self.mcp_bridge.register_widget(
+                        "Font Dialog: Search",
+                        "textbox",
+                        &filter_edit,
+                        None,
+                    );
+                    #[cfg(not(feature = "mcp"))]
+                    let _ = filter_edit;
+                });
+                ui.separator();
+
+                // Only the empty-filter (common) case avoids allocating: it
+                // reuses `available_font_families` directly. A non-empty
+                // filter needs one Vec<usize> of matching indices, built from
+                // the precomputed lowercase names (no per-name allocation).
+                let filter = self.font_filter.to_ascii_lowercase();
+                let filtered_indices: Option<Vec<usize>> = if filter.is_empty() {
+                    None
+                } else {
+                    Some(
+                        self.available_font_families_lower
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, lower)| lower.contains(&filter))
+                            .map(|(i, _)| i)
+                            .collect(),
+                    )
+                };
+                let match_count = filtered_indices
+                    .as_ref()
+                    .map_or(self.available_font_families.len(), Vec::len);
+
+                let row_height = ui.spacing().interact_size.y;
+                egui::ScrollArea::vertical().max_height(360.0).show_rows(
+                    ui,
+                    row_height,
+                    match_count + 1, // + 1 for the pinned "System Default" row
+                    |ui, rows| {
+                        for row in rows {
+                            if row == 0 {
+                                let default_selected = self.selected_font_family.is_none();
+                                let default_btn =
+                                    ui.selectable_label(default_selected, "System Default");
+                                #[cfg(feature = "mcp")]
+                                self.mcp_bridge.register_widget(
+                                    "Font Dialog: System Default",
+                                    "button",
+                                    &default_btn,
+                                    Some(if default_selected { "selected" } else { "" }),
+                                );
+                                if default_btn.clicked() {
+                                    new_selection = Some(None);
+                                }
+                                continue;
+                            }
+                            let font_index = filtered_indices
+                                .as_ref()
+                                .map_or(row - 1, |indices| indices[row - 1]);
+                            let name = &self.available_font_families[font_index];
+                            let is_selected =
+                                self.selected_font_family.as_deref() == Some(name.as_str());
+                            if ui.selectable_label(is_selected, name).clicked() {
+                                new_selection = Some(Some(name.clone()));
+                            }
+                        }
+                    },
+                );
+            });
+
+        self.show_font_dialog = open;
+        if let Some(choice) = new_selection {
+            self.selected_font_family = choice;
+        }
+    }
+
     fn render_lightbox(&mut self, ctx: &egui::Context) {
         let Some(lightbox) = &mut self.lightbox else {
             return;
@@ -4370,6 +4497,7 @@ impl eframe::App for MarkdownApp {
             math_scale: Some(self.math_scale),
             highlight_color: self.highlight_color.map(|c| [c.r(), c.g(), c.b(), c.a()]),
             link_color: self.link_color.map(|c| [c.r(), c.g(), c.b(), c.a()]),
+            selected_font_family: self.selected_font_family.clone(),
             open_tabs: Some(self.get_open_tab_paths()),
             active_tab: Some(self.active_tab),
             show_explorer: Some(self.show_explorer),
@@ -4457,6 +4585,14 @@ impl eframe::App for MarkdownApp {
                 visuals.hyperlink_color = color;
             }
             ctx.set_visuals(visuals);
+        }
+
+        // Reload fonts only when the selected family actually changes —
+        // rescanning the system font collection on every frame would be
+        // expensive and is unnecessary (see docs/EGUI_WORKFLOW.md).
+        if self.last_applied_font_family != self.selected_font_family {
+            self.last_applied_font_family = self.selected_font_family.clone();
+            setup_fonts(ctx, self.selected_font_family.as_deref());
         }
 
         ctx.set_zoom_factor(self.zoom_level);
@@ -4933,6 +5069,25 @@ impl eframe::App for MarkdownApp {
                         ui.close();
                     }
 
+                    let font_label = format!(
+                        "Font: {}…",
+                        self.selected_font_family
+                            .as_deref()
+                            .unwrap_or("System Default")
+                    );
+                    let font_btn = ui.add(egui::Button::new(font_label));
+                    #[cfg(feature = "mcp")]
+                    self.mcp_bridge.register_widget(
+                        "Menu: View → Font",
+                        "button",
+                        &font_btn,
+                        self.selected_font_family.as_deref(),
+                    );
+                    if font_btn.clicked() {
+                        self.show_font_dialog = true;
+                        ui.close();
+                    }
+
                     ui.separator();
 
                     let zoom_in_btn = ui.add(egui::Button::new("Zoom In").shortcut_text("Ctrl++"));
@@ -5213,6 +5368,8 @@ impl eframe::App for MarkdownApp {
 
         // Highlight color picker window
         self.render_color_settings(ctx);
+        // Document font picker window
+        self.render_font_settings(ctx);
 
         // Drag and drop overlay
         if self.is_dragging {

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,6 +386,11 @@ struct PersistedState {
     /// Preferred document body/heading font family name. `None` means use the
     /// auto-detected system sans-serif (see `system_fonts::setup_fonts`).
     selected_font_family: Option<String>,
+    /// Disable egui's pixel-snapping for glyph positions (see
+    /// `TessellationOptions::round_text_to_pixels`). Off by default, matching
+    /// today's behavior; `Some(true)` trades a touch of sharpness for glyphs
+    /// that no longer look unevenly spaced at fractional zoom levels.
+    smooth_text_rendering: Option<bool>,
     open_tabs: Option<Vec<PathBuf>>,
     active_tab: Option<usize>,
     // File explorer state
@@ -1921,6 +1926,10 @@ struct MarkdownApp {
     show_font_dialog: bool,
     // Transient UI-only search text for the font picker (not persisted).
     font_filter: String,
+    // Disables egui's glyph pixel-snapping when true. Applied unconditionally
+    // every frame (see ctx.set_zoom_factor below) since it's a single write
+    // into egui's own memory, not worth a last-applied change-gate.
+    smooth_text_rendering: bool,
     watch_enabled: bool,
     error_message: Option<String>,
     is_dragging: bool,
@@ -2052,6 +2061,7 @@ impl MarkdownApp {
         let link_color = persisted
             .link_color
             .map(|[r, g, b, a]| egui::Color32::from_rgba_premultiplied(r, g, b, a));
+        let smooth_text_rendering = persisted.smooth_text_rendering.unwrap_or(false);
         let show_explorer = persisted.show_explorer.unwrap_or(true);
         let explorer_width =
             restored_sidebar_width(persisted.explorer_width, EXPLORER_DEFAULT_WIDTH);
@@ -2160,6 +2170,7 @@ impl MarkdownApp {
             available_font_families_lower,
             show_font_dialog: false,
             font_filter: String::new(),
+            smooth_text_rendering,
             watch_enabled: watch,
             error_message: startup_error,
             is_dragging: false,
@@ -4498,6 +4509,7 @@ impl eframe::App for MarkdownApp {
             highlight_color: self.highlight_color.map(|c| [c.r(), c.g(), c.b(), c.a()]),
             link_color: self.link_color.map(|c| [c.r(), c.g(), c.b(), c.a()]),
             selected_font_family: self.selected_font_family.clone(),
+            smooth_text_rendering: Some(self.smooth_text_rendering),
             open_tabs: Some(self.get_open_tab_paths()),
             active_tab: Some(self.active_tab),
             show_explorer: Some(self.show_explorer),
@@ -4596,6 +4608,16 @@ impl eframe::App for MarkdownApp {
         }
 
         ctx.set_zoom_factor(self.zoom_level);
+
+        // Disabling pixel-snapping lets glyphs render at their exact
+        // sub-pixel position instead of each being individually rounded to
+        // the physical pixel grid — the rounding is what makes text look
+        // unevenly spaced/jagged at the fractional effective pixel ratios
+        // this app's zoom levels commonly produce. Trivial cost (one write
+        // into egui's own memory), so no last-applied change-gate needed.
+        ctx.tessellation_options_mut(|opts| {
+            opts.round_text_to_pixels = !self.smooth_text_rendering;
+        });
 
         // Update window title only when dirty
         if self.title_dirty {
@@ -5085,6 +5107,28 @@ impl eframe::App for MarkdownApp {
                     );
                     if font_btn.clicked() {
                         self.show_font_dialog = true;
+                        ui.close();
+                    }
+
+                    let smooth_text_text = if self.smooth_text_rendering {
+                        "✓ Smooth Text Rendering"
+                    } else {
+                        "Smooth Text Rendering"
+                    };
+                    let smooth_text_btn = ui.add(egui::Button::new(smooth_text_text));
+                    #[cfg(feature = "mcp")]
+                    self.mcp_bridge.register_widget(
+                        "Menu: View → Smooth Text Rendering",
+                        "button",
+                        &smooth_text_btn,
+                        Some(if self.smooth_text_rendering {
+                            "on"
+                        } else {
+                            "off"
+                        }),
+                    );
+                    if smooth_text_btn.clicked() {
+                        self.smooth_text_rendering = !self.smooth_text_rendering;
                         ui.close();
                     }
 

--- a/src/system_fonts.rs
+++ b/src/system_fonts.rs
@@ -219,30 +219,67 @@ fn install_regular_fonts(
     source_cache: &mut SourceCache,
     definitions: &mut FontDefinitions,
     locale: Option<&str>,
+    preferred_family: Option<&str>,
 ) -> Vec<InstalledFont> {
     let mut installed = Vec::new();
     let mut loaded_faces = HashSet::new();
 
-    let families: Vec<_> = collection
-        .generic_families(GenericFamily::SansSerif)
-        .collect();
-    if let Some(selected) = select_from_families(
-        collection,
-        source_cache,
-        &families,
-        FontWeight::NORMAL,
-        "Aa",
-        false,
-    ) {
-        install_regular_font(
-            definitions,
-            &mut installed,
-            &mut loaded_faces,
-            "SystemSans",
-            selected,
+    if let Some(name) = preferred_family {
+        match collection.family_id(name) {
+            Some(family_id) => {
+                if let Some(selected) = select_from_families(
+                    collection,
+                    source_cache,
+                    &[family_id],
+                    FontWeight::NORMAL,
+                    "Aa",
+                    false,
+                ) {
+                    install_regular_font(
+                        definitions,
+                        &mut installed,
+                        &mut loaded_faces,
+                        "SystemSans",
+                        selected,
+                        "Aa",
+                        true,
+                    );
+                } else {
+                    log::warn!(
+                        "Preferred font '{name}' has no usable regular face; falling back to system default."
+                    );
+                }
+            }
+            None => {
+                log::warn!("Preferred font '{name}' not found; falling back to system default.");
+            }
+        }
+    }
+
+    // Auto-detect the system sans-serif only if no preferred family was
+    // requested, or the preferred family couldn't be installed above.
+    if installed.is_empty() {
+        let families: Vec<_> = collection
+            .generic_families(GenericFamily::SansSerif)
+            .collect();
+        if let Some(selected) = select_from_families(
+            collection,
+            source_cache,
+            &families,
+            FontWeight::NORMAL,
             "Aa",
-            true,
-        );
+            false,
+        ) {
+            install_regular_font(
+                definitions,
+                &mut installed,
+                &mut loaded_faces,
+                "SystemSans",
+                selected,
+                "Aa",
+                true,
+            );
+        }
     }
 
     for spec in SCRIPT_FALLBACKS {
@@ -414,10 +451,20 @@ fn install_strong_font_family(
 ///
 /// Fontique delegates to fontconfig on Linux/FreeBSD, DirectWrite on Windows,
 /// CoreText on Apple platforms, and the system configuration on Android.
-pub(crate) fn setup_fonts(ctx: &egui::Context) {
+///
+/// `preferred_family` optionally names a specific installed family (matched
+/// case-insensitively) to use as the primary proportional font instead of the
+/// auto-detected system sans-serif; an unset or unresolvable preference falls
+/// back to today's auto-detect behavior. Returns the sorted, deduplicated
+/// list of installed family names so callers can build a font picker without
+/// scanning the font collection a second time.
+pub(crate) fn setup_fonts(ctx: &egui::Context, preferred_family: Option<&str>) -> Vec<String> {
     let started = std::time::Instant::now();
     let mut collection = Collection::new(CollectionOptions::default());
-    let family_count = collection.family_names().count();
+    let mut family_names: Vec<String> = collection.family_names().map(str::to_owned).collect();
+    family_names.sort_by_key(|name| name.to_lowercase());
+    family_names.dedup();
+    let family_count = family_names.len();
     let mut source_cache = SourceCache::default();
     let locale = sys_locale::get_locale();
     let mut definitions = FontDefinitions::default();
@@ -431,6 +478,7 @@ pub(crate) fn setup_fonts(ctx: &egui::Context) {
         &mut source_cache,
         &mut definitions,
         locale.as_deref(),
+        preferred_family,
     );
     let bold_count = install_strong_font_family(
         &mut collection,
@@ -451,6 +499,7 @@ pub(crate) fn setup_fonts(ctx: &egui::Context) {
         );
     }
     ctx.set_fonts(definitions);
+    family_names
 }
 
 #[cfg(test)]
@@ -506,10 +555,67 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires installed system fonts"]
+    fn unknown_preferred_family_falls_back_to_auto_detect() {
+        let mut collection = Collection::new(CollectionOptions::default());
+        let mut source_cache = SourceCache::default();
+        let mut definitions = FontDefinitions::default();
+        let installed = install_regular_fonts(
+            &mut collection,
+            &mut source_cache,
+            &mut definitions,
+            None,
+            Some("Definitely Not An Installed Font Name 12345"),
+        );
+        assert!(
+            installed.iter().any(|f| f.primary),
+            "auto-detect fallback should still install a primary font"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires installed system fonts"]
+    fn known_preferred_family_becomes_primary() {
+        let mut collection = Collection::new(CollectionOptions::default());
+        let mut source_cache = SourceCache::default();
+
+        // Discover whatever the system's default sans-serif family is, then
+        // request it explicitly by name and confirm it round-trips as
+        // primary. Avoids hardcoding a font name that may not exist on every
+        // machine/CI image.
+        let mut baseline_definitions = FontDefinitions::default();
+        let baseline = install_regular_fonts(
+            &mut collection,
+            &mut source_cache,
+            &mut baseline_definitions,
+            None,
+            None,
+        );
+        let Some(baseline_primary) = baseline.iter().find(|f| f.primary) else {
+            return; // no system fonts available in this environment
+        };
+        let family_name = baseline_primary.selected.family.clone();
+
+        let mut definitions = FontDefinitions::default();
+        let installed = install_regular_fonts(
+            &mut collection,
+            &mut source_cache,
+            &mut definitions,
+            None,
+            Some(&family_name),
+        );
+        let primary = installed
+            .iter()
+            .find(|f| f.primary)
+            .expect("primary font installed");
+        assert_eq!(primary.selected.family, family_name);
+    }
+
+    #[test]
     #[ignore = "requires installed multilingual regular and bold fonts"]
     fn installed_fonts_cover_reported_scripts() {
         let context = egui::Context::default();
-        setup_fonts(&context);
+        setup_fonts(&context, None);
         context.begin_pass(Default::default());
         let regular = egui::FontId::proportional(16.0);
         let strong = egui::FontId::new(16.0, FontFamily::Name(STRONG_FONT_FAMILY.into()));


### PR DESCRIPTION
## Summary

Allows users to browse and apply installed system fonts via View menu. Font selection is searchable, cached for performance, and persists across restarts. Users can now choose their preferred reading font instead of relying solely on the auto-detected system sans-serif.

## Test Plan

- [ ] Open View → Font to verify picker renders
- [ ] Search for a font name and verify filter works
- [ ] Select a font and verify document updates immediately
- [ ] Restart the app and verify font selection persists
- [ ] Verify monospace/code font is unchanged
- [ ] Verify performance with many fonts (picker remains responsive)