### PR TITLE
diag: report how a viewport slice's event range is chosen (#140)

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -1102,6 +1102,67 @@ events={events}{}",
     );
 }
 
+/// Diagnostic instrument for issue #140, companion to [`diag_report_slice`].
+///
+/// Inert unless `MDV_DIAG_SPLIT` is set. Where `diag_report_slice` reports
+/// where a slice is *placed*, this reports how its event range was *chosen* —
+/// the split-point table and both `partition_point` results that select it.
+///
+/// #140's candidate path is a stored scroll offset that briefly exceeds the
+/// document's updated extent after an asynchronous layout change, so the two
+/// values that decide that are printed side by side: the viewport the frame
+/// shows, and `page_size.y`, the extent the bootstrap pass measured. When the
+/// former runs past the latter the line is marked `OFFSET>EXTENT`.
+///
+/// It earned its place on #167, where `MDV_DIAG_SLICE` correctly reported no
+/// off-screen placement in either the working or the broken run — a true
+/// negative that excluded the placement hypothesis but could not say what was
+/// wrong. This probe showed it in one frame: `below` had collapsed to 1, so
+/// the range ended at event 11 of 63 and everything below the frontmatter
+/// table went unpainted.
+///
+/// The summary line prints on **every** frame, so its silence means the probe
+/// was not running rather than that nothing happened. The full table is
+/// expensive on a long document, so it is dumped only when the selection looks
+/// degenerate — an empty range, or one that stops at the first split point
+/// while more of the document lies inside the viewport.
+#[allow(clippy::too_many_arguments)]
+fn diag_report_split(
+    split_points: &[(usize, Pos2, Pos2)],
+    above: usize,
+    below: usize,
+    first_event_index: usize,
+    last_event_index: usize,
+    total_events: usize,
+    viewport_min_y: f32,
+    viewport_max_y: f32,
+    extent_y: f32,
+) {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    if !*ENABLED.get_or_init(|| std::env::var_os("MDV_DIAG_SPLIT").is_some()) {
+        return;
+    }
+    let overshoot = viewport_max_y > extent_y;
+    eprintln!(
+        "DIAG split viewport=[{viewport_min_y:.0},{viewport_max_y:.0}] extent={extent_y:.0} \
+above={above} below={below} events=[{first_event_index},{last_event_index})/{total_events} \
+sp={}{}",
+        split_points.len(),
+        if overshoot { " OFFSET>EXTENT" } else { "" }
+    );
+
+    // A range that selects nothing, or that stops at the very first boundary
+    // while the viewport plainly reaches further, is the shape #167 produced.
+    let degenerate = first_event_index >= last_event_index
+        || (below <= 1 && split_points.len() > 2);
+    if degenerate {
+        for (i, (event_index, start, end)) in split_points.iter().enumerate() {
+            eprintln!("  sp[{i}] ev={event_index} start.y={:.1} end.y={:.1}", start.y, end.y);
+        }
+    }
+}
+
 fn markdown_table_id(source_id: Id, source_start: usize) -> Id {
     source_id.with("_markdown_table").with(source_start)
 }
@@ -1790,6 +1851,18 @@ impl CommonMarkViewerInternal {
                 } else {
                     Vec::new()
                 };
+
+                diag_report_split(
+                    &scroll_cache.split_points,
+                    above,
+                    below,
+                    first_event_index,
+                    last_event_index,
+                    scroll_cache.events.len(),
+                    viewport.min.y,
+                    viewport.max.y,
+                    page_size.y,
+                );
 
                 (first_event_index, first_end_position.y, events_range,
                  viewport.min.y, viewport.max.y)

--- a/docs/devlog/067-split-selection-probe.md
+++ b/docs/devlog/067-split-selection-probe.md
@@ -1,0 +1,74 @@
+# 067 — A permanent probe for slice *range selection* (issue #140)
+
+**Branch:** `diag/140-split-probe`
+**Date:** 2026-09-07
+**Status:** complete; held until v0.2.0 is tagged
+
+## Why
+
+`MDV_DIAG_SLICE` reports where a viewport slice is *placed*. On #167 it did its
+job perfectly and was still not enough: it reported **zero** off-screen
+placements in both the working and the broken run. That true negative correctly
+excluded the placement hypothesis — and could say nothing about what was
+actually wrong.
+
+The answer was in how the event *range* is chosen:
+
+```rust
+let below = split_points.partition_point(|(_, start, _)| start.y <= viewport.max.y);
+let last_event_index = split_points.get(below + 1)...;
+```
+
+`below` had collapsed to 1, so the range ended at event 11 of 63 and everything
+below the frontmatter table went unpainted. A throwaway probe showed that in one
+frame. This makes it permanent, because #140 is still open and is the same class
+of failure.
+
+## What it reports
+
+Every frame, one line:
+
+```
+DIAG split viewport=[876,1626] extent=1626 above=10 below=17 events=[32,134)/134 sp=17
+```
+
+`extent` is `page_size.y`, the height the bootstrap pass measured. #140's
+candidate path is a stored scroll offset that briefly exceeds the updated
+extent, so the viewport and the extent are printed side by side and the line is
+marked `OFFSET>EXTENT` when the former runs past the latter.
+
+The split-point table is dumped only when the selection looks degenerate — an
+empty range, or one stopping at the first boundary while the viewport reaches
+further. Dumping 17 rows every frame would bury the signal on a long document.
+
+**The summary line prints unconditionally** while enabled, so its silence means
+the probe was not running, not that nothing happened. That distinction is the
+whole reason the existing probe is written the same way.
+
+## Verification
+
+Both halves, same document, same harness:
+
+| run | DIAG lines |
+|---|---|
+| `MDV_DIAG_SPLIT=1` | **486** |
+| without the variable | **0** |
+
+On the healthy run, `OFFSET>EXTENT` and degenerate-table dumps were both 0 —
+genuine zeroes from a probe proven to be reporting, not an unimplemented check.
+At the document bottom the line reads `viewport=[876,1626] extent=1626`: equal,
+never exceeding, which is the post-render clamp behaving.
+
+## Cost
+
+One relaxed bool load per painted slice when disabled, matching
+`diag_report_slice`. Same `OnceLock` pattern.
+
+## Release timing
+
+Touches the vendored renderer (workspace 0.28.0, unpublished). Held until the
+`v0.2.0` tag so a verified release is not disturbed.
+
+## Files
+
+- `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs`


### PR DESCRIPTION
For #140. **Draft on purpose — do not merge before `v0.2.0` is tagged.**

## Why a second probe

`MDV_DIAG_SLICE` reports where a slice is *placed*. On #167 it did exactly its job and was **still not enough**: it reported zero off-screen placements in *both* the working and the broken run. That true negative correctly excluded the placement hypothesis — and could say nothing about what was actually wrong.

The cause was in how the event *range* gets chosen:

```rust
let below = split_points.partition_point(|(_, start, _)| start.y <= viewport.max.y);
let last_event_index = split_points.get(below + 1)...;
```

`below` had collapsed to 1, so the range ended at event 11 of 63 and everything below the frontmatter table went unpainted. A throwaway probe showed that in a single frame. #140 is still open and is the same class of failure, so this makes the instrument permanent instead of rebuilding it next time.

## What it prints

One line per frame:

```
DIAG split viewport=[876,1626] extent=1626 above=10 below=17 events=[32,134)/134 sp=17
```

`extent` is `page_size.y`, the height the bootstrap pass measured. **#140's stated candidate path is a stored scroll offset that briefly exceeds the updated content extent**, so those two values sit side by side and the line is marked `OFFSET>EXTENT` when the viewport runs past the extent.

The split-point table is dumped only when the selection looks degenerate — an empty range, or one stopping at the first boundary while the viewport plainly reaches further. Seventeen rows every frame would bury the signal on a long document.

**The summary line is unconditional while enabled**, so its silence means the probe was not running rather than that nothing happened. That distinction is why `diag_report_slice` is written the same way, and it is what made its null result on #167 trustworthy.

## Verification — both halves

Same document, same harness:

| run | DIAG lines |
|---|---|
| `MDV_DIAG_SPLIT=1` | **486** |
| without the variable | **0** |

On the healthy run, `OFFSET>EXTENT` and degenerate-table dumps were both **0** — genuine zeroes from a probe proven to be reporting, not an unimplemented check that would report zero either way. At the document bottom the line reads `viewport=[876,1626] extent=1626`: equal, never exceeding, which is the post-render clamp from `docs/LESSONS.md` behaving as documented.

## Cost when disabled

One relaxed bool load per painted slice, same `OnceLock` pattern as the existing probe.

## Release timing

Touches the vendored renderer (workspace 0.28.0, not yet published). Held until the tag so the release that has been verified end to end is not disturbed.