### PR TITLE
Bump to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to markdown-viewer will be documented in this file.
 
-## [0.2.1] - 2026-09-08
+## [0.2.1] - 2026-09-10
 
 A short follow-up to 0.2.0: one link-handling feature, one silent failure made visible, and the viewport slicer's range selection made permanently observable.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "md-viewer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-viewer"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Fast, lightweight markdown viewer for Linux with tabs, file explorer, and live reload"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: md-viewer
 base: core22
-version: '0.2.0'
+version: '0.2.1'
 summary: Fast, lightweight markdown viewer for Linux
 description: |
   A fast, lightweight markdown viewer for Linux built with Rust and egui.


### PR DESCRIPTION
Version bump only — **no tag**, which stays a separate and deliberate step.

`Cargo.toml`, `Cargo.lock` and `snap/snapcraft.yaml` move together, and the changelog date goes from 2026-09-08 to today: the section was written before the tag existed, which is how 0.2.0's was written too, and #172 had to correct that one's date for the same reason.

**The lock is edited on the `md-viewer` block, not by a version-wide `sed`.** At v0.1.8 that rewrote five lines, because four unrelated crates happened to sit at the same version — `docs/LESSONS.md` records it. The diff here is four lines in four files, one each.

**Contracts checked locally rather than left to CI:**

| check | result |
|---|---|
| `cargo metadata --locked` | exit 0 — the lock still represents the manifest |
| `scripts/check-workspace-sync.sh` | synchronized at renderer version 0.28.1 |
| `scripts/check-fork-publishable.sh` | 0.28.1 is not on crates.io, so it publishes fresh |
| version-sync (Cargo vs snapcraft) | 0.2.1 == 0.2.1 |

**What 0.2.1 contains** — 16 commits since v0.2.0, in four sections: copying a link's address from its context menu; dense tables trading bounded horizontal overflow for much less height; two link-handling fixes (a missing target now reports, and a destination that cannot be decoded no longer does nothing at all); and the internal notes — the split-selection probe, the fork's 0.28.1 bump, and the `required-features` fix that lets the renderer suite run without a feature list.