### PR TITLE
fix(frontmatter): wrap long values instead of clipping them

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -282,7 +282,14 @@ fn render_frontmatter_table(
                         ui.label(egui::RichText::new(key).strong());
                         ui.add_space(12.0);
                     });
-                    ui.label(value);
+                    // Wrap rather than clip. `ui.label` inside a Grid does
+                    // not wrap on its own — the column simply grows and the
+                    // frame's `set_max_width` clips whatever runs past it, so
+                    // a long value was cut mid-word with no scrollbar and no
+                    // way to read the rest. `Label::wrap` inside the grid
+                    // cell is enough — the frame's max width already bounds
+                    // the column, it just was not being wrapped against.
+                    ui.add(egui::Label::new(value).wrap());
                     ui.end_row();
                 }
             });

--- a/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
+++ b/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
@@ -48,7 +48,14 @@ fn render_geometry_with_hooks(
     width: f32,
     hooks: &[&str],
 ) -> (Rect, f32, Vec<PaintedText>) {
-    render_geometry_with_body_size(markdown, width, hooks, None)
+    render_geometry_with_body_size(markdown, width, hooks, None, false)
+}
+
+/// `render_frontmatter` gates both parsing and rendering of a `---` block, so
+/// a frontmatter test that leaves it off silently measures an ordinary
+/// paragraph instead of the key/value table.
+fn render_geometry_frontmatter(markdown: &str, width: f32) -> (Rect, f32, Vec<PaintedText>) {
+    render_geometry_with_body_size(markdown, width, &[], None, true)
 }
 
 fn render_geometry_with_body_size(
@@ -56,6 +63,7 @@ fn render_geometry_with_body_size(
     width: f32,
     hooks: &[&str],
     body_size: Option<f32>,
+    frontmatter: bool,
 ) -> (Rect, f32, Vec<PaintedText>) {
     let ctx = Context::default();
     if let Some(size) = body_size {
@@ -81,6 +89,7 @@ fn render_geometry_with_body_size(
                 .default_width(Some(width as usize))
                 .table_max_width(Some(width as usize))
                 .line_height(1.5)
+                .render_frontmatter(frontmatter)
                 .show(ui, &mut cache, markdown);
             body_rect = response.response.rect;
         });
@@ -106,7 +115,7 @@ fn fitted_columns_do_not_split_short_header_words() {
         "|---|---|---|---|---|\n",
         "| core | For a mission instance with a deliberately long description | Instances | No | DL |",
     );
-    let (_, _, painted) = render_geometry_with_body_size(markdown, 400.0, &[], Some(16.0));
+    let (_, _, painted) = render_geometry_with_body_size(markdown, 400.0, &[], Some(16.0), false);
     let required = painted
         .iter()
         .find(|entry| entry.text == "Required")
@@ -342,6 +351,61 @@ fn html_table_reflows_after_panel_width_changes() {
 
     assert!(heights[1] < heights[0], "table did not widen: {heights:?}");
     assert!(heights[2] > heights[1], "table did not narrow: {heights:?}");
+}
+
+#[test]
+fn frontmatter_wraps_a_long_value_instead_of_clipping_it() {
+    // A frontmatter value longer than its column used to be clipped mid-word:
+    // `ui.label` inside a Grid does not wrap, so the frame's max width simply
+    // cut it off, with no scrollbar and no way to read the rest.
+    let markdown = "\
+---
+title: Short
+abstract: A deliberately long single value that has to go somewhere when the column is narrower than the text
+---
+
+AFTER_FRONTMATTER";
+    let width = 320.0;
+    let (_, _, painted) = render_geometry_frontmatter(markdown, width);
+
+    // Guard the guard: without the frontmatter option this markdown renders as
+    // an ordinary paragraph that wraps anyway, and the assertions below pass on
+    // a clipping build. The key column only exists on the table path.
+    assert!(
+        painted.iter().any(|t| t.text.contains("abstract")),
+        "frontmatter table was not rendered; the test would prove nothing: {painted:#?}"
+    );
+
+    let value_rows: Vec<_> = painted
+        .iter()
+        .filter(|t| t.text.contains("deliberately") || t.text.contains("narrower"))
+        .collect();
+    assert!(
+        !value_rows.is_empty(),
+        "the long value was not painted at all: {painted:#?}"
+    );
+
+    // Clipping shows up as text that is painted but cut by its clip rect.
+    for t in &value_rows {
+        assert!(
+            t.rect.right() <= t.clip_rect.right() + 0.5,
+            "value is clipped rather than wrapped: {t:#?}"
+        );
+    }
+
+    // Wrapping shows up as the value occupying more than one row.
+    let rows: usize = value_rows.iter().map(|t| t.rows).max().unwrap_or(1);
+    assert!(
+        rows > 1,
+        "value should wrap across rows, got {rows}: {value_rows:#?}"
+    );
+
+    // And the whole value must survive, not just its first line.
+    let joined: String = value_rows.iter().map(|t| t.text.as_str()).collect();
+    assert!(
+        joined.contains("narrower than the text"),
+        "value was truncated: {joined:?}"
+    );
 }
 
 #[test]

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1213,6 +1213,26 @@ Do not change renderer soft-break behavior to satisfy a fixture whose syntax exp
 
 **Files:** `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`, `crates/egui_commonmark/egui_commonmark_backend/src/pulldown.rs` (`ContentGeometry`), `crates/egui_commonmark/egui_commonmark/tests/wrapping.rs`, `crates/egui_commonmark/egui_commonmark/tests/slice_perf.rs`, `scripts/visual-regression.sh`, `docs/devlog/055-viewport-slice-layout.md`
 
+### An option-gated render path makes a test measure something else entirely
+**Context:** Regression test for frontmatter values being clipped instead of wrapped (defect in #128, found while taking 0.2.0 README screenshots).
+**Problem:** The test passed identically before and after the fix — worthless as a guard. `CommonMarkOptions::render_frontmatter` defaults to `false` and gates **both** parsing and rendering: `latex_delimiters::parse_events` only enables pulldown-cmark's metadata-block option when it is set. The shared `render_geometry` test helper never enabled it, so a `---` block parsed as an ordinary paragraph. Ordinary paragraphs wrap on their own, so the assertions were satisfied by content that never touched `render_frontmatter_table`.
+**Fix:** a `render_geometry_frontmatter` helper that turns the option on, plus an assertion *inside* the test that the table was actually rendered:
+```rust
+assert!(
+    painted.iter().any(|t| t.text.contains("abstract")),
+    "frontmatter table was not rendered; the test would prove nothing: {painted:#?}"
+);
+```
+**Control matrix** (the step that caught it — the test had to be observed red):
+
+| build | result |
+|---|---|
+| `ui.label(value)` (clipping) | FAIL — `value should wrap across rows, got 1` |
+| `Label::new(value).wrap()` | PASS |
+
+**General lesson:** when a feature sits behind a default-off option, a test that does not enable it does not fail — it silently exercises the fallback path and reports success. Shared render helpers are where this hides, because the option is set by the *application*, not the helper. Two defenses: assert a marker that only the intended path can produce, and never trust a test that has not been observed red. Same family as the `#157` fixtures that all landed in the excluded dense regime, and the `#115` control run against a stale `main`: in each case the setup sat outside the region it was meant to probe, and the result still looked like an answer.
+**Files:** `crates/egui_commonmark/egui_commonmark/tests/wrapping.rs`, `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`, `docs/devlog/063-frontmatter-wrap.md`
+
 ### A scroll-regression fixture only proves anything if the sampling is fine enough to land in the failure window
 **Context:** Issue #121 — scrolling the wrench `asset_reference.md` intermittently painted an empty document pane. Writing `scripts/scroll-regression.sh` to guard the fix.
 **What the guard has to catch:** a viewport slice that anchors outside the viewport and paints nothing, so scrolling appears to skip whole sections. `scripts/visual-regression.sh` does not catch it — on the broken build (main @ 7b8f53b) it reports PASS while four of sixty-one captured frames are blank.

--- a/docs/devlog/063-frontmatter-wrap.md
+++ b/docs/devlog/063-frontmatter-wrap.md
@@ -1,0 +1,69 @@
+# 063 — Frontmatter values wrap instead of clipping
+
+**Branch:** `fix/frontmatter-wrap`
+**Date:** 2026-09-05
+**Status:** complete
+
+## Problem
+
+A frontmatter value longer than its column was cut off mid-word, with no
+scrollbar and no way to read the rest. Found while taking README screenshots
+for 0.2.0, at a 900 px window: `abstract:` ended at "…has to go some".
+
+This is a defect in #128 (the frontmatter table itself), not an inherited one.
+
+## Cause
+
+`render_frontmatter_table` painted the value with `ui.label(value)` inside an
+`egui::Grid`. Three things combine:
+
+- a plain `Label` does not wrap,
+- a Grid column grows to its content,
+- the surrounding frame's `set_max_width` then clips whatever ran past it.
+
+So the column grew past the frame and the frame cut it.
+
+## Fix
+
+`ui.add(egui::Label::new(value).wrap())`. One line. The frame's max width
+already bounds the column — the label just was not being wrapped against it.
+
+An earlier attempt also computed a value-column width from the widest key.
+That turned out to be unnecessary once the label wrapped, and was removed
+rather than left in as dead scaffolding.
+
+## Key discovery: the first version of the test was blind
+
+The regression test passed **before and after** the fix. It proved nothing.
+
+`CommonMarkOptions::render_frontmatter` defaults to `false`, and it gates both
+*parsing* and *rendering* — `latex_delimiters::parse_events` only enables
+pulldown-cmark's metadata-block option when it is set. The test helper
+(`render_geometry`) never enabled it, so the `---` block was parsed as an
+ordinary paragraph. Ordinary paragraphs wrap on their own, hence green on a
+clipping build.
+
+Two things came out of this:
+
+1. `render_geometry_frontmatter` — a helper variant that turns the option on.
+2. An assertion *inside* the test that the frontmatter table was actually
+   rendered (`painted` contains the key), so a future change that drops the
+   option fails loudly instead of passing meaninglessly.
+
+The only reason this was caught is that the fix was temporarily reverted and
+the test re-run. A test that has never been observed red is not evidence.
+
+**Control matrix:**
+
+| build | result |
+|---|---|
+| without fix (`ui.label`) | FAIL — `value should wrap across rows, got 1` |
+| with fix (`Label::wrap`) | PASS |
+
+Note the clip-rect assertion is not the one that discriminates; the row-count
+assertion is. Kept anyway, it costs nothing.
+
+## Files
+
+- `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`
+- `crates/egui_commonmark/egui_commonmark/tests/wrapping.rs`


### PR DESCRIPTION
## Problem

A frontmatter value longer than its column was cut off mid-word, with no scrollbar and no way to read the rest. Found at a 900px window while taking README screenshots for 0.2.0.

This is a defect in #128 — the frontmatter table itself — not something inherited.

## Cause

`render_frontmatter_table` painted the value with `ui.label(value)` inside an `egui::Grid`. Three things combine:

- a plain `Label` does not wrap,
- a Grid column grows to its content,
- the surrounding frame's `set_max_width` then clips whatever ran past it.

So the column grew past the frame and the frame cut it.

## Fix

```rust
ui.add(egui::Label::new(value).wrap())
```

One line. The frame's max width already bounds the column — the label just was not being wrapped against it. An earlier attempt also computed a value-column width from the widest key; that turned out to be unnecessary once the label wrapped, and was removed rather than left in as dead scaffolding.

## The first test was blind — worth reading before reviewing the second

The regression test passed **identically before and after** the fix. It proved nothing.

`CommonMarkOptions::render_frontmatter` defaults to `false` and gates *both* parsing and rendering — `latex_delimiters::parse_events` only enables pulldown-cmark's metadata-block option when it is set. The shared `render_geometry` helper never enabled it, so the `---` block parsed as an ordinary paragraph. Ordinary paragraphs wrap on their own, hence green on a clipping build.

Two things came out of that:

1. `render_geometry_frontmatter`, a helper variant that turns the option on.
2. An assertion *inside* the test that the table was actually rendered, so a future change that drops the option fails loudly instead of passing meaninglessly.

## Verification

Control run — the fix was reverted and the same test re-run:

| build | result |
|---|---|
| `ui.label(value)` (clipping) | **FAIL** — `value should wrap across rows, got 1` |
| `Label::new(value).wrap()` | **PASS** |

- Renderer suite: 90 / 1 / 27 / 16 pass, 1 ignored. `wrapping` went 26 → 27, exactly the new test.
- Root suite: 64 pass, 1 ignored.
- Clippy unchanged against main: 20 findings on both, and the two "only here" lists are the same warnings shifted by the 7 lines the comment adds. Root workspace: 0.

Docs: `docs/devlog/063-frontmatter-wrap.md`, plus a `LESSONS.md` entry on option-gated render paths making a test measure something else.