### PR TITLE
Declare required-features so a plain cargo test works in the renderer workspace

### DIFF
--- a/crates/egui_commonmark/egui_commonmark/Cargo.toml
+++ b/crates/egui_commonmark/egui_commonmark/Cargo.toml
@@ -96,3 +96,15 @@ egui_commonmark_macros_extended = { workspace = true } # Tests won't build other
 
 [package.metadata.docs.rs]
 features = ["better_syntax_highlighting", "document-features", "macros"]
+
+# `commonmark!` / `commonmark_str!` only exist with the `macros` feature. Without
+# these declarations Cargo builds both examples unconditionally and a plain
+# `cargo test` fails with 16 `cannot find macro` errors, which reads like a
+# broken checkout rather than a missing feature flag (see issue #122).
+[[example]]
+name = "macros"
+required-features = ["macros"]
+
+[[example]]
+name = "mixing"
+required-features = ["macros"]

--- a/crates/egui_commonmark/egui_commonmark/src/lib.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/lib.rs
@@ -47,11 +47,20 @@
 //! ## Example
 //!
 //! ```
+//! # // The macro only exists with the `macros` feature. rustdoc compiles a
+//! # // doctest with the crate's own cfgs, so gating keeps this compiled and run
+//! # // when the feature is on and trivially empty when it is off — rather than
+//! # // failing a plain `cargo test` with `cannot find macro` (issue #122).
+//! # #[cfg(feature = "macros")]
+//! # fn main() {
 //! use egui_commonmark_extended::{CommonMarkCache, commonmark};
 //! # egui::__run_test_ui(|ui| {
 //! let mut cache = CommonMarkCache::default();
 //! let _response = commonmark!(ui, &mut cache, "# ATX Heading Level 1");
 //! # });
+//! # }
+//! # #[cfg(not(feature = "macros"))]
+//! # fn main() {}
 //! ```
 //!
 //! Alternatively you can embed a file


### PR DESCRIPTION
Closes the half of #122 that was actually costing something, without touching the workspace layout.

## The defect

`commonmark!` and `commonmark_str!` exist only with the `macros` feature, but **no `[[example]]` section declared `required-features`**, so Cargo builds `examples/macros.rs` and `examples/mixing.rs` in every configuration. A plain `cargo test` in the renderer workspace therefore aborts before running a single test:

```
error: cannot find macro `commonmark` in this scope
error: could not compile `egui_commonmark_extended` (example "macros") due to 16 previous errors
```

That is the failure #122 names as the real cost of the current layout — "reads like a broken checkout rather than a missing flag" — and it is not caused by the layout at all.

The same defect sat in a crate-level doctest, where the `commonmark!` example was a plain fence while its `commonmark_str!` sibling was already `rust,ignore`. Rather than dropping the check to match, it is gated on the feature: rustdoc compiles a doctest with the crate's own cfgs, so it stays compiled and run where the macro exists.

| | renderer workspace, `cargo test`, no features |
|---|---|
| before | 16 errors, **0 tests run** |
| after | **148 tests, all green** |

## Verified in both directions

A fix that turns a loud failure into a silent skip would be worse than the defect, so both directions were measured rather than assumed.

**With `macros` the examples are still really built** — binaries deleted first, then checked for existence:

```
gebaut: macros      gebaut: mixing      gebaut: hello_world
```

**Without it they are skipped, with zero errors, and the other seven still build** — so declaring two `[[example]]` sections did not disable autodiscovery for the rest:

```
Fehler: 0
uebersprungen: macros   uebersprungen: mixing   gebaut: hello_world
```

**The gated doctest still really compiles.** Counts alone cannot show this (16 pass either way), so the body was deliberately broken:

| | broken doctest body |
|---|---|
| `--features …,macros` | `FAILED. 15 passed; 1 failed` |
| no features | `ok. 16 passed; 0 failed` |

## Other checks

- CI's four renderer test invocations: unchanged and green (135 passed, 1 ignored for the featured one).
- CI's renderer clippy, forced re-check on both trees: **23 warnings before, 23 after**, 0 errors. (Note for anyone repeating it: clippy emits nothing on a cached build, so the counts are only comparable after touching the sources.)
- Root suite: `cargo test --locked` 65 passed, 0 failed — untouched.
- `cargo fmt --check` clean.
- No fork version bump needed: `main` already carries 0.28.1 and crates.io is at 0.28.0, so this rides along on the next release.

Full experiment behind the #122 half of this — including why unifying the workspaces would *not* have fixed it — is written up in that issue.