### PR TITLE
Check test targets in the cross-platform job

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -24,4 +24,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --locked
+      # --all-targets so test code compiles here too. Without it, a test
+      # behind `#[cfg(target_os = "windows")]` is not merely unexecuted on
+      # Windows — it is never compiled anywhere, which is how
+      # `windows_drive_prefixes_are_not_treated_as_uri_schemes` (#154) ended up
+      # guarding the one branch Linux cannot exercise while itself being
+      # unchecked. Still `check`, not `test`: this job is a portability guard,
+      # and running the suite on three platforms is a separate decision.
+      - run: cargo check --locked --all-targets


### PR DESCRIPTION
`cargo check --locked` builds only the default targets, so **test code is never compiled**. A test behind `#[cfg(target_os = "windows")]` is therefore not merely unexecuted on Windows — it is not built anywhere at all.

#154 has exactly that shape. `windows_drive_prefixes_are_not_treated_as_uri_schemes` is the only assertion covering the drive-letter branch, which is the one piece of that PR Linux cannot exercise:

```rust
#[cfg(target_os = "windows")]
if scheme.len() == 1 {
    return None;   // C:\docs\guide.md is a path, not scheme "C"
}
```

`--all-targets` at least compiles it on the platform it describes.

**Deliberately still `check`, not `test`.** This job is a portability guard; running the whole suite on three platforms is a separate decision with its own wall-clock cost, and it should be made on purpose rather than smuggled in here.

The gap is mine: I added this workflow in #138, and then reviewed #154 against a safety net thinner than it looked. Verified locally that `cargo check --locked --all-targets` is clean on this tree.