### PR TITLE
Keep visible spacing between Markdown table cells

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -2224,36 +2224,49 @@ impl CommonMarkViewerInternal {
                                                     row_ui.col(|ui| {
                                                         ui.style_mut().wrap_mode =
                                                             Some(egui::TextWrapMode::Wrap);
-                                                        let col_w = ui.max_rect().width();
-                                                        ui.set_width(col_w);
-                                                        // Isolate the wrapping cursor from the
-                                                        // preallocated TableBuilder row height.
-                                                        // Otherwise egui uses that entire height as
-                                                        // the first text line's minimum height and
-                                                        // later inline widgets overflow the row.
-                                                        ui.horizontal_wrapped(|ui| {
-                                                            for (e, src_span) in col {
-                                                                let tmp_start = std::mem::replace(
-                                                                    &mut self.line.should_start_newline,
-                                                                    false,
-                                                                );
-                                                                let tmp_end = std::mem::replace(
-                                                                    &mut self.line.should_end_newline,
-                                                                    false,
-                                                                );
-                                                                self.event(
-                                                                    ui,
-                                                                    e.clone(),
-                                                                    src_span.clone(),
-                                                                    cache,
-                                                                    options,
-                                                                    col_w,
-                                                                );
-                                                                self.line.should_start_newline =
-                                                                    tmp_start;
-                                                                self.line.should_end_newline = tmp_end;
-                                                            }
-                                                        });
+                                                        ui.set_width(ui.max_rect().width());
+                                                        egui::Frame::NONE
+                                                            .inner_margin(egui::Margin::symmetric(4, 0))
+                                                            .show(ui, |ui| {
+                                                                let col_w = ui.available_width();
+                                                                ui.set_width(col_w);
+                                                                // Isolate the wrapping cursor from the
+                                                                // preallocated TableBuilder row height.
+                                                                // Otherwise egui uses that entire height as
+                                                                // the first text line's minimum height and
+                                                                // later inline widgets overflow the row.
+                                                                ui.horizontal_wrapped(|ui| {
+                                                                    for (e, src_span) in col {
+                                                                        let tmp_start =
+                                                                            std::mem::replace(
+                                                                                &mut self
+                                                                                    .line
+                                                                                    .should_start_newline,
+                                                                                false,
+                                                                            );
+                                                                        let tmp_end =
+                                                                            std::mem::replace(
+                                                                                &mut self
+                                                                                    .line
+                                                                                    .should_end_newline,
+                                                                                false,
+                                                                            );
+                                                                        self.event(
+                                                                            ui,
+                                                                            e.clone(),
+                                                                            src_span.clone(),
+                                                                            cache,
+                                                                            options,
+                                                                            col_w,
+                                                                        );
+                                                                        self.line
+                                                                            .should_start_newline =
+                                                                            tmp_start;
+                                                                        self.line.should_end_newline =
+                                                                            tmp_end;
+                                                                    }
+                                                                });
+                                                            });
                                                     });
                                                 }
                                         });

--- a/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
+++ b/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
@@ -116,6 +116,27 @@ fn fitted_columns_do_not_split_short_header_words() {
 }
 
 #[test]
+fn fitted_markdown_cells_keep_visible_horizontal_padding() {
+    let markdown = concat!(
+        "| Owner | Mitigation |\n",
+        "|---|---|\n",
+        "| preserve the final visual rendering | clamp the bias during processing |\n",
+    );
+    let (_, _, painted) = render_geometry(markdown, 308.0);
+    let left = painted
+        .iter()
+        .find(|entry| entry.text == "preserve the final visual rendering")
+        .unwrap();
+    let right = painted
+        .iter()
+        .find(|entry| entry.text == "clamp the bias during processing")
+        .unwrap();
+    let gap = right.rect.left() - left.rect.right();
+
+    assert!(gap >= 8.0, "adjacent cell text gap was only {gap}: {painted:#?}");
+}
+
+#[test]
 fn markdown_table_uses_height_aware_column_widths() {
     let markdown = "| Key | Description |\n|---|---|\n| A | ALPHA long prose that wraps over several lines and benefits from extra width in this column |\n| LongerKey | BETA another differently sized explanation that should determine the actual row maximum |";
     let (body, _, painted) = render_geometry(markdown, 360.0);


### PR DESCRIPTION
Closes #163.

## Summary

- give Markdown table cells 4 px of horizontal inset on each side
- render cell contents against the resulting inner width, matching the existing height estimators’ 8 px allowance
- keep vertical inset at zero so fitted row heights and clipping behavior do not change

This does not change the table width allocator, column bounds, divider positions, manual resize state, or the existing HTML-table path.

On current `main`, the production geometry fixture left only about 0.94 px between adjacent cells at a 308 px document width (1.34 px at 412 px). The change preserves an 8 px visible gap.

## Testing

- root test suite: 64 passed, 1 ignored
- renderer library with features: 90 passed
- wrapping tests: 26 passed
- slice performance test passed
- macros and trybuild tests passed
- documentation tests: 16 passed, 1 ignored
- `git diff --check`

The exact commit was reviewed at high reasoning depth after the full test run; no blocking issues were found.