### PR TITLE
Reserve a table's own height instead of everything below the cursor

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -1545,7 +1545,43 @@ impl CommonMarkViewerInternal {
             // top of everything above it.
             let mut table_scope_rect = ui.cursor();
             table_scope_rect.max.x = table_scope_rect.min.x + table_bound;
-            table_scope_rect.max.y = ui.max_rect().bottom();
+            // Reserve the table's own height rather than "everything below the
+            // cursor".
+            //
+            // egui_extras accounts for the rows it skips only once its loop
+            // reaches the first *visible* row (`heterogeneous_rows` ->
+            // `add_buffer`). A table lying entirely above the visible range
+            // never gets there and reserves nothing, collapsing to zero height.
+            // Every block below it then lays out too high, so a paint made
+            // while scrolled measures the document shorter — and any position
+            // recorded during such a paint (heading y for outline clicks) is
+            // compressed by the same factor.
+            let reserved_row_heights: Vec<f32> = table_rows
+                .iter()
+                .map(|row| {
+                    row.iter()
+                        .enumerate()
+                        .map(|(column, cell)| {
+                            table_cell_height(
+                                cell,
+                                line_h,
+                                cache,
+                                ui,
+                                initial_widths.get(column).copied().unwrap_or(40.0),
+                                options,
+                            )
+                        })
+                        .fold(cell_h, f32::max)
+                })
+                .collect();
+            let group_frame = egui::Frame::group(ui.style());
+            let reserved_height = reserved_row_heights.iter().sum::<f32>()
+                + ui.spacing().item_spacing.y
+                    * reserved_row_heights.len().saturating_sub(1) as f32
+                + f32::from(group_frame.inner_margin.top)
+                + f32::from(group_frame.inner_margin.bottom)
+                + group_frame.stroke.width * 2.0;
+            table_scope_rect.max.y = table_scope_rect.min.y + reserved_height;
             let _ = ui
                 .scope_builder(egui::UiBuilder::new().max_rect(table_scope_rect), |ui| {
                     let mut scroll_out = egui::ScrollArea::horizontal()

--- a/docs/devlog/062-table-height-reservation.md
+++ b/docs/devlog/062-table-height-reservation.md
@@ -1,0 +1,100 @@
+# Fix: reserve a table's own height instead of everything below the cursor
+
+**Status:** ✅ Complete
+**Branch:** `fix/table-height-reserve`
+**Date:** 2026-09-04
+
+## Summary
+
+Clicking a heading in the outline scrolled past it. On a 120-section document
+with a 12-row table per section, clicking "Section 30" put the *end* of section
+30 at the top of the viewport — `entry_30_11`, `entry_30_12`, "Closing text for
+section 30" — with the heading itself scrolled off above. Roughly one section of
+overshoot, about a full viewport on this document.
+
+## Root cause
+
+`egui_extras` accounts for the rows it skips only once its loop reaches the
+first *visible* row (`heterogeneous_rows` → `add_buffer`). A table lying
+entirely above the visible range never reaches that point and reserves nothing,
+collapsing to zero height. Every block below it then lays out too high.
+
+An outline click forces a full paint at the estimated offset so headings can
+record their y. That paint is scrolled, so any table above the viewport has
+collapsed and the recorded positions are wrong.
+
+The table scope previously reserved `ui.max_rect().bottom()` — "everything
+below the cursor" — which does not describe the table's actual extent. Stating
+the real height makes the table occupy its space whether or not its rows were
+culled.
+
+## Provenance
+
+The analysis and the approach come from uncommitted work on
+`fix/viewport-slice-layout`, which also carries a *different*, committed
+approach to the same area: discarding position recordings made during a
+scrolled paint. That one is deliberately **not** included here — it is a
+workaround for the distortion this change removes at the source, and with the
+distortion gone it would only discard legitimate re-measurements.
+
+That branch's commit message describes a 3x undershoot ("Section 30 landed on
+Section 10"). That symptom **no longer reproduces**: #113 and #114 removed the
+layout distortion it described. What remains is the overshoot measured above —
+same mechanism, opposite sign, much smaller.
+
+## Key discoveries
+
+### The reservation is necessarily an estimate
+
+Row heights are computed twice, and that is not redundancy. The reservation
+runs *before* the table is built and can only use `initial_widths` — the
+pre-layout estimate. The existing computation inside `body()` uses
+`body.widths()`, the widths the table actually laid out with. Two different
+questions at two different times.
+
+So the reserved height can be slightly wrong. Measured on a table with images:
+content below the table sits **1 px lower** than on `main` — 0.3 % of a ~330 px
+table, in the over-reserving direction. Documents without images are
+pixel-identical.
+
+### It is not free of cost, but the cost is unmeasurable here
+
+Doubling the per-table row-height computation sounded expensive enough to check
+before proposing it. Over 200 wheel clicks on a 120-table document: **22.71 s
+CPU on `main`, 22.64 s with the reservation** — 0.3 %, inside the noise. The
+row-height work is small next to painting.
+
+### The symptom in the source branch no longer exists
+
+`fix/viewport-slice-layout` describes a 3x undershoot ("Section 30 landed on
+Section 10"). Measured today on `main`: clicking Section 30 lands at the *end*
+of section 30 — an overshoot of about one section. Same mechanism, opposite
+sign, much smaller, because #113 and #114 removed the larger distortion.
+
+Concluding from "the described symptom is gone" that "the branch is obsolete"
+would have been wrong, and was the first conclusion drawn here. The click was
+still landing in the wrong place; only the direction had changed.
+
+## Verification
+
+| check | result |
+|---|---|
+| Outline click, "Section 30" | `main`: end of section 30. This branch: **the heading** |
+| Scroll CPU, 200 wheel clicks | 22.71 s → 22.64 s |
+| Tables without images | pixel-identical |
+| Tables with images | 1 px vertical shift below the table |
+| Frontmatter / math documents | pixel-identical |
+| `scripts/scroll-regression.sh` | PASS, bottom at frame 103 (same as `main`) |
+| All suites | root 60, renderer 65+1+18+16, backend 27+1 |
+
+The control run matters for the image case: capturing the same build twice is
+pixel-identical, so the 1 px is caused by this change and not by async image
+loading.
+
+## Future improvements
+
+- The estimate/actual width split is the only source of the 1 px. Reserving
+  from the same widths the table lays out with would need the reservation to
+  happen after `body()`, which is exactly what it cannot do.
+- Only Markdown tables reserve. `render_html_table` uses a separate path and
+  still reserves "everything below the cursor".


### PR DESCRIPTION
## The bug

Clicking a heading in the outline scrolls *past* it. On a 120-section document with a 12-row table per section, clicking **Section 30** puts the end of that section at the top of the viewport:

| build | what is at the top of the viewport after clicking "Section 30" |
|---|---|
| `main` | `entry_30_11`, `entry_30_12`, "Closing text for section 30" — the heading is scrolled off above |
| this branch | **`Section 30`**, its intro paragraph, the start of its table |

About a full viewport of overshoot on this document.

## Root cause

`egui_extras` accounts for the rows it skips only once its loop reaches the first *visible* row (`heterogeneous_rows` → `add_buffer`). A table lying entirely above the visible range never reaches that point and reserves nothing, collapsing to zero height. Every block below it then lays out too high.

An outline click forces a full paint at the estimated offset so headings can record their y. That paint is scrolled — so every table above the viewport has collapsed, and the recorded positions are off by their summed height.

The table scope reserved `ui.max_rect().bottom()` — "everything below the cursor" — which does not describe the table's extent. Stating the real height makes the table occupy its space whether or not its rows were culled.

## Two things measured before proposing this

**The reservation is necessarily an estimate.** Row heights end up computed twice, and that is not redundancy: the reservation runs *before* the table is built and can only use `initial_widths`, while the rows are laid out later with `body.widths()`. Two different questions at two different times.

The cost of that estimate: on a table containing images, content below the table sits **1 px lower** than on `main` — 0.3 % of a ~330 px table, in the over-reserving direction. Documents without images are pixel-identical. A control run (same build captured twice) is pixel-identical, so the 1 px is this change and not async image loading.

**The extra row-height pass sounded expensive.** Over 200 wheel clicks on the 120-table document: **22.71 s CPU on `main`, 22.64 s here** — 0.3 %, inside the noise. Row-height work is small next to painting. Worth checking given how many entries in `docs/LESSONS.md` are about per-frame work quietly costing the frame budget.

## Verification

| check | result |
|---|---|
| Outline click, Section 30 | fixed, see table above |
| Scroll CPU, 200 wheel clicks | 22.71 s → 22.64 s |
| Tables without images | pixel-identical |
| Tables with images | 1 px shift below the table |
| Frontmatter and math documents | pixel-identical |
| `scripts/scroll-regression.sh` | PASS, bottom at frame 103 — same as `main` |
| Test suites | root 60, renderer 65 + 1 + 18 + 16, backend 27 + 1, zero failures |
| `cargo fmt --check` | clean |

## Provenance, and what is deliberately left out

The analysis and approach come from **uncommitted** work on `fix/viewport-slice-layout`. That branch also carries a *committed*, different approach to the same area: discarding position recordings made during a scrolled paint. That one is **not** included here — it works around the distortion this change removes at the source, and with the distortion gone it would only discard legitimate re-measurements.

That branch's commit message describes a **3x undershoot** ("Section 30 landed on Section 10"). That symptom no longer reproduces — #113 and #114 removed the larger distortion. What remains is the overshoot above: same mechanism, opposite sign, much smaller.

Worth stating because it nearly cost the fix: concluding from "the described symptom is gone" that "the branch is obsolete" was the first conclusion drawn here, and it was wrong. The click was still landing in the wrong place; only the direction had changed.

`fix/viewport-slice-layout` is intentionally left in place until this is merged and confirmed, so the alternative approach stays documented.

## Not covered

`render_html_table` uses a separate path and still reserves "everything below the cursor". HTML tables are unaffected by this change, for better and worse.