### PR TITLE
Take the release body from CHANGELOG.md, not git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,16 @@ jobs:
 
       - name: Generate changelog
         if: runner.os == 'Linux'
-        run: git-cliff --latest --strip header > RELEASE_NOTES.md
+        # From CHANGELOG.md, not `git-cliff --latest`. git-cliff parses
+        # conventional commits and this history does not conform: v0.1.17's
+        # release page carried eleven lines while its CHANGELOG entry was a page
+        # of prose. The Release page is the only changelog most users ever see —
+        # snap and AUR users never open the repository. Falls back to git-cliff
+        # when the tagged version has no section.
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          bash scripts/release-notes.sh "$VERSION" > RELEASE_NOTES.md
+          echo "release notes: $(wc -l < RELEASE_NOTES.md) lines"
 
       - name: Build release
         run: cargo build --release --target ${{ matrix.target }}

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Extract one version's section from CHANGELOG.md for the GitHub Release body.
+#
+# The release body used to come from `git-cliff --latest`, which parses
+# conventional commits. This history does not conform, so v0.1.17's release page
+# carried eleven lines — two bullets — while its CHANGELOG entry was a page of
+# prose. The Release page is the only changelog most users ever see: snap and
+# AUR users never open the repository.
+#
+# Falls back to git-cliff when the version has no section, so a tag that skips
+# the changelog still produces something rather than an empty release.
+set -euo pipefail
+VERSION="${1:?usage: release-notes.sh <version-without-v>}"
+CHANGELOG="${2:-CHANGELOG.md}"
+
+if [ -f "$CHANGELOG" ] && grep -q "^## \[${VERSION}\]" "$CHANGELOG"; then
+    awk -v v="^## \\\\[${VERSION}\\\\]" '
+        $0 ~ v      { inside = 1; next }
+        inside && /^## \[/ { exit }
+        inside      { print }
+    ' "$CHANGELOG" | sed -e '/./,$!d' | awk 'BEGIN{RS="";ORS="\n\n"}1'
+else
+    echo "::warning::no CHANGELOG section for ${VERSION}; falling back to git-cliff" >&2
+    git-cliff --latest --strip header
+fi


### PR DESCRIPTION
The GitHub Release body came from `git-cliff --latest`, which parses conventional commits. **This history does not conform.** Here is the entire release page for v0.1.17:

```
### Bug Fixes
- **#62:** Set Wayland app_id so GNOME matches the dock icon

### Features
- **#60:** Render LaTeX \(...\) and \[...\] math delimiters
```

Eleven lines, while its CHANGELOG entry was a page of prose. For 0.2.0, with 63 merged PRs, the entry written for it would not have reached the release page at all.

**That page is the only changelog most users ever see.** Snap and AUR users never open the repository.

## Change

`scripts/release-notes.sh <version>` extracts that version's section from `CHANGELOG.md`, and falls back to `git-cliff --latest` when there is no section — so a tag that skips the changelog still produces something rather than an empty release.

| | lines |
|---|---|
| `git-cliff --latest` at v0.1.17 | 11 |
| this, for 0.2.0 | **63** |

Both branches were exercised: the extraction against the real `CHANGELOG.md`, and the fallback via an unknown version (which correctly emits `::warning::` and calls git-cliff).

## Not the forbidden command

`CHANGELOG.md` was never at risk here — git-cliff wrote to `RELEASE_NOTES.md` all along. The `-o CHANGELOG.md` form that `docs/LESSONS.md` forbids is a different invocation and appears nowhere in CI. I checked before assuming.