### PR TITLE
CI: check macOS and Windows builds on pull requests

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,0 +1,27 @@
+name: Cross-platform check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: cargo check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --locked


### PR DESCRIPTION
## Summary

- add native `cargo check --locked` jobs for macOS and Windows
- keep the existing Linux job as the full lint/build/test path
- use a separate workflow so the lightweight portability guard remains independent of Linux CI

## Scope

These jobs validate that the application's locked production dependency graph compiles on the native GitHub-hosted macOS and Windows runners. They do not claim to validate linking, runtime behavior, packaging, or release artifacts; those remain covered by the release workflow and platform-specific testing.

## Local validation

- workflow YAML parsed successfully
- `cargo check --locked` passed on Linux as a syntax/dependency sanity check
- `git diff --check`

The actual macOS and Windows result is intentionally left to the native GitHub Actions jobs introduced by this PR.
