### PR TITLE
Validate the crates.io token before building anything

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,42 @@ jobs:
             exit 1
           fi
 
+      - name: crates.io token is valid
+        # The publish job runs ~20 minutes in, after the whole build matrix and
+        # the snap. When the token is dead it fails there, at the very end, while
+        # every other channel has already published — so the release looks
+        # finished and the crates.io gap goes unnoticed. That is exactly what
+        # happened to v0.1.16 and v0.1.17: both failed here with
+        # `403 Forbidden: authentication failed`, and crates.io sat four versions
+        # behind for six weeks before anyone looked.
+        #
+        # `GET /api/v1/me` is read-only and costs a second, so the same failure
+        # now lands before anything is built or published anywhere.
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
+            echo "::notice::CARGO_REGISTRY_TOKEN is unset — crates.io publish will be skipped."
+            exit 0
+          fi
+          CODE=$(curl -sS -o /tmp/me.json -w '%{http_code}' \
+            -H "Authorization: ${CARGO_REGISTRY_TOKEN}" \
+            -H "User-Agent: md-viewer-release (https://github.com/aydiler/md-viewer)" \
+            https://crates.io/api/v1/me || echo 000)
+          case "$CODE" in
+            200)
+              echo "crates.io token accepted for: $(python3 -c 'import json;print(json.load(open("/tmp/me.json"))["user"]["login"])')"
+              ;;
+            401|403)
+              echo "::error::crates.io rejected CARGO_REGISTRY_TOKEN (HTTP $CODE). Mint a new token at https://crates.io/settings/tokens and update the repository secret, then re-tag."
+              exit 1
+              ;;
+            *)
+              echo "::error::Could not reach crates.io to validate the token (HTTP $CODE). Re-run the job."
+              exit 1
+              ;;
+          esac
+
       - name: Vendored fork is publishable to crates.io
         # Fails the release if the vendored egui_commonmark fork's source differs
         # from what is already published at its pinned version. crates.io is


### PR DESCRIPTION
## crates.io has been four versions behind for six weeks

| crate | crates.io | `main` |
|---|---|---|
| `md-viewer` | **0.1.15** (2026-07-23) | 0.2.0 |
| `egui_commonmark_backend_extended` | **0.25.0** (2026-07-15) | 0.28.0 |
| `egui_commonmark_macros_extended` | **0.25.0** | 0.28.0 |
| `egui_commonmark_extended` | **0.25.0** | 0.28.0 |

Both release runs that should have closed the gap failed identically:

```
error: failed to publish to registry at https://crates.io
  the remote server responded with an error (status 403 Forbidden): authentication failed
```

v0.1.16 ([run 32582386439](https://github.com/aydiler/md-viewer/actions/runs/32582386439)) and v0.1.17 ([run 32590830300](https://github.com/aydiler/md-viewer/actions/runs/32590830300)), both on 2026-08-22.

## The token expired

| | |
|---|---|
| `CARGO_REGISTRY_TOKEN` secret set | 2026-05-16 |
| last successful fork publish (0.25.0) | 2026-07-15 |
| last successful `md-viewer` publish (0.1.15) | 2026-07-23 |
| first `403 authentication failed` | 2026-08-22 |

Consistent with a 90-day token lapsing around 2026-08-14. Nothing in the release workflow changed between the last success and the first failure, and the failure is on the very first crate — not a dependency-resolution or feature-parity problem.

I also ruled out the more interesting hypothesis: the error prints `cargo publish failed for egui_commonmark_backend`, without the `_extended` suffix, which would suggest publishing under a name we do not own. It is only a cosmetic label in `scripts/publish-crates.sh` (the directory basename); the manifest correctly says `egui_commonmark_backend_extended`.

## Why nobody noticed

`publish-crates` runs about twenty minutes in, after the whole build matrix and the snap. By the time it fails, the snap, both AUR packages and the GitHub Release have already published — so the release *looks* delivered. The run is red, but red at the very end of a release that shipped everything a user would actually check.

## What this changes

A read-only `GET /api/v1/me` in the `validate` job, which already gates the workflow. A dead token now fails in about a second, before anything is built or published anywhere, and the error names the fix. An unset secret stays a `::notice::`, matching how the publish job already treats it.

## What this does **not** fix

The token itself. That needs a new one minted at https://crates.io/settings/tokens and stored in the repository secret — I cannot do that. **Until then, tagging `v0.2.0` will publish to the Snap Store, both AUR packages and GitHub Releases, but not to crates.io** — and with this merged, it will refuse to start instead of discovering that twenty minutes later.