### PR TITLE
Gate math cache-key tests behind the math feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Test renderer crates
         run: |
           cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_extended --features "$RENDERER_FEATURES"
+          cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_backend_extended --no-default-features
           cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_backend_extended --all-features
           cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_macros_extended
 

--- a/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/misc.rs
@@ -452,6 +452,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "math")]
     #[test]
     fn math_cache_key_includes_the_point_size() {
         // Without this, the first rendered size is served for every later
@@ -461,6 +462,7 @@ mod tests {
         assert_ne!(at(16.0), at(16.5));
     }
 
+    #[cfg(feature = "math")]
     #[test]
     fn math_cache_key_absorbs_sub_hundredth_size_jitter() {
         // The size derives from a resolved font height, which fluctuates in the


### PR DESCRIPTION
## Summary

- gate the two remaining `math_cache_hash` tests behind the `math` feature, matching the function they exercise
- exercise the backend package with `--no-default-features` in the existing renderer CI job
- leave production code and runtime behavior unchanged

## Why

`math_cache_hash` is compiled only when the `math` feature is enabled. Two cache-key tests were not gated, so the backend package failed to compile in its feature-minimal configuration even though the runtime library supports that configuration.

This PR is deliberately scoped to the backend package. It does not claim that every target in the complete vendored renderer workspace supports `--no-default-features`.

## Testing

- `cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_backend_extended --no-default-features` (13 tests and 1 doctest passed)
- `cargo test --manifest-path crates/egui_commonmark/Cargo.toml -p egui_commonmark_backend_extended --all-features` (27 tests and 1 doctest passed)
- `cargo fmt --check`
- `git diff --check`
