### PR TITLE
Stop the guards killing every Xvfb on the machine

### DIFF
--- a/scripts/scroll-regression.sh
+++ b/scripts/scroll-regression.sh
@@ -125,7 +125,9 @@ export XDG_DATA_HOME="/tmp/mdv-$TAG-data" XDG_CONFIG_HOME="/tmp/mdv-$TAG-config"
 FRAMES="/tmp/frames-$TAG"
 
 APP_PID=""
-cleanup() {
+XVFB_PID=""
+# Safe to call mid-run: touches only the application.
+kill_app() {
     # Kill by recorded PID. Matching by name does not work reliably: Linux
     # truncates a process's comm to 15 characters, so `pkill -x` misses any
     # binary with a longer name (a copy called `mdv-main-7a6346c` shows up as
@@ -134,21 +136,41 @@ cleanup() {
     [ -n "$APP_PID" ] && kill -9 "$APP_PID" 2>/dev/null
     true
 }
+
+# EXIT trap only — never call this while the run still needs the display.
+cleanup() {
+    kill_app
+    # Kill the Xvfb this run started, by PID. Leaving it behind means the
+    # next run's blunt `pkill -9 Xvfb` has to clean up after us — which
+    # also kills any unrelated Xvfb on the machine, and races with a
+    # concurrent guard run.
+    [ -n "$XVFB_PID" ] && kill -9 "$XVFB_PID" 2>/dev/null
+    true
+}
 trap cleanup EXIT
 
 echo "== starting Xvfb on :$DISPLAY_NUM =="
-pkill -9 Xvfb 2>/dev/null
+# Kill only an Xvfb on *our* display, never every Xvfb on the machine:
+# this box runs a systemd user unit `xvfb99.service` (Restart=always),
+# and a blanket `pkill -9 Xvfb` takes it down on every guard run — which
+# is both rude and a source of races when two runs overlap. `pgrep -f`
+# is safe here because this pattern cannot match the script's own
+# command line.
+for pid in $(pgrep -f "Xvfb :$DISPLAY_NUM " 2>/dev/null); do
+    kill -9 "$pid" 2>/dev/null
+done
 rm -f "/tmp/.X${DISPLAY_NUM}-lock" "/tmp/.X11-unix/X${DISPLAY_NUM}"
 # Redirect: a backgrounded process that inherits stdout holds the pipe open,
 # so `scripts/scroll-regression.sh | tail` would hang forever waiting for EOF.
 Xvfb ":$DISPLAY_NUM" -screen 0 1920x1080x24 >/dev/null 2>&1 &
+XVFB_PID=$!
 sleep 2
 if ! xdpyinfo >/dev/null 2>&1; then
     echo "error: Xvfb is not responding on :$DISPLAY_NUM" >&2
     exit 2
 fi
 
-cleanup
+kill_app
 rm -rf "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$FRAMES"
 mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$FRAMES"
 

--- a/scripts/visual-regression.sh
+++ b/scripts/visual-regression.sh
@@ -73,27 +73,51 @@ export DISPLAY=":$DISPLAY_NUM" WINIT_UNIX_BACKEND=x11 WAYLAND_DISPLAY=
 # at the top of the document.
 export XDG_DATA_HOME="/tmp/mdv-$TAG-data" XDG_CONFIG_HOME="/tmp/mdv-$TAG-config"
 
+APP_PID=""
+XVFB_PID=""
+# Safe to call mid-run: touches only the application.
+kill_app() {
+    # Kill by recorded PID, matching scroll-regression.sh. Name matching is not
+    # reliable: Linux truncates a process's comm to 15 characters, so a binary
+    # copied to a longer name is missed, and `pkill -f` would match this
+    # script's own command line and kill the run itself.
+    [ -n "$APP_PID" ] && kill -9 "$APP_PID" 2>/dev/null
+    true
+}
+
+# EXIT trap only — never call this while the run still needs the display.
 cleanup() {
-    # Match process NAMES, not the full command line — a `pkill -f` pattern
-    # would also match this script and kill the run itself.
-    pkill -9 '^md-viewer$' 2>/dev/null
+    kill_app
+    # Kill the Xvfb this run started. Leaving it behind means the next run's
+    # blunt `pkill -9 Xvfb` has to clean up after us — which also kills any
+    # unrelated Xvfb on the machine, and races with a concurrent guard run.
+    [ -n "$XVFB_PID" ] && kill -9 "$XVFB_PID" 2>/dev/null
     true
 }
 trap cleanup EXIT
 
 echo "== starting Xvfb on :$DISPLAY_NUM =="
-pkill -9 Xvfb 2>/dev/null
+# Kill only an Xvfb on *our* display, never every Xvfb on the machine:
+# this box runs a systemd user unit `xvfb99.service` (Restart=always),
+# and a blanket `pkill -9 Xvfb` takes it down on every guard run — which
+# is both rude and a source of races when two runs overlap. `pgrep -f`
+# is safe here because this pattern cannot match the script's own
+# command line.
+for pid in $(pgrep -f "Xvfb :$DISPLAY_NUM " 2>/dev/null); do
+    kill -9 "$pid" 2>/dev/null
+done
 rm -f "/tmp/.X${DISPLAY_NUM}-lock" "/tmp/.X11-unix/X${DISPLAY_NUM}"
 # Redirect: a backgrounded process that inherits stdout holds the pipe open,
 # so `scripts/visual-regression.sh | tail` would hang forever waiting for EOF.
 Xvfb ":$DISPLAY_NUM" -screen 0 1920x1080x24 >/dev/null 2>&1 &
+XVFB_PID=$!
 sleep 2
 if ! xdpyinfo >/dev/null 2>&1; then
     echo "error: Xvfb is not responding on :$DISPLAY_NUM" >&2
     exit 2
 fi
 
-cleanup
+kill_app
 rm -rf "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "/tmp/shot-$TAG-"*.png
 mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME"
 
@@ -108,6 +132,7 @@ fi
 
 echo "== launching $BIN =="
 setsid "$BIN" --foreground "$DOC" </dev/null >"/tmp/mdv-$TAG.log" 2>&1 &
+APP_PID=$!
 sleep 5
 
 WINDOWS=$(xdotool search --name "Markdown Viewer" 2>/dev/null)


### PR DESCRIPTION
Both guards began with `pkill -9 Xvfb`. This box runs a systemd user unit:

```
xvfb99.service — Xvfb virtual display :99
ExecStart=/usr/bin/Xvfb :99 -screen 0 1920x1080x24
Restart=always
```

So **every guard run killed the user's managed display.** `NRestarts` was the receipt, and its `ActiveEnterTimestamp` matched the last run to the second. It comes back, but the restart races with a guard that is starting its own display — and that is what broke two runs today, including a `main` verification that reported `expected exactly 1 window, found 0`.

## Three changes

- Kill only an Xvfb on **our own** display, via a `pgrep -f` pattern that cannot match the script's own command line.
- Each guard tracks the Xvfb it started and kills it by PID on exit, instead of relying on the next run's blanket kill to clean up after it.
- `visual-regression.sh` gains the PID-based app kill that `scroll-regression.sh` already documents. `pkill -9 '^md-viewer$'` misses a binary whose name exceeds the 15 characters Linux keeps in `comm` — the same trap #126 recorded.

## The mistake worth recording

`cleanup` is now split in two, because it is **also called mid-run** to clear stale instances before launching. My first attempt folded the Xvfb kill into it, so both guards destroyed their own display seconds after starting it and reported `expected exactly 1 window, found 0` — the very symptom I was fixing. `kill_app` is the mid-run half; `cleanup` is the EXIT trap and nothing else, with a comment saying so.

## Verification

Measured `NRestarts` either side of each run:

| guard | verdict | NRestarts | Xvfb left | service |
|---|---|---|---|---|
| `scroll-regression.sh` | **PASS** | 1 → 1 | only systemd's `:99` | active |
| `visual-regression.sh` | **PASS** | 1 → 1 | only systemd's `:99` | active |

Before this change the counter rose on every run.