### PR TITLE
Render YAML frontmatter as a key/value table

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/lib.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/lib.rs
@@ -275,6 +275,18 @@ impl<'f> CommonMarkViewer<'f> {
         self
     }
 
+    /// Parse a leading `---` block as YAML frontmatter and render it as a
+    /// key/value table instead of as document content.
+    ///
+    /// Off by default. This changes how the document is *parsed*, not only how
+    /// it is painted: with it off, `---` opens a thematic break and the
+    /// metadata lines become an ordinary paragraph. Enabling it by default
+    /// would therefore change existing consumers' output.
+    pub fn render_frontmatter(mut self, enabled: bool) -> Self {
+        self.options.render_frontmatter = enabled;
+        self
+    }
+
     /// Set line height as a multiplier of font size.
     ///
     /// Recommended value: 1.5 (per WCAG 2.1 SC 1.4.12)

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/latex_delimiters.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/latex_delimiters.rs
@@ -65,28 +65,38 @@ impl OffsetMap {
 /// `\(...\)` / `\[...\]` delimiters to `$...$` / `$$...$$` on an in-memory
 /// copy when paired occurrences exist in prose. Returned event ranges always
 /// refer to `text`, the original source.
-pub fn parse_events(text: &str, math_enabled: bool) -> Vec<(Event<'static>, Range<usize>)> {
+pub fn parse_events(
+    text: &str,
+    math_enabled: bool,
+    frontmatter_enabled: bool,
+) -> Vec<(Event<'static>, Range<usize>)> {
     if !math_enabled {
-        return parse_owned(text, false);
+        return parse_owned(text, false, frontmatter_enabled);
     }
     let rewrites = find_rewrites(text);
     if rewrites.is_empty() {
-        return parse_owned(text, true);
+        return parse_owned(text, true, frontmatter_enabled);
     }
     let (normalized, map) = build_normalized(text, &rewrites);
-    let mut events = parse_owned(&normalized, true);
+    let mut events = parse_owned(&normalized, true, frontmatter_enabled);
     for (_, range) in events.iter_mut() {
         map.map_range(range);
     }
     events
 }
 
-fn parse_owned(text: &str, math_enabled: bool) -> Vec<(Event<'static>, Range<usize>)> {
-    let options = if math_enabled {
-        parser_options() | Options::ENABLE_MATH
-    } else {
-        parser_options()
-    };
+fn parse_owned(
+    text: &str,
+    math_enabled: bool,
+    frontmatter_enabled: bool,
+) -> Vec<(Event<'static>, Range<usize>)> {
+    let mut options = parser_options();
+    if math_enabled {
+        options |= Options::ENABLE_MATH;
+    }
+    if frontmatter_enabled {
+        options |= Options::ENABLE_YAML_STYLE_METADATA_BLOCKS;
+    }
     Parser::new_ext(text, options)
         .into_offset_iter()
         .map(|(event, range)| (event.into_static(), range))
@@ -291,7 +301,7 @@ mod tests {
 
     /// Collect (event-debug, original-slice) pairs.
     fn outline(text: &str) -> Vec<(String, String)> {
-        parse_events(text, true)
+        parse_events(text, true, false)
             .into_iter()
             .map(|(event, range)| (format!("{event:?}"), text[range].to_string()))
             .collect()
@@ -305,7 +315,7 @@ mod tests {
     }
 
     fn plain_texts(text: &str) -> Vec<String> {
-        parse_events(text, true)
+        parse_events(text, true, false)
             .into_iter()
             .filter(|(event, _)| matches!(event, Event::Text(_)))
             .map(|(event, _)| match event {
@@ -334,7 +344,7 @@ mod tests {
             r"| \(a_t/(D_t^{opp}+\epsilon)\) |",
             "\n",
         );
-        let formulas: Vec<_> = parse_events(text, true)
+        let formulas: Vec<_> = parse_events(text, true, false)
             .into_iter()
             .filter_map(|(event, range)| match event {
                 Event::InlineMath(tex) => Some((tex.into_string(), text[range].to_string())),
@@ -389,7 +399,7 @@ mod tests {
             r"| first | \(\operatorname{EW}[|\Delta OI|]\) | native |",
             "\n",
         );
-        let events = parse_events(text, true);
+        let events = parse_events(text, true, false);
 
         assert_eq!(
             events
@@ -484,7 +494,7 @@ mod tests {
     #[test]
     fn ranges_after_conversion_point_into_the_original() {
         let text = "a \\(x\\) b";
-        let events = parse_events(text, true);
+        let events = parse_events(text, true, false);
         let after = events
             .iter()
             .find(|(e, _)| matches!(e, Event::Text(t) if t.contains('b')))
@@ -501,14 +511,14 @@ mod tests {
     fn fast_path_when_nothing_converts() {
         // No LaTeX pairs: identical output to a direct parse.
         assert_eq!(
-            parse_events("plain $x$ text", true),
-            parse_owned("plain $x$ text", true)
+            parse_events("plain $x$ text", true, false),
+            parse_owned("plain $x$ text", true, false)
         );
     }
 
     #[test]
     fn math_disabled_leaves_everything_alone() {
-        let events = parse_events("\\(x\\)", false);
+        let events = parse_events("\\(x\\)", false, false);
         assert!(events.iter().all(|(e, _)| !matches!(
             e,
             Event::InlineMath(_) | Event::DisplayMath(_)

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -201,6 +201,90 @@ fn visit_highlight_segments<'a>(
 /// Blind char-count cut (not break-friendly on `/`, `-`, etc.): variable-length
 /// segments can still exceed the column at narrow widths and re-introduce the
 /// original clipping bug. Fixed-size chunks always fit.
+/// Split a YAML frontmatter block into top-level key/value pairs.
+///
+/// Deliberately not a YAML parser. VS Code renders frontmatter as a flat
+/// two-column table and does not descend into nested structures; matching that
+/// keeps a de-facto-standard block readable without taking on a YAML
+/// dependency and its error modes. Anything that is not a top-level
+/// `key: value` line — nested mappings, sequence items, folded scalars — is
+/// appended to the preceding value verbatim, so no source text is dropped.
+fn parse_frontmatter_pairs(raw: &str) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::new();
+
+    for line in raw.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        // A continuation line is indented, or is a sequence item, or has no
+        // colon at all. Only an unindented `key:` starts a new row.
+        let is_continuation = line.starts_with(char::is_whitespace) || line.trim_start().starts_with('-');
+        let split = if is_continuation {
+            None
+        } else {
+            line.find(':')
+        };
+
+        match split {
+            Some(idx) => {
+                let key = line[..idx].trim().to_owned();
+                let value = line[idx + 1..].trim().to_owned();
+                pairs.push((key, value));
+            }
+            None => {
+                if let Some((_, value)) = pairs.last_mut() {
+                    if !value.is_empty() {
+                        value.push(' ');
+                    }
+                    value.push_str(line.trim());
+                } else {
+                    // Leading junk before any key: keep it visible rather than
+                    // silently dropping it.
+                    pairs.push((String::new(), line.trim().to_owned()));
+                }
+            }
+        }
+    }
+
+    pairs
+}
+
+/// Paint a frontmatter block as a two-column key/value table.
+fn render_frontmatter_table(
+    ui: &mut Ui,
+    raw: &str,
+    options: &CommonMarkOptions,
+    max_width: f32,
+) {
+    let pairs = parse_frontmatter_pairs(raw);
+    if pairs.is_empty() {
+        return;
+    }
+
+    let _ = options;
+    egui::Frame::group(ui.style()).show(ui, |ui| {
+        ui.set_max_width(max_width);
+        egui::Grid::new(ui.next_auto_id())
+            .num_columns(2)
+            .spacing(egui::vec2(ui.spacing().item_spacing.x, 4.0))
+            .striped(true)
+            .show(ui, |ui| {
+                for (key, value) in pairs {
+                    // The gap has to be produced *inside* the key cell: the
+                    // grid sizes column one to its widest entry, so a long key
+                    // otherwise ends flush against its value ("authorJane Doe").
+                    ui.horizontal(|ui| {
+                        ui.label(egui::RichText::new(key).strong());
+                        ui.add_space(12.0);
+                    });
+                    ui.label(value);
+                    ui.end_row();
+                }
+            });
+    });
+}
+
 fn inline_code_wrap_segments(text: &str) -> Vec<String> {
     const MAX_SEGMENT_CHARS: usize = 56;
 
@@ -529,6 +613,9 @@ pub struct CommonMarkViewerInternal {
     /// Nested table/list/blockquote UIs must not replace this origin when
     /// converting navigation positions into document coordinates.
     render_origin_y: f32,
+    /// Raw text of the frontmatter block being collected. `Some` only between
+    /// `Tag::MetadataBlock` and its end, so ordinary text is unaffected.
+    frontmatter: Option<String>,
 }
 
 pub(crate) struct CheckboxClickEvent {
@@ -554,6 +641,7 @@ impl CommonMarkViewerInternal {
             is_table: false,
             is_blockquote: false,
             checkbox_events: Vec::new(),
+            frontmatter: None,
             current_heading_y: None,
             current_heading_source_start: None,
             current_heading_text: String::new(),
@@ -787,7 +875,7 @@ impl CommonMarkViewerInternal {
             // rewritten pre-parse on an in-memory copy and ranges are mapped
             // back, so they stay valid against the original text.
             let owned_events: Vec<(pulldown_cmark::Event<'static>, Range<usize>)> =
-                super::latex_delimiters::parse_events(text, math_enabled);
+                super::latex_delimiters::parse_events(text, math_enabled, options.render_frontmatter);
             cache.set_cached_events(content_hash, owned_events);
         }
 
@@ -970,7 +1058,7 @@ impl CommonMarkViewerInternal {
                 // Must produce byte-identical events to the cache-fill parse
                 // above — including any LaTeX delimiter rewrite (#60) — or
                 // split_points index into an unrelated stream (see devlog 027).
-                sc.events = super::latex_delimiters::parse_events(text, math_enabled);
+                sc.events = super::latex_delimiters::parse_events(text, math_enabled, options.render_frontmatter);
                 sc.content_version = version;
                 // Content changed — cached split_points y-coords are no
                 // longer valid for this content. Drop them so the first
@@ -1558,7 +1646,13 @@ impl CommonMarkViewerInternal {
             }
             pulldown_cmark::Event::End(tag) => self.end_tag(ui, tag, cache, options, max_width),
             pulldown_cmark::Event::Text(text) => {
-                self.event_text_with_highlights(text, &src_span, cache, ui, options);
+                // Inside a frontmatter block the text is metadata, not prose:
+                // collect it and paint the whole block at TagEnd instead.
+                if let Some(buffer) = self.frontmatter.as_mut() {
+                    buffer.push_str(&text);
+                } else {
+                    self.event_text_with_highlights(text, &src_span, cache, ui, options);
+                }
             }
             pulldown_cmark::Event::Code(text) => {
                 // A bare local Markdown filename is often written as inline code.
@@ -2006,7 +2100,10 @@ impl CommonMarkViewerInternal {
             pulldown_cmark::Tag::HtmlBlock => {
                 self.line.try_insert_start(ui);
             }
-            pulldown_cmark::Tag::MetadataBlock(_) => {}
+            pulldown_cmark::Tag::MetadataBlock(_) => {
+                self.line.try_insert_start(ui);
+                self.frontmatter = Some(String::new());
+            }
 
             pulldown_cmark::Tag::DefinitionList => {
                 self.line.try_insert_start(ui);
@@ -2192,7 +2289,12 @@ impl CommonMarkViewerInternal {
                 }
             }
 
-            pulldown_cmark::TagEnd::MetadataBlock(_) => {}
+            pulldown_cmark::TagEnd::MetadataBlock(_) => {
+                if let Some(raw) = self.frontmatter.take() {
+                    render_frontmatter_table(ui, &raw, options, max_width);
+                    self.line.try_insert_end(ui);
+                }
+            }
 
             pulldown_cmark::TagEnd::DefinitionList => self.line.try_insert_end(ui),
             pulldown_cmark::TagEnd::DefinitionListTitle
@@ -2370,6 +2472,63 @@ impl CommonMarkViewerInternal {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn frontmatter_splits_top_level_key_value_pairs() {
+        let pairs = parse_frontmatter_pairs(
+            "title: My Document\nauthor: Jane Doe\ndate: 2026-08-30\n",
+        );
+        assert_eq!(
+            pairs,
+            vec![
+                ("title".to_owned(), "My Document".to_owned()),
+                ("author".to_owned(), "Jane Doe".to_owned()),
+                ("date".to_owned(), "2026-08-30".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn frontmatter_keeps_a_value_containing_a_colon_intact() {
+        // Only the *first* colon separates; a URL must not be truncated.
+        let pairs = parse_frontmatter_pairs("url: https://example.com/path?a=1\n");
+        assert_eq!(
+            pairs,
+            vec![("url".to_owned(), "https://example.com/path?a=1".to_owned())]
+        );
+    }
+
+    #[test]
+    fn frontmatter_folds_nested_lines_into_the_preceding_value() {
+        // Not a YAML parser by design: nested mappings and sequence items are
+        // folded into the parent value rather than dropped or mis-split into
+        // their own rows.
+        let pairs = parse_frontmatter_pairs("nested:\n  key: value\nlist:\n  - first\n  - second\n");
+        assert_eq!(
+            pairs,
+            vec![
+                ("nested".to_owned(), "key: value".to_owned()),
+                ("list".to_owned(), "- first - second".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn frontmatter_ignores_blank_lines_and_survives_leading_junk() {
+        let pairs = parse_frontmatter_pairs("\n\nstray\n\ntitle: X\n");
+        assert_eq!(
+            pairs,
+            vec![
+                (String::new(), "stray".to_owned()),
+                ("title".to_owned(), "X".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn frontmatter_of_only_blank_lines_yields_nothing_to_paint() {
+        assert!(parse_frontmatter_pairs("\n   \n").is_empty());
+    }
+
     use super::*;
     use pulldown_cmark::{Event, Options, Parser, Tag};
 
@@ -2948,7 +3107,7 @@ mod tests {
         );
         let active_start = markdown.find("ACTIVE_TABLE_MATCH").unwrap();
         let active_range = active_start..active_start + "ACTIVE_TABLE_MATCH".len();
-        let heading_source_start = crate::parsers::latex_delimiters::parse_events(markdown, false)
+        let heading_source_start = crate::parsers::latex_delimiters::parse_events(markdown, false, false)
             .into_iter()
             .find_map(|(event, range)| {
                 matches!(event, Event::Start(Tag::Heading { .. })).then_some(range.start)

--- a/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
@@ -68,6 +68,11 @@ pub struct CommonMarkOptions<'f> {
     /// Opt into using the named strong font family. Callers must register
     /// `STRONG_FONT_FAMILY` in egui before enabling this to avoid lookup panics.
     pub use_strong_font_family: bool,
+    /// Opt into parsing a leading `---` block as YAML frontmatter and rendering
+    /// it as a key/value table. Off by default: enabling it changes how a
+    /// document that starts with `---` is *parsed*, not just painted, so it
+    /// must not silently alter existing consumers' output.
+    pub render_frontmatter: bool,
 }
 
 impl std::fmt::Debug for CommonMarkOptions<'_> {
@@ -93,6 +98,7 @@ impl std::fmt::Debug for CommonMarkOptions<'_> {
             .field("mutable", &self.mutable)
             .field("typography", &self.typography)
             .field("use_strong_font_family", &self.use_strong_font_family)
+            .field("render_frontmatter", &self.render_frontmatter)
             .finish()
     }
 }
@@ -117,6 +123,7 @@ impl Default for CommonMarkOptions<'_> {
             html_fn: None,
             typography: TypographyConfig::default(),
             use_strong_font_family: false,
+            render_frontmatter: false,
         }
     }
 }

--- a/docs/devlog/059-yaml-frontmatter.md
+++ b/docs/devlog/059-yaml-frontmatter.md
@@ -1,0 +1,70 @@
+# Feature: YAML frontmatter rendering
+
+**Status:** ✅ Complete
+**Branch:** `feature/yaml-frontmatter`
+**Date:** 2026-09-04
+**Issue:** #117
+
+## Summary
+
+Documents that open with a `---` delimited YAML frontmatter block currently render it as content: a thematic break, the raw `key: value` lines as a paragraph, another thematic break. Reported in #117 as "any doc using it renders with a broken-looking block at the top".
+
+Renders it as a two-column key/value table instead, which is what VS Code does and what the reporter asked for.
+
+## Why the parser never saw it as frontmatter
+
+`pulldown-cmark` supports this via `Options::ENABLE_YAML_STYLE_METADATA_BLOCKS`, and the renderer already carries `Tag::MetadataBlock` / `TagEnd::MetadataBlock` arms — but they are empty no-ops, and `parser_options()` never set the flag. So the events were never produced, and the block fell through to ordinary block parsing.
+
+Two things therefore had to change together: enable the parser option, and give the metadata arms something to do. Enabling the option alone would make frontmatter silently vanish.
+
+## Design
+
+Opt-in, following the `use_strong_font_family` precedent in this codebase: default `false` so existing library consumers of `egui_commonmark_extended` see no change, enabled explicitly by md-viewer.
+
+- `CommonMarkOptions::render_frontmatter: bool`
+- `CommonMarkViewer::render_frontmatter(bool)` builder
+- threaded into the parse path next to the existing `math_enabled` flag
+
+The flag has to reach the *parser*, not just the renderer, which is why it travels through `latex_delimiters::parse_events`.
+
+## Key discoveries
+
+### egui's `Grid` does not turn `spacing.x` into a column gap
+
+`Grid::spacing(vec2(x, y))` visibly changed row spacing but left the columns
+touching: a key as long as the column's widest entry rendered flush against its
+value — `authorJane Doe`. The gap has to be produced *inside* the key cell:
+
+```rust
+ui.horizontal(|ui| {
+    ui.label(RichText::new(key).strong());
+    ui.add_space(12.0);
+});
+```
+
+Only visible by looking at a screenshot. The unit tests for the parsing were
+green throughout, because the defect is in layout, not in the split.
+
+### A full `/tmp` looks exactly like a broken change
+
+Ten doctests failed with `error: linking with x86_64-linux-gnu-gcc failed`
+during this work. The real message was several screens down:
+`LLVM ERROR: IO failure on output stream: Disk quota exceeded`. Doctests link
+into `/tmp`, which is a 16 GB tmpfs here, and debug builds of this project are
+~800 MB each — a handful of them copied aside for A/B comparison fills it.
+
+Two tells that it was not the change: every failure was in a method the branch
+never touched, and the failure count differed between runs (10, then 5). A code
+defect does not fluctuate.
+
+## Future improvements
+
+- Nested mappings and sequences fold into the parent value
+  (`nested: key: value other: thing`). Matching VS Code, and no source text is
+  dropped, but a document with deep frontmatter reads poorly. Rendering nested
+  levels would need a real YAML parser and a nested display.
+- TOML frontmatter (`+++`) is not handled. `pulldown-cmark` has
+  `ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS` for it; the renderer side would be
+  identical, only the parser flag differs.
+- The block is always shown when enabled. A collapsible header would suit long
+  frontmatter, at the cost of persisted per-document UI state.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3385,6 +3385,10 @@ impl MarkdownApp {
                     .table_max_width(Some(content_width))
                     .indentation_spaces(2)
                     .use_strong_font_family(true)
+                    // Frontmatter is metadata, not prose: show it as a
+                    // key/value table rather than a thematic break plus a
+                    // paragraph of raw `key: value` lines (#117).
+                    .render_frontmatter(true)
                     .show_alt_text_on_hover(true)
                     .syntax_theme_dark("base16-ocean.dark")
                     .syntax_theme_light("base16-ocean.light")


### PR DESCRIPTION
Closes #117.

## The problem

A document opening with a `---` delimited frontmatter block rendered it as content — a thematic break, the raw `key: value` lines as a paragraph, then another break. The reporter's words: "any doc using it renders with a broken-looking block at the top."

## Why it never worked

Both halves were already present and never connected:

- `pulldown-cmark` supports frontmatter through `Options::ENABLE_YAML_STYLE_METADATA_BLOCKS` — `parser_options()` never set it.
- The renderer already carried `Tag::MetadataBlock` and `TagEnd::MetadataBlock` arms — both empty no-ops.

So the events were never produced, and the block fell through to ordinary block parsing. Both had to change together: setting the flag alone would have made frontmatter *silently vanish* instead of merely looking wrong.

## What it renders

A flat two-column key/value table, the way VS Code does it.

Deliberately **not** a YAML parser. The reporter noted VS Code does not descend into nested structures either; matching that keeps a de-facto-standard block readable without taking on a YAML dependency and its error modes. Nested mappings and sequence items fold into the preceding value rather than being dropped, so no source text is lost:

```
nested:          ->  nested | key: value other: thing
  key: value
  other: thing
```

## Opt-in, and why

`CommonMarkViewer::render_frontmatter(bool)`, default `false`, following the `use_strong_font_family` precedent in this codebase. md-viewer enables it.

The default has to stay off because this changes how a document is **parsed**, not only how it is painted. With it off, a leading `---` opens a thematic break and the metadata lines are an ordinary paragraph — enabling it by default would change existing consumers' output.

## Testing

- Five unit tests for `parse_frontmatter_pairs`: top-level splitting, a value containing a colon (`url: https://…` must not truncate at the second colon), nested folding, blank lines and leading junk, and an all-blank block painting nothing.
- Full suites: root 59, renderer 63 + 1 + 18 + 16, backend 25 + 1, macros 4 + 1, doctests 16. Zero failures. `cargo fmt --check` clean.
- Visually verified on the exact document from the issue: frontmatter renders as a table, body follows unchanged.
- **Regression check:** a document that merely *starts* with `---` still renders a horizontal rule, heading and text unaffected.

## Two things worth knowing, both recorded in the devlog

**egui's `Grid` does not turn `spacing.x` into a column gap.** `Grid::spacing(vec2(x, y))` visibly changed row spacing but left columns touching — a key as long as the column's widest entry rendered flush against its value (`authorJane Doe`). The gap has to be produced *inside* the key cell. Only visible by looking at a screenshot; the parsing unit tests were green throughout, because the defect is in layout, not in the split.

**A full `/tmp` looks exactly like a broken change.** Ten doctests failed here with `error: linking with x86_64-linux-gnu-gcc failed`; the real message was several screens down — `LLVM ERROR: IO failure on output stream: Disk quota exceeded`. Doctests link into `/tmp`, a 16 GB tmpfs on this machine, and debug builds of this project are ~800 MB each. Two tells that it was not the change: every failure was in a method this branch never touches, and the count differed between runs (10, then 5). A code defect does not fluctuate.