### PR TITLE
Let visual-regression.sh pick its display too

### DIFF
--- a/scripts/visual-regression.sh
+++ b/scripts/visual-regression.sh
@@ -28,7 +28,9 @@ set -uo pipefail
 BIN="${1:-target/debug/md-viewer}"
 DOC="${2:-}"
 TAG="visreg"
-DISPLAY_NUM=99
+# Override when :99 is occupied or wedged: MDV_DISPLAY=98 scripts/visual-regression.sh
+# (scroll-regression.sh honours the same variable.)
+DISPLAY_NUM="${MDV_DISPLAY:-99}"
 
 if [ ! -x "$BIN" ]; then
     echo "error: $BIN is not an executable — build it first (cargo build)" >&2


### PR DESCRIPTION
`scroll-regression.sh` has honoured `MDV_DISPLAY` since #126. `visual-regression.sh` had `DISPLAY_NUM=99` hardcoded.

That matters when `:99` is occupied or wedged — which happened twice today — because one guard can be moved aside and the other cannot, and the two cannot be pointed at separate displays to keep their windows from overlapping. `docs/LESSONS.md` already warns that screenshots of an obscured X11 window return the *other* window's pixels, so sharing a display between two guards is a way to get quietly wrong evidence.

## Verification

Ran the script for real on `:97`, a display not used before in this session:

```
== starting Xvfb on :97 ==
PASS: no blank frames, no horizontal drift across scroll positions
```

A dry run of the variable assignment would not have shown that: the value has to reach the Xvfb start, xdotool's window search **and** the screenshot capture. Both of today's display problems lived in that chain rather than in the assignment — once when `MDV_DISPLAY=:98` with a leading colon produced `::98`, and once when burst captures returned six identical frames.

One line plus a comment matching the other script's.