### PR TITLE
Correct the release runbook

### DIFF
--- a/.claude/rules/release-workflow.md
+++ b/.claude/rules/release-workflow.md
@@ -1,33 +1,89 @@
 # Release Workflow
 
-## Automatic Changelog Suggestion
+## The CHANGELOG is hand-written — never regenerate it
 
-When the user mentions any of these, **suggest generating a changelog**:
-- "release", "version", "tag", "publish"
-- "what changed", "changelog", "release notes"
-- Merging a significant feature to main
+**Do not run `git-cliff -o CHANGELOG.md`.** It parses conventional commits, this
+repository's history does not conform, and the generated file is sparse enough
+that entire versions disappear (v0.1.4, v0.1.6 and v0.1.7 vanished on the
+v0.1.8 attempt). Running it with `-o` overwrites the existing hand-written
+prose with that degraded version.
 
-Suggest: "Would you like me to generate/update the CHANGELOG.md using git-cliff?"
+If you want a starting point, `git-cliff --tag vX.Y.Z` prints to stdout and can
+be read for inspiration. The entry itself is written by hand, in the style of
+the existing ones: what changed, why, and the PR reference.
 
-## Generating Changelog
+Recovery if it was run anyway: `git checkout CHANGELOG.md`.
 
-If git-cliff is installed, generate changelog automatically:
+See `docs/LESSONS.md`, "CHANGELOG.md is hand-curated".
 
-```bash
-git-cliff -o CHANGELOG.md
-```
+## Before tagging
 
-If not installed:
-```bash
-cargo install git-cliff
-```
+1. **Everything intended for the release is merged to `main`,** and `main` is
+   in sync with `origin/main`.
 
-Use `/changelog` as an explicit shortcut if needed.
+2. **Bump the version in `Cargo.toml` and `Cargo.lock`.**
 
-## Before Tagging a Release
+   Edit the lockfile *surgically* — scope the change to the `md-viewer` block:
 
-1. Ensure all features are merged to main
-2. Generate fresh changelog: `git-cliff -o CHANGELOG.md`
-3. Review changelog for accuracy
-4. Commit changelog if changed
-5. Create version tag: `git tag v0.X.0`
+   ```
+   name = "md-viewer"
+   version = "0.1.7"      ->      version = "0.1.8"
+   ```
+
+   Never `sed` it. `sed -i 's/^version = "0.1.7"$/.../' Cargo.lock` rewrote five
+   lines on the v0.1.8 attempt — four unrelated crates happened to sit at the
+   same version and were silently given invalid ones. `cargo update -p md-viewer
+   --precise X.Y.Z` from a clean tree is the unambiguous alternative.
+
+   Always `git diff Cargo.lock` afterwards. Anything beyond the one line under
+   `[[package]] name = "md-viewer"` is a mistake.
+
+3. **If the vendored renderer changed, bump its workspace version too**
+   (`crates/egui_commonmark/Cargo.toml`, `[workspace.package] version`). All
+   three fork crates share it.
+
+4. **Prepend a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`,** by hand.
+
+5. **Commit, then tag:** `git tag vX.Y.Z && git push origin vX.Y.Z`.
+
+## What the tag sets off
+
+Pushing the tag runs `.github/workflows/release.yml`, which publishes to
+**four** places. It is not reversible by deleting the tag.
+
+- **crates.io** — the `publish-crates` job runs `scripts/publish-crates.sh`,
+  which publishes in dependency order with a 45 s sparse-index pause between
+  steps: `egui_commonmark_backend_extended` → `..._macros_extended` →
+  `..._extended` → `md-viewer`. Re-tagging is safe: "already uploaded" counts
+  as success.
+
+  The fork crates therefore do **not** need publishing by hand first. A local
+  `cargo package -p md-viewer` *will* fail while the fork's new version is not
+  yet on crates.io — that is expected and not a release blocker, because the
+  pipeline publishes them earlier in the same run.
+
+- **Snap Store** — built in CI with LXD. Never `snapcraft --destructive-mode`
+  from this machine: its glibc is newer than the declared `base:`, and the
+  resulting snap fails to start on the target distro (issue #3). If CI fails,
+  fix CI.
+
+- **AUR**, twice — `md-viewer` (source) and `md-viewer-bin`.
+
+- **GitHub Release** with the platform tarballs.
+
+## Verification worth doing before tagging
+
+- `cargo test` at the root, and the renderer crates through their own manifest:
+
+  ```bash
+  RENDERER_FEATURES=better_syntax_highlighting,svg,svg_text,load-images,fetch,mermaid,math,macros
+  cargo test --manifest-path crates/egui_commonmark/Cargo.toml \
+      -p egui_commonmark_extended --features "$RENDERER_FEATURES"
+  ```
+
+  The two are separate workspaces — a plain `cargo test` at the root covers
+  only half the code, silently. (Discussed in issue #122.)
+
+- `scripts/scroll-regression.sh` and `scripts/visual-regression.sh`. Neither
+  runs in CI — they need Xvfb, xdotool and ImageMagick — and between them they
+  have caught several rendering defects that all three CI jobs passed.


### PR DESCRIPTION
`.claude/rules/release-workflow.md` is the file the next session reads before tagging. Two things in it were wrong.

## It instructed running a command LESSONS.md forbids

```
2. Generate fresh changelog: git-cliff -o CHANGELOG.md
```

`docs/LESSONS.md` records under "CHANGELOG.md is hand-curated" that this **destroys** the file: git-cliff parses conventional commits, this repository's history does not conform, and v0.1.4, v0.1.6 and v0.1.7 vanished entirely on the v0.1.8 attempt. The rule told the reader to do the thing the lessons file exists to prevent.

## It said nothing about what tagging does

Pushing a tag publishes to **four** places — crates.io, the Snap Store, AUR twice, and GitHub Releases — and deleting the tag does not undo any of it. That belongs in the runbook, not in the discovery afterwards.

## Also written down, from today's session

- **The lockfile bump must be surgical.** `sed` on the version line rewrote five entries on the v0.1.8 attempt, silently giving four unrelated crates invalid versions. The `cargo update -p md-viewer --precise` alternative is noted, along with "always `git diff Cargo.lock` afterwards".

- **The fork crates do not need publishing by hand.** `scripts/publish-crates.sh` already publishes backend → macros → extended → md-viewer in order, with the sparse-index pause, inside the release run. I want this written down because I got it wrong earlier today: a local `cargo package -p md-viewer` fails while the fork's new version is not yet on crates.io, and I read that as a release blocker. It is expected — the pipeline publishes them earlier in the same run.

- **`cargo test` at the root covers only half the code.** The renderer is a separate workspace; the working invocation with the feature list is spelled out. (Same friction as issue #122.)

- **The two visual guards do not run in CI.** `scripts/scroll-regression.sh` and `scripts/visual-regression.sh` need Xvfb, xdotool and ImageMagick. Between them they have caught several rendering defects that all three CI jobs passed — including one today on a PR whose CI was fully green.

Documentation only; no code changes.