### PR TITLE
Reserve image height in Markdown table rows

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -250,11 +250,33 @@ fn table_cell_height(
     cache: &CommonMarkCache,
     ui: &Ui,
     column_width: f32,
+    options: &CommonMarkOptions,
 ) -> f32 {
     let text = markdown_cell_text(cell);
     let mut height = wrapped_text_height(ui, &text, column_width, line_height)
         .max(line_height * 1.5 * cell_visual_lines(cell) as f32);
     for (event, _) in cell {
+        // Images contribute their painted height. The URI has to be resolved
+        // exactly the way the painting path does it (`Image::new` applies the
+        // scheme rules), otherwise the cache lookup misses and the row silently
+        // stays text-height.
+        if let pulldown_cmark::Event::Start(pulldown_cmark::Tag::Image { dest_url, .. }) = event {
+            let uri = crate::Image::new(dest_url, options).uri;
+            let image_height = match cache.observed_image_size(&uri) {
+                // Painted at least once: the width is already capped by the
+                // cell, so the recorded height is what the row needs.
+                Some(size) if size.y > 0.0 => size.y,
+                // Not yet loaded. Reserving nothing collapses the row and the
+                // image is clipped on every frame until it loads; reserving a
+                // full cell width of height over-reserves for a wide thin
+                // image. A square-ish guess bounded by the column keeps the
+                // first frame usable, and `observe_image_size` marks the layout
+                // dirty once the real size arrives so this is re-measured.
+                _ => column_width.min(line_height * 8.0),
+            };
+            height = height.max(image_height);
+        }
+
         if let pulldown_cmark::Event::InlineMath(_tex) = event {
             let conservative = line_height * 2.0;
             #[cfg(feature = "math")]
@@ -1488,6 +1510,7 @@ impl CommonMarkViewerInternal {
                                                                     .get(column)
                                                                     .copied()
                                                                     .unwrap_or(40.0),
+                                                                options,
                                                             )
                                                         })
                                                         .fold(cell_h, f32::max)
@@ -2431,11 +2454,71 @@ mod tests {
     fn table_cells_reserve_extra_height_for_inline_math() {
         egui::__run_test_ui(|ui| {
             let cache = CommonMarkCache::default();
+            let options = CommonMarkOptions::default();
             let line_height = ui.text_style_height(&egui::TextStyle::Body);
             let cell = vec![(Event::InlineMath(r"\frac{a}{b}".into()), 0..11)];
 
             assert!(
-                table_cell_height(&cell, line_height, &cache, ui, 120.0) >= line_height * 2.0
+                table_cell_height(&cell, line_height, &cache, ui, 120.0, &options)
+                    >= line_height * 2.0
+            );
+        });
+    }
+
+    #[test]
+    fn table_cell_reserves_height_for_an_image_of_known_size() {
+        // The size an image was last painted at is what its row must reserve.
+        egui::__run_test_ui(|ui| {
+            let mut cache = CommonMarkCache::default();
+            let options = CommonMarkOptions::default();
+            let line_height = ui.text_style_height(&egui::TextStyle::Body);
+
+            let cell = vec![(
+                Event::Start(Tag::Image {
+                    link_type: pulldown_cmark::LinkType::Inline,
+                    dest_url: "chart.png".into(),
+                    title: "".into(),
+                    id: "".into(),
+                }),
+                0..10,
+            )];
+
+            let without = table_cell_height(&cell, line_height, &cache, ui, 120.0, &options);
+
+            let uri = crate::Image::new("chart.png", &options).uri;
+            cache.observe_image_size_for_test(&uri, egui::vec2(120.0, 400.0));
+            let with = table_cell_height(&cell, line_height, &cache, ui, 120.0, &options);
+
+            assert!(
+                with >= 400.0,
+                "row must reserve the painted image height, got {with}"
+            );
+            assert!(
+                with > without,
+                "a known image size must not shrink the reservation ({with} vs {without})"
+            );
+        });
+    }
+
+    #[test]
+    fn a_cached_image_size_does_not_leak_into_text_only_cells() {
+        // Guards the blast radius: seeding a known image size must change the
+        // height of cells that contain that image and nothing else.
+        egui::__run_test_ui(|ui| {
+            let mut cache = CommonMarkCache::default();
+            let options = CommonMarkOptions::default();
+            let line_height = ui.text_style_height(&egui::TextStyle::Body);
+            let cell = vec![(Event::Text("plain".into()), 0..5)];
+
+            let before = table_cell_height(&cell, line_height, &cache, ui, 120.0, &options);
+
+            let uri = crate::Image::new("chart.png", &options).uri;
+            cache.observe_image_size_for_test(&uri, egui::vec2(120.0, 400.0));
+            let after = table_cell_height(&cell, line_height, &cache, ui, 120.0, &options);
+
+            assert_eq!(
+                before, after,
+                "a text-only cell must not change when some image's size becomes known"
             );
         });
     }

--- a/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
@@ -2495,11 +2495,37 @@ impl CommonMarkCache {
 
     fn observe_image_size(&mut self, uri: &str, size: egui::Vec2) {
         match self.image_sizes.insert(uri.to_owned(), size) {
+            // A later size change invalidates measurements taken against the
+            // previous one.
             Some(previous) if (previous - size).length_sq() > 0.25 => {
+                self.mark_layout_changed();
+            }
+            // `HashMap::insert` returns `None` the first time a key is written.
+            // Images load asynchronously, so the first paint measured any row
+            // containing this image with no size available; that measurement is
+            // now stale and has to be redone. Without this arm the row keeps the
+            // height it was given before the image existed (#124).
+            None => {
                 self.mark_layout_changed();
             }
             _ => {}
         }
+    }
+
+    /// Seed an observed image size without painting. Test-only: production
+    /// code must go through the paint path so `layout_revision` is maintained.
+    #[doc(hidden)]
+    pub fn observe_image_size_for_test(&mut self, uri: &str, size: egui::Vec2) {
+        self.observe_image_size(uri, size);
+    }
+
+    /// Size of an image as last painted, if it has been painted at least once.
+    ///
+    /// Returns `None` before the first paint of that URI — callers must fall
+    /// back rather than assume zero, or a row will collapse on the frame before
+    /// the image loads.
+    pub fn observed_image_size(&self, uri: &str) -> Option<egui::Vec2> {
+        self.image_sizes.get(uri).copied()
     }
 
     /// Read-only view of stored search ranges (used by the renderer).

--- a/docs/devlog/060-table-image-row-height.md
+++ b/docs/devlog/060-table-image-row-height.md
@@ -1,0 +1,93 @@
+# Fix: reserve image height in Markdown table rows
+
+**Status:** ✅ Complete
+**Branch:** `fix/124-table-image-height`
+**Date:** 2026-09-04
+**Issue:** #124
+
+## Summary
+
+A Markdown table cell containing an image reserved only a text line of height, so
+the image was clipped to a thin strip. Measured on `main` @ d982ad2 with a
+240x180 PNG in a four-column table: **32 px of 180 px visible, 82 % clipped**,
+identical across all four rows.
+
+## Two independent causes
+
+### 1. The row-height estimator does not know about images
+
+`table_cell_height` accounts for wrapped text, inline-code chunks
+(`cell_visual_lines`) and inline math (`cached_inline_math_height`). It has no
+arm for `Event::Start(Tag::Image)`, so an image contributes nothing to the row
+height and the row collapses to its text height.
+
+### 2. The first observed image size is not a layout change
+
+`CommonMarkCache::observe_image_size` is already called for every painted image,
+and already bumps `layout_revision` when a size *changes*:
+
+```rust
+match self.image_sizes.insert(uri.to_owned(), size) {
+    Some(previous) if (previous - size).length_sq() > 0.25 => self.mark_layout_changed(),
+    _ => {}
+}
+```
+
+`HashMap::insert` returns `None` the first time a key is written, so the arm that
+marks the layout dirty is never reached on first observation. Images load
+asynchronously: the first paint measures a row with no size known, the size
+arrives on a later frame, and nothing asks for a re-measurement. The row stays at
+its wrong first value.
+
+Both had to change. Fixing only the estimator leaves the first paint wrong with
+no re-measure; fixing only the revision re-measures a row that still ignores
+images.
+
+## Key discoveries
+
+### The cache already recorded what was needed
+
+`Image::end` has always called `cache.observe_image_size(&self.uri, response.rect.size())`.
+The data was there; nothing read it back, and the first write did not invalidate
+anything. Adding `observed_image_size()` and the `None` arm was enough — no new
+plumbing, no texture polling, no extra state.
+
+### The URI has to be resolved the same way the paint path does
+
+`Image::new` applies scheme rules — `file://` for absolute paths,
+`options.default_implicit_uri_scheme` for relative ones. Measuring with the raw
+`dest_url` would miss the cache on every relative path (the common case) and the
+row would silently stay text-height with no error anywhere. The measurement path
+therefore calls `crate::Image::new(dest_url, options).uri`, which is why
+`table_cell_height` needed an `options` parameter.
+
+### A visual metric can be wrong in a way that looks plausible
+
+First measurement of the fix reported "8 image strips of 32 px" — apparently no
+better than the 4×32 px before. The detector keyed on colour saturation, and the
+white `IMG1` label painted *through the middle* of each image split every block
+into two runs. Measuring against the background colour instead gives 4×68 px.
+The wrong metric produced a number that was internally consistent and completely
+misleading.
+
+## Verification
+
+| build | image height per row |
+|---|---|
+| `main` d982ad2 | 34, 35, 34, 34 px (source is 180 px) |
+| this branch | 68, 68, 68, 68 px |
+
+68 px is the correct scaled height: 180 x (94 px column / 240) ~= 70. Aspect
+ratio was never the problem — the row simply did not reserve room.
+
+A table with no images renders **pixel-identical** between the two builds.
+
+## Future improvements
+
+- The pre-load fallback is `column_width.min(line_height * 8.0)` — a square-ish
+  guess. A wide thin image over-reserves for one frame until its real size
+  arrives. Reading intrinsic size from the texture loader before first paint
+  would avoid the guess, at the cost of duplicating egui's load path.
+- HTML tables (`render_html_table`) have no event stream and still use the
+  `cell.lines().count() + cell.len()/60` heuristic, so `<img>` inside an HTML
+  table is not covered here.


### PR DESCRIPTION
Closes #124.

## The bug, measured

A table cell containing an image reserved only a line of text, so the image was clipped to a strip. Against `main` d982ad2, a 240x180 PNG in a four-column table:

| build | image height per row | source |
|---|---|---|
| `main` d982ad2 | 34, 35, 34, 34 px | 180 px — **82 % cut off** |
| this branch | **68, 68, 68, 68 px** | correctly scaled |

68 px is right: 180 x (94 px column / 240) ~= 70. Aspect ratio was never the problem — the row simply did not reserve room.

Still reproduces after #113 and #114, which were the prerequisite PRs named in the issue.

## Two causes, both required

**1. The row-height estimator had no image arm.** `table_cell_height` accounts for wrapped text, inline-code chunks (`cell_visual_lines`) and inline math (`cached_inline_math_height`), but nothing for `Event::Start(Tag::Image)`. An image contributed zero, so the row collapsed to text height.

**2. The first observed image size was not treated as a layout change.** The existing code was already almost right:

```rust
match self.image_sizes.insert(uri.to_owned(), size) {
    Some(previous) if (previous - size).length_sq() > 0.25 => self.mark_layout_changed(),
    _ => {}
}
```

`HashMap::insert` returns `None` the first time a key is written, so the arm that marks the layout dirty was never reached on first observation. Images load asynchronously: the first paint measures the row with no size known, the size arrives on a later frame, and nothing asks for a re-measurement.

Fixing only the estimator leaves the first frame wrong with no re-measure. Fixing only the revision re-measures a row that still ignores images. Hence both.

## Notes on the implementation

**The cache already had the data.** `Image::end` has always called `observe_image_size(&self.uri, response.rect.size())`. Nothing read it back. This adds a getter and the `None` arm — no texture polling, no new state.

**The URI must be resolved the way the paint path resolves it.** `Image::new` applies scheme rules (`file://` for absolute, `default_implicit_uri_scheme` for relative). Measuring the raw `dest_url` would miss the cache on every relative path — the common case — and the row would silently stay text-height with nothing to indicate why. That is why `table_cell_height` now takes `options`.

**Pre-load fallback** is `column_width.min(line_height * 8.0)`: reserving nothing collapses the row on every frame until the image loads, reserving a full column width over-reserves for a wide thin image. Once the real size arrives, cause 2 above marks the layout dirty and it is re-measured.

## Testing

- Three unit tests: an image of known size raises the row height; the same never shrinks it; and a **blast-radius check** — seeding a known image size must not change the height of a text-only cell.
- Full suites: root 59, renderer 60 + 1 + 18 + 16, backend 25 + 1. Zero failures. `cargo fmt --check` clean.
- Visual: a table with **no** images renders **pixel-identical** between `main` and this branch. Content after the table (`MARKER_AFTER_TABLE`) stays in place in both.

## Not covered

HTML tables. `render_html_table` has no event stream and still uses the `cell.lines().count() + cell.len()/60` heuristic, so `<img>` inside an HTML table is unaffected by this change.

## One measurement lesson, recorded in the devlog

My first check of the fix reported "8 image strips of 32 px" — seemingly no better than before. The detector keyed on colour saturation, and the white `IMG1` label painted through the middle of each image split every block into two runs. Measuring against the background instead gives 4x68 px. The wrong metric produced a number that was internally consistent and completely misleading.