### PR TITLE
Let formula size follow typography, independent of UI zoom

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/lib.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/lib.rs
@@ -287,6 +287,20 @@ impl<'f> CommonMarkViewer<'f> {
         self
     }
 
+    /// Size of rendered formulas as a multiple of the resolved Body font size.
+    ///
+    /// `1.0` (the default) renders math at the same point size as body text.
+    /// Math glyphs and dense fractions read as perceptually smaller than prose
+    /// at equal point size, so a value slightly above 1.0 is often more
+    /// legible. Application zoom is not a substitute — it scales the whole UI,
+    /// leaving formulas and their surrounding text in the same ratio.
+    ///
+    /// Values are clamped to at least 1pt.
+    pub fn math_scale(mut self, scale: f32) -> Self {
+        self.options.math_scale = scale;
+        self
+    }
+
     /// Set line height as a multiplier of font size.
     ///
     /// Recommended value: 1.5 (per WCAG 2.1 SC 1.4.12)

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -364,12 +364,12 @@ fn table_cell_height(
         if let pulldown_cmark::Event::InlineMath(_tex) = event {
             let conservative = line_height * 2.0;
             #[cfg(feature = "math")]
-            let formula_height = crate::cached_inline_math_height(ui, cache, _tex)
+            let formula_height = crate::cached_inline_math_height(ui, cache, _tex, options)
                 .map(|exact| exact + line_height * 0.5)
                 .unwrap_or(conservative);
             #[cfg(not(feature = "math"))]
             let formula_height = {
-                let _ = (cache, ui);
+                let _ = (cache, ui, options);
                 conservative
             };
             height = height.max(formula_height);
@@ -702,6 +702,9 @@ fn compute_layout_signature(ui: &egui::Ui, options: &CommonMarkOptions) -> u64 {
     // Caller-configured constraints that affect block widths.
     options.default_width.hash(&mut h);
     options.indentation_spaces.hash(&mut h);
+    // Formula size changes rendered formula extents, so split_points measured
+    // at the old scale are stale. Quantized like the heights above.
+    ((options.math_scale * 100.0).round() as i32).hash(&mut h);
     h.finish()
 }
 
@@ -1776,9 +1779,9 @@ impl CommonMarkViewerInternal {
                     #[cfg(feature = "math")]
                     {
                         if self.is_table {
-                            crate::render_math_in_table(ui, cache, &tex);
+                            crate::render_math_in_table(ui, cache, &tex, options);
                         } else {
-                            crate::render_math(ui, cache, &tex, true);
+                            crate::render_math(ui, cache, &tex, true, options);
                         }
                     }
                     #[cfg(not(feature = "math"))]
@@ -1796,7 +1799,7 @@ impl CommonMarkViewerInternal {
                 newline(ui);
                 #[cfg(feature = "math")]
                 {
-                    crate::render_math(ui, cache, &tex, false);
+                    crate::render_math(ui, cache, &tex, false, options);
                 }
                 #[cfg(not(feature = "math"))]
                 if let Some(math_fn) = options.math_fn {

--- a/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
@@ -73,6 +73,14 @@ pub struct CommonMarkOptions<'f> {
     /// document that starts with `---` is *parsed*, not just painted, so it
     /// must not silently alter existing consumers' output.
     pub render_frontmatter: bool,
+    /// Size of rendered formulas, as a multiple of the resolved Body font size.
+    ///
+    /// `1.0` renders math at the same point size as body text. Math glyphs and
+    /// dense fractions read as perceptually smaller than prose at equal point
+    /// size, so a value slightly above 1.0 is often more legible. Application
+    /// zoom is not a substitute: it scales the whole UI, leaving the formula
+    /// and its surrounding text in the same ratio.
+    pub math_scale: f32,
 }
 
 impl std::fmt::Debug for CommonMarkOptions<'_> {
@@ -99,6 +107,7 @@ impl std::fmt::Debug for CommonMarkOptions<'_> {
             .field("typography", &self.typography)
             .field("use_strong_font_family", &self.use_strong_font_family)
             .field("render_frontmatter", &self.render_frontmatter)
+            .field("math_scale", &self.math_scale)
             .finish()
     }
 }
@@ -124,6 +133,7 @@ impl Default for CommonMarkOptions<'_> {
             typography: TypographyConfig::default(),
             use_strong_font_family: false,
             render_frontmatter: false,
+            math_scale: 1.0,
         }
     }
 }
@@ -401,6 +411,7 @@ mod tests {
                 false,
                 egui::Color32::BLACK,
                 egui::Color32::WHITE,
+                16.0,
             )
             .unwrap_or_else(|error| panic!("failed to render {latex:?}: {error}"));
 
@@ -417,6 +428,7 @@ mod tests {
             false,
             egui::Color32::BLACK,
             egui::Color32::WHITE,
+            16.0,
         );
         assert_ne!(
             base,
@@ -425,6 +437,7 @@ mod tests {
                 false,
                 egui::Color32::DARK_GRAY,
                 egui::Color32::WHITE,
+                16.0,
             )
         );
         assert_ne!(
@@ -434,8 +447,27 @@ mod tests {
                 false,
                 egui::Color32::BLACK,
                 egui::Color32::LIGHT_GRAY,
+                16.0,
             )
         );
+    }
+
+    #[test]
+    fn math_cache_key_includes_the_point_size() {
+        // Without this, the first rendered size is served for every later
+        // scale and changing the setting appears to do nothing.
+        let at = |pt| math_cache_hash("x + y", true, egui::Color32::BLACK, egui::Color32::WHITE, pt);
+        assert_ne!(at(16.0), at(20.0));
+        assert_ne!(at(16.0), at(16.5));
+    }
+
+    #[test]
+    fn math_cache_key_absorbs_sub_hundredth_size_jitter() {
+        // The size derives from a resolved font height, which fluctuates in the
+        // last float digits between frames. Re-keying on that would recompile
+        // every formula through typst on every paint.
+        let at = |pt| math_cache_hash("x + y", true, egui::Color32::BLACK, egui::Color32::WHITE, pt);
+        assert_eq!(at(16.0), at(16.0001));
     }
 
     #[cfg(feature = "math")]
@@ -452,6 +484,7 @@ mod tests {
                     is_inline: true,
                     fg: egui::Color32::BLACK,
                     bg: egui::Color32::WHITE,
+                    size_pt: 16.0,
                     result_tx,
                 },
             ),
@@ -477,6 +510,7 @@ mod tests {
                 is_inline: true,
                 fg: egui::Color32::BLACK,
                 bg: egui::Color32::WHITE,
+                size_pt: 16.0,
                 result_tx,
             }
         };
@@ -507,6 +541,7 @@ mod tests {
                 true,
                 egui::Color32::BLACK,
                 egui::Color32::WHITE,
+                16.0,
             )
             .unwrap()
             .image
@@ -528,6 +563,7 @@ mod tests {
             true,
             egui::Color32::WHITE,
             bg,
+            16.0,
         )
         .unwrap();
         let [width, height] = rendered.image.size;
@@ -1327,6 +1363,9 @@ struct MathJob {
     is_inline: bool,
     fg: egui::Color32,
     bg: egui::Color32,
+    /// Resolved point size. Travels with the job because the worker thread has
+    /// no `Ui` to ask, and must match the size that produced `hash`.
+    size_pt: f32,
     result_tx: mpsc::Sender<MathRenderResult>,
 }
 
@@ -1354,7 +1393,8 @@ fn start_math_workers(worker_count: usize, queue_capacity: usize) -> mpsc::SyncS
                     },
                     Err(_) => break,
                 };
-                let result = render_math_formula(&job.latex, job.is_inline, job.fg, job.bg);
+                let result =
+                    render_math_formula(&job.latex, job.is_inline, job.fg, job.bg, job.size_pt);
                 let _ = job.result_tx.send(MathRenderResult {
                     hash: job.hash,
                     result,
@@ -1574,6 +1614,7 @@ fn render_math_formula(
     is_inline: bool,
     fg: egui::Color32,
     bg: egui::Color32,
+    size_pt: f32,
 ) -> Result<MathRendered, String> {
     // 0. Decode common HTML entities that OCR/conversion tools may leave in math
     let latex = latex
@@ -1611,10 +1652,11 @@ fn render_math_formula(
     let source = format!(
         r#"{preamble}
 #set page(width: auto, height: auto, margin: 0pt, fill: none)
-#set text(size: 16pt, fill: black)
+#set text(size: {size_pt}pt, fill: black)
 {equation}"#,
         preamble = MITEX_PREAMBLE,
         equation = equation,
+        size_pt = size_pt,
     );
 
     // 3. Compile with typst. Reuse the embedded fonts (see MATH_FONTS) instead
@@ -1715,9 +1757,17 @@ pub fn cached_inline_math_height(
     ui: &egui::Ui,
     cache: &CommonMarkCache,
     latex: &str,
+    options: &CommonMarkOptions,
 ) -> Option<f32> {
-    // Key must match what the render pipeline stores (exact colors, like #92).
-    let hash = math_cache_hash(latex, true, ui.visuals().text_color(), ui.visuals().panel_fill);
+    // Key must match what the render pipeline stores (exact colors, like #92,
+    // and the same point size — see `math_size_pt`).
+    let hash = math_cache_hash(
+        latex,
+        true,
+        ui.visuals().text_color(),
+        ui.visuals().panel_fill,
+        math_size_pt(ui, options),
+    );
     match cache.math_states.get(&hash) {
         Some(MathState::Ready { size, .. }) => Some(size.y),
         _ => None,
@@ -1732,14 +1782,20 @@ pub fn render_math(
     cache: &mut CommonMarkCache,
     latex: &str,
     is_inline: bool,
+    options: &CommonMarkOptions,
 ) {
-    render_math_with_layout(ui, cache, latex, is_inline, true);
+    render_math_with_layout(ui, cache, latex, is_inline, true, options);
 }
 
 /// Render inline math in a vertically centered fixed-height table cell.
 #[cfg(feature = "math")]
-pub fn render_math_in_table(ui: &mut egui::Ui, cache: &mut CommonMarkCache, latex: &str) {
-    render_math_with_layout(ui, cache, latex, true, false);
+pub fn render_math_in_table(
+    ui: &mut egui::Ui,
+    cache: &mut CommonMarkCache,
+    latex: &str,
+    options: &CommonMarkOptions,
+) {
+    render_math_with_layout(ui, cache, latex, true, false, options);
 }
 
 #[cfg(feature = "math")]
@@ -1749,11 +1805,13 @@ fn render_math_with_layout(
     latex: &str,
     is_inline: bool,
     align_to_text_baseline: bool,
+    options: &CommonMarkOptions,
 ) {
     let bg = ui.visuals().panel_fill;
     let fg = ui.visuals().text_color();
+    let size_pt = math_size_pt(ui, options);
 
-    let hash = math_cache_hash(latex, is_inline, fg, bg);
+    let hash = math_cache_hash(latex, is_inline, fg, bg, size_pt);
 
     // Poll for completed background renders
     let mut received_any = false;
@@ -1800,7 +1858,9 @@ fn render_math_with_layout(
         && !cache.math_rendering.contains(&hash)
         && cache.math_rendering.len() < math_concurrency()
     {
-        if spawn_math_render(hash, latex, is_inline, fg, bg, cache) == MathEnqueueStatus::Full {
+        if spawn_math_render(hash, latex, is_inline, fg, bg, size_pt, cache)
+            == MathEnqueueStatus::Full
+        {
             // The shared queue is bounded. Retry promptly after workers have
             // had a chance to drain it instead of silently waiting for an
             // unrelated UI event to revisit this formula.
@@ -1924,13 +1984,34 @@ fn math_cache_hash(
     is_inline: bool,
     fg: egui::Color32,
     bg: egui::Color32,
+    size_pt: f32,
 ) -> u64 {
     let mut hasher = DefaultHasher::new();
     latex.hash(&mut hasher);
     is_inline.hash(&mut hasher);
     fg.hash(&mut hasher);
     bg.hash(&mut hasher);
+    // Quantized to 0.01 pt: the rendered bitmap differs at any size the eye can
+    // tell apart, but per-frame float resolution of the body height must not
+    // spawn a fresh typst compile every paint.
+    ((size_pt * 100.0).round() as i64).hash(&mut hasher);
     hasher.finish()
+}
+
+/// Point size to render formulas at, given the ui's Body style and the
+/// configured scale.
+///
+/// Kept in one place because the render path and the height-lookup path
+/// compute the cache key independently — if they disagree by so much as a
+/// rounding step, the lookup misses a key that was just stored.
+pub fn math_size_pt(ui: &egui::Ui, options: &CommonMarkOptions) -> f32 {
+    let body = ui
+        .style()
+        .text_styles
+        .get(&egui::TextStyle::Body)
+        .map(|f| f.size)
+        .unwrap_or(16.0);
+    (body * options.math_scale).max(1.0)
 }
 
 #[cfg(feature = "math")]
@@ -1940,6 +2021,7 @@ fn spawn_math_render(
     is_inline: bool,
     fg: egui::Color32,
     bg: egui::Color32,
+    size_pt: f32,
     cache: &mut CommonMarkCache,
 ) -> MathEnqueueStatus {
     let job = MathJob {
@@ -1947,6 +2029,7 @@ fn spawn_math_render(
         latex: latex.to_owned(),
         is_inline,
         fg,
+        size_pt,
         bg,
         result_tx: cache.math_tx.clone(),
     };

--- a/docs/devlog/061-formula-scale.md
+++ b/docs/devlog/061-formula-scale.md
@@ -1,0 +1,86 @@
+# Feature: formula scale relative to body typography
+
+**Status:** ✅ Complete
+**Branch:** `feature/123-formula-scale`
+**Date:** 2026-09-04
+**Issue:** #123
+
+## Summary
+
+The math renderer compiled every formula with a hard-coded Typst setting:
+
+```typst
+#set text(size: 16pt, fill: black)
+```
+
+The application Body style is also 16 logical points, so this was not an
+accidental downscale — but it is a fixed coupling. Math glyphs and dense
+fractions read as perceptually smaller than surrounding prose, and the only
+existing remedy is application zoom, which enlarges the entire UI rather than
+the formulas relative to the text.
+
+Adds a scale relative to the resolved Body font size.
+
+## The five places the size has to reach
+
+Taken from the issue, and each one is a real failure if missed:
+
+1. **The Typst source** — otherwise nothing changes visually.
+2. **The math cache key** — otherwise the first-rendered size is served for
+   every later scale, and changing the setting appears to do nothing.
+3. **Cached inline height/baseline** (`cached_inline_math_height`) — it
+   recomputes the same hash independently, so it must agree with the render
+   path or it looks up a key that was never stored.
+4. **The scroll/layout invalidation signature** — otherwise `split_points`
+   keep positions measured at the old formula size.
+5. **Table row-height measurement** — `table_cell_height` asks
+   `cached_inline_math_height` how tall an inline formula is; a stale answer
+   clips the formula inside its row.
+
+## Key discoveries
+
+### The cache key has to quantize the size
+
+The point size derives from the resolved Body font height, which fluctuates in
+its last float digits between frames — the same behaviour that forced
+`compute_layout_signature` to quantize (see LESSONS.md, "layout_signature must
+quantize floats"). Hashing the raw `f32` would produce a fresh key almost every
+paint, and every miss **recompiles the formula through typst on a worker
+thread**. Quantized to 0.01 pt: finer than anything the eye resolves, coarser
+than the jitter. A test pins it.
+
+### Two code paths compute the same key independently
+
+`render_math_with_layout` stores under a key it computes; `cached_inline_math_height`
+looks up a key it computes separately. If they disagree by a rounding step, the
+lookup misses a key that was just stored — and the failure is silent: the row
+height falls back to a conservative guess and the formula is clipped. Both now
+go through one `math_size_pt` helper, which exists for exactly that reason.
+
+### The size has to travel to the worker thread
+
+Rendering happens off-thread and the worker has no `Ui` to ask for a font
+height, so the resolved size rides along in `MathJob` next to the colours.
+
+## Verification
+
+Measured block heights, same document, 100 % vs 150 %:
+
+| block | 100 % | 150 % |
+|---|---|---|
+| heading | 26 px | 26 px |
+| paragraph with inline formulas | 20 px | **31 px** |
+| plain text line | 17 px | 17 px |
+| display formula | 38 px | **61 px** |
+| body text after | 17 px | 17 px |
+
+Formulas grow, prose does not — which is the whole point, and what application
+zoom cannot do.
+
+## Future improvements
+
+- Inline and display formulas share one scale. The issue notes they may
+  eventually want separate policies; one shared scale was the smaller first
+  step and nothing here blocks splitting it later.
+- The menu offers fixed steps (100/110/125/150 %). A continuous slider would
+  need throttling — every distinct value is a fresh typst compile per formula.

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,6 +375,7 @@ struct PersistedState {
     zoom_level: Option<f32>,
     show_outline: Option<bool>,
     full_width_content: Option<bool>,
+    math_scale: Option<f32>,
     /// Selection/highlight background color override, stored as premultiplied
     /// RGBA bytes (`Color32`'s canonical representation — see `Color32::r/g/b/a`
     /// and `Color32::from_rgba_premultiplied`). `None` = current theme default.
@@ -1759,6 +1760,7 @@ struct MarkdownApp {
     zoom_level: f32,
     show_outline: bool,
     full_width_content: bool,
+    math_scale: f32,
     // Selection/highlight background color override. `None` = theme default.
     highlight_color: Option<egui::Color32>,
     // Mirrors `last_applied_dark_mode`: only rebuild Visuals when this changes.
@@ -1868,6 +1870,7 @@ impl MarkdownApp {
         let zoom_level = persisted.zoom_level.unwrap_or(1.0).clamp(0.5, 3.0);
         let show_outline = persisted.show_outline.unwrap_or(true);
         let full_width_content = persisted.full_width_content.unwrap_or(false);
+        let math_scale = persisted.math_scale.unwrap_or(1.0).clamp(1.0, 2.0);
         let highlight_color = persisted
             .highlight_color
             .map(|[r, g, b, a]| egui::Color32::from_rgba_premultiplied(r, g, b, a));
@@ -1965,6 +1968,7 @@ impl MarkdownApp {
             zoom_level,
             show_outline,
             full_width_content,
+            math_scale,
             // Frame 1 always rebuilds Visuals anyway (last_applied_dark_mode
             // starts at None), so this just avoids a spurious second rebuild
             // afterward if nothing further changes.
@@ -3390,6 +3394,7 @@ impl MarkdownApp {
                     // key/value table rather than a thematic break plus a
                     // paragraph of raw `key: value` lines (#117).
                     .render_frontmatter(true)
+                    .math_scale(self.math_scale)
                     .show_alt_text_on_hover(true)
                     .syntax_theme_dark("base16-ocean.dark")
                     .syntax_theme_light("base16-ocean.light")
@@ -4219,6 +4224,7 @@ impl eframe::App for MarkdownApp {
             zoom_level: Some(self.zoom_level),
             show_outline: Some(self.show_outline),
             full_width_content: Some(self.full_width_content),
+            math_scale: Some(self.math_scale),
             highlight_color: self.highlight_color.map(|c| [c.r(), c.g(), c.b(), c.a()]),
             link_color: self.link_color.map(|c| [c.r(), c.g(), c.b(), c.a()]),
             open_tabs: Some(self.get_open_tab_paths()),
@@ -4824,6 +4830,38 @@ impl eframe::App for MarkdownApp {
                         self.zoom_level = 1.0;
                         ui.close();
                     }
+
+                    ui.separator();
+                    // Distinct from zoom: zoom scales the whole UI, leaving
+                    // formulas and prose in the same ratio. This changes only
+                    // the formulas, relative to the text around them.
+                    ui.menu_button("Formula Size", |ui| {
+                        for (label, scale) in [
+                            ("100%", 1.0f32),
+                            ("110%", 1.1),
+                            ("125%", 1.25),
+                            ("150%", 1.5),
+                        ] {
+                            let selected = (self.math_scale - scale).abs() < 0.001;
+                            let text = if selected {
+                                format!("✓ {label}")
+                            } else {
+                                format!("   {label}")
+                            };
+                            let btn = ui.add(egui::Button::new(text));
+                            #[cfg(feature = "mcp")]
+                            self.mcp_bridge.register_widget(
+                                &format!("Menu: View → Formula Size → {label}"),
+                                "button",
+                                &btn,
+                                Some(if selected { "selected" } else { "unselected" }),
+                            );
+                            if btn.clicked() {
+                                self.math_scale = scale;
+                                ui.close();
+                            }
+                        }
+                    });
                 });
                 #[cfg(feature = "mcp")]
                 self.mcp_bridge


### PR DESCRIPTION
Closes #123.

## The problem

Every formula compiled with a hard-coded Typst setting:

```typst
#set text(size: 16pt, fill: black)
```

The application Body style is also 16 points, so this was not an accidental downscale — but it is a fixed coupling. Math glyphs and dense fractions read as perceptually smaller than surrounding prose, and the only existing remedy was application zoom, which enlarges the whole UI and therefore leaves formulas and text in exactly the same ratio.

## What this adds

`CommonMarkViewer::math_scale(f32)` — a multiple of the resolved Body font size, default `1.0`. md-viewer exposes it as **View → Formula Size** (100 / 110 / 125 / 150 %), persisted.

## Measured

Same document, 100 % vs 150 %:

| block | 100 % | 150 % |
|---|---|---|
| heading | 26 px | 26 px |
| paragraph with inline formulas | 20 px | **31 px** |
| plain text line | 17 px | 17 px |
| display formula | 38 px | **61 px** |
| body text after | 17 px | 17 px |

Formulas grow, prose does not. That is the distinction from zoom.

## The five places the size has to reach

Straight from the issue's list, and each omission is a distinct failure:

1. **The typst source** — or nothing changes visually.
2. **The math cache key** — or the first rendered size is served for every later scale, and the setting appears to do nothing.
3. **`cached_inline_math_height`** — it computes that key *independently*. A disagreement of one rounding step misses a key that was just stored, **silently**: the row falls back to a conservative height guess and the formula is clipped. Both paths now go through one `math_size_pt` helper, which exists for exactly this reason.
4. **The layout signature** — or `split_points` keep positions measured at the old size.
5. **Table row-height measurement** — reached via the height lookup in 3.

## Why the key quantizes

The point size derives from the resolved Body font height, which fluctuates in its last float digits between frames. Hashing the raw `f32` would produce a fresh key on nearly every paint, and every miss **recompiles the formula through typst on a worker thread**. Quantized to 0.01 pt — finer than the eye resolves, coarser than the jitter.

This is the same trap `docs/LESSONS.md` already records for `compute_layout_signature` ("layout_signature must quantize floats"). A test pins the behaviour in both directions: 16.0 vs 16.5 must differ, 16.0 vs 16.0001 must not.

## Note on library consumers

The scale is relative to *their* resolved Body size, as the issue proposed. A consumer whose Body style is not 16pt previously got 16pt math regardless; at `1.0` they now get math matching their body text. That is the intended semantic — "follow typography" — but it is a visible change for such a consumer, so worth stating plainly rather than burying.

## Testing

- Three cache-key tests: colours still distinguish (existing, updated), point size distinguishes, sub-0.01pt jitter does not.
- Full suites: root 59, renderer 58 + 1 + 18 + 16, backend 27 + 1. Zero failures. `cargo fmt --check` clean.
- Visual verification at 100 % and 150 %, numbers above.

## Merge note

This conflicts with **#129** — both add an `options` parameter to `table_cell_height`. The conflict is the same line in both branches and trivial to resolve; whichever lands second needs one hand-edit.