### PR TITLE
fix(ci): the crates.io token pre-flight could never pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,17 +59,32 @@ jobs:
     permissions:
       contents: read
     steps:
-        - name: crates.io token is valid
-          # The publish job runs ~20 minutes in, after the whole build matrix and
-          # the snap. When the token is dead it fails there, at the very end, while
-          # every other channel has already published — so the release looks
-          # finished and the crates.io gap goes unnoticed. That is exactly what
-          # happened to v0.1.16 and v0.1.17: both failed here with
-          # `403 Forbidden: authentication failed`, and crates.io sat four versions
-          # behind for six weeks before anyone looked.
+        - name: crates.io token is present and well formed
+          # This job previously called `GET /api/v1/me` with the token in an
+          # `Authorization` header. That check could never pass. The endpoint is
+          # session-only, and crates.io answers *any* API token with
           #
-          # `GET /api/v1/me` is read-only and costs a second, so the same failure
-          # now lands before anything is built or published anywhere.
+          #   403 {"detail":"this action can only be performed on the crates.io website"}
+          #
+          # so a perfectly valid token failed the gate and `publish-crates` was
+          # skipped — manufacturing exactly the silent crates.io gap this job
+          # exists to prevent. It was added in #135 and never exercised against a
+          # working token, because the token was already dead when it landed.
+          #
+          # crates.io publishes no read-only endpoint that authenticates with an
+          # API token, so there is nothing to probe: the only proof of validity
+          # is a publish. What is left is a shape check, which still catches the
+          # two failure modes that actually occur — an unset secret and a paste
+          # that lost characters — in about a second, before anything is built.
+          #
+          # A genuinely revoked token now fails in `publish-crates`, which since
+          # #151 gates nothing else: the snap, both AUR packages and the GitHub
+          # Release publish regardless, and the run still goes red.
+          #
+          # Historical note: v0.1.16 and v0.1.17 really did fail with
+          # `403 Forbidden: authentication failed` — but from `cargo publish`,
+          # which is genuinely token-authenticated. That diagnosis stands; only
+          # the probe built to catch it was wrong.
           env:
             CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           run: |
@@ -77,23 +92,14 @@ jobs:
               echo "::notice::CARGO_REGISTRY_TOKEN is unset — crates.io publish will be skipped."
               exit 0
             fi
-            CODE=$(curl -sS -o /tmp/me.json -w '%{http_code}' \
-              -H "Authorization: ${CARGO_REGISTRY_TOKEN}" \
-              -H "User-Agent: md-viewer-release (https://github.com/aydiler/md-viewer)" \
-              https://crates.io/api/v1/me || echo 000)
-            case "$CODE" in
-              200)
-                echo "crates.io token accepted for: $(python3 -c 'import json;print(json.load(open("/tmp/me.json"))["user"]["login"])')"
-                ;;
-              401|403)
-                echo "::error::crates.io rejected CARGO_REGISTRY_TOKEN (HTTP $CODE). Mint a new token at https://crates.io/settings/tokens and update the repository secret, then re-tag."
-                exit 1
-                ;;
-              *)
-                echo "::error::Could not reach crates.io to validate the token (HTTP $CODE). Re-run the job."
-                exit 1
-                ;;
-            esac
+            # Shape only. See the comment above for why there is nothing to probe.
+            if printf '%s' "${CARGO_REGISTRY_TOKEN}" | grep -qE '^cio[A-Za-z0-9]{32}$'; then
+              echo "CARGO_REGISTRY_TOKEN is present and well formed; validity is proven by publish-crates."
+            else
+              LEN=$(printf '%s' "${CARGO_REGISTRY_TOKEN}" | wc -c)
+              echo "::error::CARGO_REGISTRY_TOKEN is not the shape of a crates.io token (expected 'cio' followed by 32 alphanumerics, got ${LEN} characters). Re-copy it from https://crates.io/settings/tokens — a truncated paste looks exactly like this."
+              exit 1
+            fi
 
   build:
     name: Build (${{ matrix.asset_name }})

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -510,6 +510,19 @@ ctx.request_repaint_after(Duration::from_millis(50)); // NOT request_repaint()
 ```
 **Files:** `.github/workflows/release.yml`
 
+### A probe that can never pass is worse than no probe
+**Context:** #135 added a crates.io token pre-flight to catch the dead credential that had left the registry four versions behind. #151 moved it into its own job so one bad token would not cost four channels. Both changes were right about the *structure* and wrong about the *check*.
+**The check could never succeed.** It called `GET /api/v1/me` with the token in an `Authorization` header. That endpoint is session-only — crates.io answers **any** API token with:
+```
+403 {"errors":[{"detail":"this action can only be performed on the crates.io website"}]}
+```
+So a perfectly valid token failed the gate, `publish-crates` was skipped, and the pipeline manufactured exactly the silent crates.io gap the job existed to prevent.
+**Why it survived two PRs and a code review:** the token really was dead when the check landed, so its failure looked like a success — the probe reported what the author expected, for the wrong reason. It was never once exercised against a working token, which is the only run that could have distinguished the two.
+**The cost was not theoretical.** It rejected two freshly minted tokens on the maintainer's behalf and reported them as "rejected by crates.io", sending him to mint a replacement that was then rejected the same way. A separate ad-hoc `curl` compounded it: crates.io returns `403` to a generic `curl/8.x` User-Agent even on public endpoints, so the same status code had two unrelated causes in the same investigation.
+**crates.io has no read-only endpoint that authenticates with an API token.** There is nothing to probe. The gate is now a shape check (`^cio[A-Za-z0-9]{32}$`), which still catches the two failure modes that actually occur — an unset secret and a paste that lost characters — in a second, before anything is built. A genuinely revoked token fails in `publish-crates`, which since #151 gates nothing else.
+**General lesson, and it generalizes past credentials:** a check whose passing condition has never been observed is not a check. Before trusting a new guard, make it succeed once on input known to be good — the same discipline as "never trust a test that has not been observed red", in the other direction. Both halves are needed: a guard must be seen to pass on the good case *and* fail on the bad one. This one was only ever seen to fail.
+**Files:** `.github/workflows/release.yml` (`check-crates-token`), `~/.local/bin/mdv-set-crates-token`, PRs #135 / #151
+
 ### A fail-fast check belongs in its own job, not in a gate everything needs
 **Context:** crates.io publishing had been silently broken since 2026-07-23 — `md-viewer` stuck at 0.1.15 — because the token expired and `publish-crates` runs last, after the snap, both AUR packages and the GitHub Release have already published. The release *looked* delivered. #135 added a one-second `GET /api/v1/me` pre-flight so a dead token fails immediately instead of twenty minutes in.
 


### PR DESCRIPTION
`check-crates-token` — which I added in #135 and moved in #151 — **rejects every valid crates.io token**. It is currently sitting in the release pipeline, and it would have skipped `publish-crates` on the 0.2.0 tag.

## What it did

```yaml
curl -H "Authorization: ${CARGO_REGISTRY_TOKEN}" https://crates.io/api/v1/me
```

`/api/v1/me` is session-only. crates.io answers **any** API token with:

```json
403 {"errors":[{"detail":"this action can only be performed on the crates.io website"}]}
```

So the gate fails, `publish-crates` is skipped, and the pipeline manufactures exactly the silent crates.io gap the job exists to prevent.

## Why it survived two PRs

The token really was dead when the check landed. Its failure therefore looked like a success — **the probe reported what I expected, for the wrong reason**, and it was never once run against a working token. That single run is the only one that could have distinguished "the token is bad" from "the check is bad".

The cost was not theoretical. It rejected two freshly minted tokens and reported them as *"rejected by crates.io"*, which sent the maintainer to mint a replacement that failed identically. A separate ad-hoc `curl` compounded the confusion: crates.io returns `403` to a generic `curl/8.x` User-Agent even on **public** endpoints, so the same status code had two unrelated causes in one investigation.

## The fix

crates.io publishes no read-only endpoint that authenticates with an API token, so there is nothing to probe. What remains is a shape check:

```bash
printf '%s' "${CARGO_REGISTRY_TOKEN}" | grep -qE '^cio[A-Za-z0-9]{32}$'
```

Verified against five inputs before committing:

| input | result |
|---|---|
| `cio` + 32 alphanumerics | accepted |
| truncated (23 chars) | rejected |
| wrong prefix | rejected |
| contains `-` | rejected |
| empty | rejected |

That still catches the two failure modes that actually occur — an unset secret and a paste that lost characters — in about a second, before anything is built. A genuinely revoked token now fails in `publish-crates`, which since #151 gates nothing else: the snap, both AUR packages and the GitHub Release publish regardless, and the run still goes red under an obvious name.

The historical diagnosis stands, and the new comment says so: v0.1.16 and v0.1.17 really did fail with `403 Forbidden: authentication failed` — but from `cargo publish`, which *is* genuinely token-authenticated. Only the probe built to catch it was wrong.

## Lesson recorded

`docs/LESSONS.md` gains "A probe that can never pass is worse than no probe". The general form is the mirror of a rule already in that file: never trust a test that has not been observed red — and equally, never trust a guard that has not been observed **green on input known to be good**. Both halves are needed. This one was only ever seen to fail.