### PR TITLE
chore: bump the vendored fork to 0.28.1 after 0.28.0 was published

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend_extended"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_extended"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "egui",
  "egui_commonmark_backend_extended",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ egui = { version = "0.33", features = ["accesskit"] }
 # egui-mcp-bridge = { path = "/home/ahmet/dev/mcp/egui-mcp/crates/egui-mcp-bridge", optional = true }
 
 # Markdown rendering with syntax highlighting (fork with typography support)
-egui_commonmark_extended = { version = "0.28.0", features = [
+egui_commonmark_extended = { version = "0.28.1", features = [
     "better_syntax_highlighting",
     "svg",
     "svg_text",
@@ -92,5 +92,5 @@ lto = "thin"
 codegen-units = 4
 
 [patch.crates-io]
-egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark", version = "0.28.0" }
-egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend", version = "0.28.0" }
+egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark", version = "0.28.1" }
+egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend", version = "0.28.1" }

--- a/crates/egui_commonmark/Cargo.lock
+++ b/crates/egui_commonmark/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend_extended"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "data-url",
  "egui",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_extended"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "document-features",
  "eframe",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_macros_extended"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "document-features",
  "egui",

--- a/crates/egui_commonmark/Cargo.toml
+++ b/crates/egui_commonmark/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.89"
-version = "0.28.0"
+version = "0.28.1"
 repository = "https://github.com/aydiler/md-viewer"
 
 [workspace.dependencies]
@@ -21,8 +21,8 @@ egui = { version = "0.33", default-features = false }
 
 # Runtime lookup for recognized GitHub/gemoji shortcode names.
 emojis = "0.9.0"
-egui_commonmark_backend_extended = { version = "0.28.0", path = "egui_commonmark_backend", default-features = false }
-egui_commonmark_macros_extended = { version = "0.28.0", path = "egui_commonmark_macros", default-features = false }
+egui_commonmark_backend_extended = { version = "0.28.1", path = "egui_commonmark_backend", default-features = false }
+egui_commonmark_macros_extended = { version = "0.28.1", path = "egui_commonmark_macros", default-features = false }
 
 # To add features to documentation
 document-features = { version = "0.2" }


### PR DESCRIPTION
Housekeeping that the v0.2.0 release makes necessary, and that would otherwise fail silently.

## Why now

v0.2.0 published `egui_commonmark_extended`, `..._backend_extended` and `..._macros_extended` **0.28.0** to crates.io. #175 and #176 then merged renderer changes on top, so `main`'s fork content no longer matches what 0.28.0 contains.

Left at 0.28.0, the next release would do this:

1. `publish-crates` uploads 0.28.0 → crates.io answers **"already uploaded"**
2. `scripts/publish-crates.sh` treats that as success, by design and correctly
3. the new renderer code never reaches the registry
4. md-viewer's publish-verify resolves the **old** 0.28.0 from it and passes

Nothing goes red. That is the shape of silent gap `.claude/rules/release-workflow.md` exists to prevent, and it is the same shape that left crates.io four versions behind for six weeks.

## Bumped by hand, and here is why that mattered

Both lockfiles contain another crate at 0.28.0:

```
$ awk '/^name = /{n=$3} /^version = "0\.28\.0"$/{print n}' Cargo.lock
egui_commonmark_backend_extended
egui_commonmark_extended
glam            <-- not ours
```

A blanket `sed 's/0\.28\.0/0.28.1/'` would have given **glam** a version that does not exist. That is the v0.1.8 lockfile incident in a new costume — `docs/LESSONS.md` records it under *"`sed 's/^version = ...' Cargo.lock` bumps unrelated crates"*, and it is why the release rules say never to sed a lockfile.

Each `[[package]]` block was matched by name instead. Six manifest lines, five lockfile blocks.

## Verification

`cargo build --locked` succeeds and leaves both lockfiles **exactly as edited** — no cargo-side correction, which is what `--locked` is for. `glam` reads 0.28.0 in both files afterwards.