### PR TITLE
Wire up the --version flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1508,6 +1508,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[derive(Parser, Debug)]
 #[command(name = "md-viewer")]
+#[command(version)]
 #[command(about = "A lightweight markdown viewer", long_about = None)]
 struct Args {
     /// Markdown file to open
@@ -5191,6 +5192,17 @@ mod tests {
         let help = Args::command().render_long_help().to_string();
         assert!(help.contains("--foreground"));
         assert!(!help.contains("--no-detach"));
+    }
+
+    #[test]
+    fn version_flag_reports_crate_version() {
+        use clap::CommandFactory;
+
+        let version = Args::command()
+            .get_version()
+            .expect("--version should be wired up")
+            .to_string();
+        assert_eq!(version, env!("CARGO_PKG_VERSION"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`md-viewer --version` currently fails:

```
$ md-viewer --version
error: unexpected argument '--version' found
```

The clap `Args` struct sets `#[command(name)]` and `#[command(about)]` but never `#[command(version)]`, so clap does not generate the flag. Adds it, plus a test asserting the reported version matches `CARGO_PKG_VERSION`.

After:

```
$ md-viewer --version
md-viewer 0.1.17
```

## Provenance

This is a cherry-pick of 42b000b from `feature/version-flag`, a branch pushed on 2026-07-11 that never became a PR. Found while auditing stale branches: of the nine orphaned remote branches, eight turned out to have landed in `main` through other commits (lightbox, duplicate-header disambiguation, Shift+wheel table scroll, the `md-viewer-bin` PKGBUILD, the snap `upload-metadata` fix, the currency/math filter). This one had not — verified by running the flag against a build of current `main`.

Cherry-picked cleanly onto `main` with no conflicts.

## Testing

- `cargo test` — 60 passed, 0 failed, 1 ignored (was 59 before; the added test accounts for the difference)
- `cargo fmt --check` — clean
- Ran the built binary: `md-viewer --version` prints `md-viewer 0.1.17`, matching `Cargo.toml`

## Note for whoever cuts the next release

`--version` reports `CARGO_PKG_VERSION`, so it is only correct if `Cargo.toml` is bumped as part of the release. `main` is currently 110 commits past the `v0.1.17` tag, so a released binary today would report a version that does not match what it contains.