### PR TITLE
fix(frontmatter): bound the value column instead of clipping or wrapping freely

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -267,11 +267,46 @@ fn render_frontmatter_table(
     }
 
     let _ = options;
+
+    // Both the key gap and the value column are derived from `max_width`, never
+    // from `ui.available_width()`. That is deliberate: `max_width` comes from
+    // `ContentGeometry` (#96) and is identical in the bootstrap pass that
+    // records `split_points` and in the slice pass that paints. Deriving either
+    // one from the ambient width makes this block's *height* differ between the
+    // two passes, which collapses slice selection and blanks the rest of the
+    // document — that was #167, and it is why #166's bare `Label::wrap()` had
+    // to be reverted.
+    const KEY_GAP: f32 = 12.0;
+    // Frame::group's two inner margins plus its stroke. Deliberately generous:
+    // over-reserving narrows the value column slightly, while under-reserving
+    // lets it overflow the frame and clip.
+    const FRAME_CHROME: f32 = 24.0;
+    const MIN_VALUE_WIDTH: f32 = 80.0;
+
+    let key_width = pairs
+        .iter()
+        .map(|(key, _)| {
+            egui::WidgetText::from(egui::RichText::new(key).strong())
+                .into_galley(
+                    ui,
+                    Some(egui::TextWrapMode::Extend),
+                    f32::INFINITY,
+                    egui::TextStyle::Body,
+                )
+                .size()
+                .x
+        })
+        .fold(0.0f32, f32::max);
+
+    let item_spacing = ui.spacing().item_spacing.x;
+    let value_width =
+        (max_width - key_width - KEY_GAP - item_spacing - FRAME_CHROME).max(MIN_VALUE_WIDTH);
+
     egui::Frame::group(ui.style()).show(ui, |ui| {
         ui.set_max_width(max_width);
         egui::Grid::new(ui.next_auto_id())
             .num_columns(2)
-            .spacing(egui::vec2(ui.spacing().item_spacing.x, 4.0))
+            .spacing(egui::vec2(item_spacing, 4.0))
             .striped(true)
             .show(ui, |ui| {
                 for (key, value) in pairs {
@@ -280,9 +315,17 @@ fn render_frontmatter_table(
                     // otherwise ends flush against its value ("authorJane Doe").
                     ui.horizontal(|ui| {
                         ui.label(egui::RichText::new(key).strong());
-                        ui.add_space(12.0);
+                        ui.add_space(KEY_GAP);
                     });
-                    ui.label(value);
+                    // Wrap inside a scope bounded by the precomputed width. A
+                    // bare `ui.label` does not wrap, so a long value grew the
+                    // column past the frame, which then clipped both the value
+                    // and — because the oversized block widens the content
+                    // column — the prose of every block after it (#128).
+                    ui.scope(|ui| {
+                        ui.set_max_width(value_width);
+                        ui.add(egui::Label::new(value).wrap());
+                    });
                     ui.end_row();
                 }
             });

--- a/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
+++ b/crates/egui_commonmark/egui_commonmark/tests/wrapping.rs
@@ -51,11 +51,39 @@ fn render_geometry_with_hooks(
     render_geometry_with_body_size(markdown, width, hooks, None)
 }
 
+/// `render_frontmatter` gates both parsing and rendering of a `---` block, so a
+/// frontmatter test that leaves it off silently measures an ordinary paragraph
+/// instead of the key/value table.
+///
+/// `ui_width` and `content_width` are separate on purpose. The renderer's
+/// bootstrap pass and its slice pass do not have the same ambient width, and
+/// they must agree on block heights — so a frontmatter block's geometry has to
+/// be a function of `content_width` alone. Coupling the two, as the other
+/// helpers do, cannot express that and would have missed #167.
+fn render_geometry_frontmatter(
+    markdown: &str,
+    ui_width: f32,
+    content_width: f32,
+) -> (Rect, f32, Vec<PaintedText>) {
+    render_geometry_inner(markdown, ui_width, content_width, &[], None, true)
+}
+
 fn render_geometry_with_body_size(
     markdown: &str,
     width: f32,
     hooks: &[&str],
     body_size: Option<f32>,
+) -> (Rect, f32, Vec<PaintedText>) {
+    render_geometry_inner(markdown, width, width, hooks, body_size, false)
+}
+
+fn render_geometry_inner(
+    markdown: &str,
+    ui_width: f32,
+    content_width: f32,
+    hooks: &[&str],
+    body_size: Option<f32>,
+    frontmatter: bool,
 ) -> (Rect, f32, Vec<PaintedText>) {
     let ctx = Context::default();
     if let Some(size) = body_size {
@@ -76,11 +104,12 @@ fn render_geometry_with_body_size(
     for pass in 0..2 {
         ctx.begin_pass(Default::default());
         egui::CentralPanel::default().show(&ctx, |ui| {
-            ui.set_width(width);
+            ui.set_width(ui_width);
             let response = CommonMarkViewer::new()
-                .default_width(Some(width as usize))
-                .table_max_width(Some(width as usize))
+                .default_width(Some(content_width as usize))
+                .table_max_width(Some(content_width as usize))
                 .line_height(1.5)
+                .render_frontmatter(frontmatter)
                 .show(ui, &mut cache, markdown);
             body_rect = response.response.rect;
         });
@@ -342,6 +371,113 @@ fn html_table_reflows_after_panel_width_changes() {
 
     assert!(heights[1] < heights[0], "table did not widen: {heights:?}");
     assert!(heights[2] > heights[1], "table did not narrow: {heights:?}");
+}
+
+const FRONTMATTER_FIXTURE: &str = "\
+---
+title: Short
+abstract: A deliberately long single value that has to go somewhere when the column is narrower than the text
+---
+
+AFTER_FRONTMATTER";
+
+#[test]
+fn frontmatter_geometry_ignores_ambient_width() {
+    // The invariant #167 broke. The bootstrap pass that records `split_points`
+    // and the slice pass that paints do not share an ambient width, so a
+    // frontmatter block whose height depends on it is recorded at one height
+    // and painted at another — which collapses slice selection and blanks
+    // every block below. Holding `content_width` fixed while varying the
+    // ambient width must therefore produce identical geometry.
+    // 400 px of content column forces the value to wrap. At 700 it very nearly
+    // fits on one line, which would satisfy the height assertion trivially and
+    // test nothing — the `rows > 1` guard below exists to catch exactly that.
+    let wide = render_geometry_frontmatter(FRONTMATTER_FIXTURE, 1400.0, 400.0);
+    let narrow = render_geometry_frontmatter(FRONTMATTER_FIXTURE, 800.0, 400.0);
+
+    // Guard the guard twice over: the table must actually have been rendered,
+    // and the value must actually have been long enough to wrap. Without the
+    // first, a disabled option turns this into a test of ordinary paragraphs;
+    // without the second, a short value satisfies it trivially.
+    for (label, (_, _, painted)) in [("wide", &wide), ("narrow", &narrow)] {
+        assert!(
+            painted.iter().any(|t| t.text.contains("abstract")),
+            "{label}: frontmatter table was not rendered; the test would prove nothing"
+        );
+    }
+
+    let block_bottom = |painted: &[PaintedText]| -> f32 {
+        painted
+            .iter()
+            .filter(|t| t.text.contains("deliberately") || t.text.contains("narrower"))
+            .map(|t| t.rect.bottom())
+            .fold(f32::MIN, f32::max)
+    };
+    let wide_bottom = block_bottom(&wide.2);
+    let narrow_bottom = block_bottom(&narrow.2);
+    assert!(
+        wide_bottom > f32::MIN && narrow_bottom > f32::MIN,
+        "the long value was not painted in one of the two passes"
+    );
+    assert!(
+        (wide_bottom - narrow_bottom).abs() < 1.0,
+        "frontmatter block height depends on ambient width: \
+{wide_bottom} at ui=1400 vs {narrow_bottom} at ui=800 (content_width fixed at 400)"
+    );
+
+    // And the block must still be honest about its own content: wrapped across
+    // rows, inside its clip rect, and complete rather than truncated.
+    let value_rows: Vec<_> = narrow
+        .2
+        .iter()
+        .filter(|t| t.text.contains("deliberately") || t.text.contains("narrower"))
+        .collect();
+    let rows: usize = value_rows.iter().map(|t| t.rows).max().unwrap_or(1);
+    assert!(rows > 1, "value should wrap across rows, got {rows}");
+    for t in &value_rows {
+        assert!(
+            t.rect.right() <= t.clip_rect.right() + 0.5,
+            "value is clipped rather than wrapped: {t:#?}"
+        );
+    }
+    let joined: String = value_rows.iter().map(|t| t.text.as_str()).collect();
+    assert!(
+        joined.contains("narrower than the text"),
+        "value was truncated: {joined:?}"
+    );
+}
+
+#[test]
+fn frontmatter_block_stays_within_the_content_column() {
+    // The second half of #128, and the part the original report missed: an
+    // unbounded value grows the grid column past the frame, which widens the
+    // content column for the *whole document*, so the prose of every later
+    // block is clipped too. The block must not exceed `content_width`.
+    // 400, not 700: at 700 the value nearly fits on one line, so an unbounded
+    // column barely overshoots and the assertion passes on a broken build.
+    const CONTENT: f32 = 400.0;
+    let (_, _, painted) = render_geometry_frontmatter(FRONTMATTER_FIXTURE, 1400.0, CONTENT);
+
+    assert!(
+        painted.iter().any(|t| t.text.contains("abstract")),
+        "frontmatter table was not rendered; the test would prove nothing"
+    );
+    let after = painted
+        .iter()
+        .find(|t| t.text.contains("AFTER_FRONTMATTER"))
+        .expect("the block after the frontmatter was not painted");
+    assert!(
+        after.rect.right() <= CONTENT + 1.0,
+        "content after the frontmatter exceeds the content column: {} > {CONTENT}",
+        after.rect.right()
+    );
+    for t in painted.iter().filter(|t| t.text.contains("deliberately")) {
+        assert!(
+            t.rect.right() <= CONTENT + 1.0,
+            "frontmatter value exceeds the content column: {} > {CONTENT}",
+            t.rect.right()
+        );
+    }
 }
 
 #[test]

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1235,6 +1235,22 @@ Deterministic: at 1040 the last of 203 frames was byte-identical to the first, s
 **And the diagnostic that settled it in minutes:** `MDV_DIAG_SPLIT=1` dumping the split-point table plus both `partition_point` results. `MDV_DIAG_SLICE=1` reported *zero* off-screen placements in both the working and broken runs — a true negative that correctly excluded the placement hypothesis and pointed at range selection instead. Both probes report every frame, which is why their silence carried information.
 **Files:** `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs` (`render_frontmatter_table`), `docs/devlog/064-frontmatter-wrap-revert.md`, issues #166 / #167
 
+**Resolved** by bounding the value column against the measured key width and
+`max_width` (devlog 065). The bound also fixed a second symptom the original
+#128 report never mentioned: because the oversized block widens the *content
+column for the whole document*, the prose of every later block was clipped too
+— visible at 1200 px as "md-viewer rende…". A frontmatter document now lays out
+identically to the same document with the `---` block removed.
+
+**The test lesson from the fix is worth as much as the fix.** Two of the three
+assertions first landed in a regime where they could not fail: at a 700 px
+content column the fixture value *nearly* fits on one line, so `rows > 1` broke
+on the fixed build and the content-column assertion **passed on the broken
+one**. Narrowing to 400 made both detect the defect, the second one reporting
+`657.06 > 400`. That is #166's mistake committed a second time, three days
+later, by the same author — caught only because the control run is now
+mandatory rather than optional.
+
 ### An option-gated render path makes a test measure something else entirely
 **Context:** Regression test for the #166 frontmatter clipping fix (since reverted — see the entry above — but this lesson is independent of that outcome).
 **Problem:** The test passed identically before and after the fix, so it was worthless as a guard. `CommonMarkOptions::render_frontmatter` defaults to `false` and gates **both** parsing and rendering: `latex_delimiters::parse_events` only enables pulldown-cmark's metadata-block option when it is set. The shared `render_geometry` test helper never enabled it, so a `---` block parsed as an ordinary paragraph. Ordinary paragraphs wrap on their own, so the assertions were satisfied by content that never reached `render_frontmatter_table`.

--- a/docs/devlog/065-frontmatter-bounded-value.md
+++ b/docs/devlog/065-frontmatter-bounded-value.md
@@ -1,0 +1,108 @@
+# 065 — Bound the frontmatter value column (fixes #128 properly)
+
+**Branch:** `fix/128-frontmatter-bounded`
+**Date:** 2026-09-07
+**Status:** complete
+
+## History this closes
+
+- **#128** introduced the frontmatter key/value table. A value longer than its
+  column was clipped.
+- **#166** "fixed" that with a bare `Label::wrap()`. It caused **#167**: every
+  block below the table stopped painting at a 1040 px window.
+- **#170** reverted #166, restoring the clipping.
+- This change fixes the original defect without reintroducing #167.
+
+## The two symptoms, one cause
+
+An unbounded value grows its grid column past the frame. That produces two
+distinct failures, and the #128 report only described the first:
+
+1. the value itself is clipped mid-word;
+2. the oversized block **widens the content column for the whole document**,
+   so the prose of every later block is clipped at the pane edge too.
+
+Symptom 2 was measured on the reverted build at 1200 px: prose read
+"md-viewer rende…" and "verbatim, s…". The control that pins it to the
+frontmatter block is the same document with the `---` block removed — prose
+wraps correctly there at the identical window size.
+
+## Why the bound is on `max_width`, not `available_width`
+
+`max_width` comes from `ContentGeometry` (#96) and is identical in the
+bootstrap pass that records `split_points` and the slice pass that paints.
+`ui.available_width()` is not. Deriving the value column from the ambient
+width makes the block's *height* differ between the two passes, and slice
+selection then ends the event range early — that is #167 exactly.
+
+So the value column is `max_width - measured_key_width - KEY_GAP -
+item_spacing - FRAME_CHROME`, floored at 80 px, and the value wraps inside a
+scope set to it. `FRAME_CHROME` is deliberately generous: over-reserving
+narrows the column slightly, under-reserving lets it overflow and clip.
+
+Key width is measured with the real strong rendering:
+
+```rust
+egui::WidgetText::from(egui::RichText::new(key).strong())
+    .into_galley(ui, Some(egui::TextWrapMode::Extend), f32::INFINITY,
+                 egui::TextStyle::Body)
+    .size().x
+```
+
+`into_galley` lives on `WidgetText`, not `RichText` — the direct call is an
+`E0599`.
+
+## Verification
+
+**App, five widths** (Xvfb, isolated `XDG_*`, painted pixels below y=380):
+
+| window | painted px |
+|---|---|
+| 900 | 14752 |
+| 1040 | 13956 |
+| 1080 | 13956 |
+| 1200 | 13956 |
+| 1600 | 13956 |
+
+1040 is the width at which #166 collapsed to 2750. Nothing collapses now, and
+the constant value across widths is the intended `default_width` cap — a
+frontmatter document now lays out exactly like the no-frontmatter control,
+whereas the reverted build ran prose to x≈1198 at 1600 because of the
+inflation described above.
+
+**Control matrix** — both tests were observed red:
+
+| test | without fix | with fix |
+|---|---|---|
+| `frontmatter_geometry_ignores_ambient_width` | FAIL — `value should wrap across rows, got 1` | PASS |
+| `frontmatter_block_stays_within_the_content_column` | FAIL — `value exceeds the content column: 657.06 > 400` | PASS |
+
+## Two traps hit while writing the tests
+
+Both are the same trap in different clothes: **the fixture sitting outside the
+regime the test is meant to probe.**
+
+1. At `content_width = 700` the fixture value very nearly fits on one line, so
+   `rows > 1` failed on the *fixed* build and the height assertion would have
+   been satisfied trivially. Narrowed to 400.
+2. `frontmatter_block_stays_within_the_content_column` initially **passed on
+   the broken build** — also because of `CONTENT = 700`, where an unbounded
+   column barely overshoots. At 400 it detects the defect and reports the
+   overshoot as a number.
+
+The second one is exactly #166's mistake repeated, and it was caught only by
+running the control. Both constants now carry a comment saying why they are
+what they are.
+
+## Harness change
+
+`render_geometry_inner` takes `ui_width` and `content_width` separately;
+`render_geometry_frontmatter` exposes that plus `render_frontmatter(true)`.
+The older helpers pass the same value for both, preserving their behaviour.
+The coupling is what made #167 inexpressible as a test.
+
+## Files
+
+- `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`
+- `crates/egui_commonmark/egui_commonmark/tests/wrapping.rs`
+- `docs/LESSONS.md`


### PR DESCRIPTION
Fixes #128 without reintroducing #167. Third attempt at this one — the history is worth reading before the diff.

| PR | what it did |
|---|---|
| #128 | added the frontmatter key/value table; a long value was clipped |
| #166 | "fixed" it with a bare `Label::wrap()` — caused #167 |
| #170 | reverted #166, restoring the clipping |
| **this** | bounds the column, fixing the original defect and both its symptoms |

## Two symptoms, one cause — and #128 only described one

An unbounded value grows its grid column past the frame. That produces:

1. the value clipped mid-word — the reported defect;
2. **the oversized block widens the content column for the whole document**, so the prose of every later block is clipped at the pane edge too.

Symptom 2 was measured on the reverted build at 1200 px: the prose read `md-viewer rende…` and `verbatim, s…`. The control that pins it to the frontmatter block is the same document with the `---` block removed — prose wraps correctly there at the identical window size. I missed this when filing #128 and again when filing #167.

## Why `max_width` and not `available_width`

This is the whole design of the fix. `max_width` comes from `ContentGeometry` (#96) and is **identical in the bootstrap pass that records `split_points` and the slice pass that paints**. `ui.available_width()` is not. Deriving the value column from the ambient width makes the block's *height* differ between passes, and slice selection then ends the event range early — #167 exactly.

```rust
value_width = max_width - measured_key_width - KEY_GAP - item_spacing - FRAME_CHROME   // floor 80
```

Key width uses the real strong rendering via `WidgetText::into_galley` (it lives on `WidgetText`, not `RichText` — the direct call is an `E0599`). `FRAME_CHROME` is deliberately generous: over-reserving narrows the column slightly, under-reserving lets it overflow and clip.

## Verification in the app — five widths

Xvfb, isolated `XDG_*`, painted pixels in the document pane below y=380:

| window | painted px |
|---|---|
| 900 | 14752 |
| **1040** | **13956** |
| 1080 | 13956 |
| 1200 | 13956 |
| 1600 | 13956 |

1040 is the width at which #166 collapsed to **2750**. Nothing collapses now. The constant value across widths is the intended `default_width` cap: a frontmatter document now lays out exactly like the no-frontmatter control, whereas the reverted build ran prose to x≈1198 at 1600 because of the inflation above.

Testing a single width is what let #166 through, so this is five.

## Control matrix — both tests observed red

| test | without the fix | with it |
|---|---|---|
| `frontmatter_geometry_ignores_ambient_width` | **FAIL** — `value should wrap across rows, got 1` | PASS |
| `frontmatter_block_stays_within_the_content_column` | **FAIL** — `value exceeds the content column: 657.06 > 400` | PASS |

## I made #166's mistake twice more while writing these tests

Both assertions first landed in a regime where they could not fail. At a 700 px content column the fixture value *nearly* fits on one line, so:

- `rows > 1` broke on the **fixed** build, and
- the content-column assertion **passed on the broken one**.

Narrowing to 400 put both in the regime they are meant to probe. That is the same error as #166, three days later, and it was caught only because the control run is now mandatory rather than optional. Both constants carry a comment explaining their value so the next reader does not "tidy" them back.

## Harness

`render_geometry_inner` now takes `ui_width` and `content_width` separately, and `render_geometry_frontmatter` exposes that plus `render_frontmatter(true)`. The older helpers pass the same value for both, so their behaviour is unchanged. That coupling is what made #167 inexpressible as a test in the first place.

## Suites

Renderer 90 / 1 / 28 / 16 (1 ignored) — `wrapping` 26 → 28, exactly the two new tests. Root 64 (1 ignored). Clippy unchanged against main at 20 findings, **none** in the changed function's line range.

Write-up in `docs/devlog/065-frontmatter-bounded-value.md`; `docs/LESSONS.md` records both the mechanism and the repeated test mistake.