### PR TITLE
Resolve links the same way with and without Ctrl

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1055,8 +1055,14 @@ impl Tab {
             return Ok(false);
         };
 
-        let path_part = link.split('#').next().unwrap_or(link);
-        let target_path = current_dir.join(path_part);
+        // Share one resolver with `resolve_link` (the ctrl+click path).
+        // These used to differ: #78 taught percent-decoding and `file://`
+        // handling to `resolve_local_link_path`, but this function still did a
+        // raw `join`, so a link with an encoded space opened in a new tab on
+        // ctrl+click and silently did nothing on a plain click.
+        let Some(target_path) = resolve_local_link_path(link, current_dir) else {
+            return Ok(false);
+        };
 
         let target_path = match target_path.canonicalize() {
             Ok(p) => p,
@@ -5447,6 +5453,92 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].byte_start, 7);
         assert_eq!(matches[0].byte_end, 11);
+    }
+
+    #[test]
+    fn shared_resolver_keeps_absolute_paths_and_literal_percent_names() {
+        let root = std::env::temp_dir().join(format!(
+            "md-viewer-141-edges-{}-{}",
+            std::process::id(),
+            now_epoch_secs()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let home = root.join("home.md");
+        let abs = root.join("absolute.md");
+        // `%` not followed by two hex digits is not an escape and must survive.
+        let literal = root.join("100%done.md");
+        fs::write(&home, "# Home").unwrap();
+        fs::write(&abs, "# Abs").unwrap();
+        fs::write(&literal, "# Literal").unwrap();
+
+        let mut tab = Tab::new(home.clone()).unwrap();
+
+        let abs_link = abs.to_string_lossy().to_string();
+        assert!(tab.navigate_to_link(&abs_link).unwrap(), "absolute path");
+        assert_eq!(tab.path, abs.canonicalize().unwrap());
+
+        assert!(
+            tab.navigate_to_link("100%done.md").unwrap(),
+            "literal percent"
+        );
+        assert_eq!(tab.path, literal.canonicalize().unwrap());
+
+        // an anchor-only destination is still not a path
+        assert!(!tab.navigate_to_link("#section").unwrap());
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn plain_click_and_ctrl_click_resolve_the_same_link_identically() {
+        // #141: `resolve_link` (ctrl+click) and `navigate_to_link` (plain click)
+        // must resolve a destination identically. #78 taught percent-decoding
+        // and `file://` to the former only, so an encoded space opened in a new
+        // tab on ctrl+click and silently did nothing on a plain click.
+        let root = std::env::temp_dir().join(format!(
+            "md-viewer-141-baseline-{}-{}",
+            std::process::id(),
+            now_epoch_secs()
+        ));
+        let spaced = root.join("docs with spaces");
+        fs::create_dir_all(&spaced).unwrap();
+        let home = root.join("home.md");
+        let guide = spaced.join("guide.md");
+        fs::write(&home, "# Home").unwrap();
+        fs::write(&guide, "# Guide").unwrap();
+
+        let mut tab = Tab::new(home.clone()).unwrap();
+        let encoded = "docs%20with%20spaces/guide.md";
+
+        // ctrl+click path: decodes, resolves
+        assert_eq!(
+            tab.resolve_link(encoded),
+            Some(guide.canonicalize().unwrap()),
+            "resolve_link should decode percent escapes"
+        );
+
+        // plain-click path must reach the same file
+        assert!(
+            tab.navigate_to_link(encoded).unwrap(),
+            "navigate_to_link must decode percent escapes too"
+        );
+        assert_eq!(tab.path, guide.canonicalize().unwrap());
+        assert!(tab.navigate_to_path(&home).unwrap());
+
+        // same divergence for file:// destinations
+        let uri = format!("file://{}", guide.canonicalize().unwrap().display());
+        assert_eq!(
+            tab.resolve_link(&uri),
+            Some(guide.canonicalize().unwrap()),
+            "resolve_link should accept file:// URIs"
+        );
+        assert!(
+            tab.navigate_to_link(&uri).unwrap(),
+            "navigate_to_link must accept file:// URIs too"
+        );
+        assert_eq!(tab.path, guide.canonicalize().unwrap());
+
+        fs::remove_dir_all(&root).ok();
     }
 
     #[test]


### PR DESCRIPTION
A plain click and a Ctrl+click on the **same destination** went through two different resolvers.

- `resolve_link` (Ctrl, opens a new tab) calls `resolve_local_link_path`, which percent-decodes and understands `file://` since #78.
- `navigate_to_link` (plain click, navigates in place) still did a raw `current_dir.join(...)`.

So a link written `docs%20with%20spaces/guide.md`:

| | Ctrl+click | plain click |
|---|---|---|
| `docs%20with%20spaces/guide.md` | opens the file | **nothing happens, silently** |
| `file:///…/guide.md` | opens the file | **nothing happens, silently** |

The plain-click path looked for a directory literally named `docs%20with%20spaces`, found nothing, and returned `Ok(false)` — no navigation, no error bar, no feedback at all. `file://` destinations were joined onto the document directory as `<dir>/file:/...`.

`navigate_to_link` now uses the same resolver. Nothing else changes: the anchor-only early return stays, `resolve_local_link_path` performs the same `#` split, and absolute paths resolve as before.

## On the tests

**The regression test was written while it still asserted the divergence, and passed in that form**, before being flipped to assert agreement. So it is known to see the bug, rather than merely being green after the fix — a test that was never red proves nothing.

A second test covers the cases where sharing a resolver could have broken something quietly, since the plain-click path now decodes where it previously compared raw bytes:

- absolute paths still resolve;
- a file whose name contains a literal `%` that is not a valid escape (`100%done.md`) is still found;
- an anchor-only destination is still not treated as a path.

## Scope

Found while gathering the current-behaviour baseline for #141, but this is not one of that issue's open questions — no one would argue a modifier key should change path resolution. The deeper semantics #141 raises (fragments navigating to headings, non-UTF-8 paths, canonicalization without requiring existence, the scheme boundary) are untouched here.

62 tests pass, `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.