### PR TITLE
Constant floating-scrollbar geometry beside panel dividers (#139)

### DIFF
--- a/scripts/hover-cursor-hash.py
+++ b/scripts/hover-cursor-hash.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Print a hash of the current X cursor image, for scripts/hover-stability.sh.
+
+The cursor is the second observable in issue #139 — the report describes the
+resize cursor alternating as well as the scrollbar changing width, and both
+turned out to reproduce at the same single pixel. Sampling it needs XFixes,
+which python-xlib exposes; without that module the caller degrades to the
+pixel half alone rather than failing.
+"""
+import hashlib
+import sys
+
+try:
+    from Xlib import display
+except ImportError:  # pragma: no cover - depends on the host
+    print("NOXLIB")
+    sys.exit(0)
+
+d = display.Display(sys.argv[1] if len(sys.argv) > 1 else None)
+if not d.has_extension("XFIXES"):
+    print("NOXFIXES")
+    sys.exit(0)
+d.xfixes_query_version()
+image = d.xfixes_get_cursor_image(d.screen().root)
+digest = hashlib.sha1(bytes(str(image.cursor_image), "utf8")).hexdigest()[:8]
+print(digest, getattr(image, "width", "?"), getattr(image, "height", "?"))

--- a/scripts/hover-stability.sh
+++ b/scripts/hover-stability.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Stationary-pointer stability check beside a resizable panel divider.
+#
+# Third companion to scroll-regression.sh and visual-regression.sh, checking a
+# failure neither can see: geometry that *alternates* while the pointer does not
+# move (issue #139).
+#
+# Why those two cannot cover it, and why this one can:
+#
+#   Both existing guards sample settled states — they move, sleep, capture once.
+#   That makes them blind to a one-frame artifact (see #140), but an oscillating
+#   state never settles, so repeated captures at a *fixed* pointer position do
+#   land on different phases. #139 is therefore reachable by capture where #140
+#   is not.
+#
+# What it found: on the build before the fix, exactly one x out of 36 scanned
+# cycles through four states with the pointer held still — visible both in the
+# painted pixels and in the cursor shape, sampled through XFixes. Its neighbours
+# are stable across 20 frames. One pixel wide is why the report reads as
+# intermittent, and why an earlier sweep in 14 px steps found nothing: the
+# window is narrower than the step.
+#
+# The failure window is one pixel, so DO NOT coarsen STEP below 1 px thinking it
+# saves time; it removes the detection.
+#
+# Usage:
+#   scripts/hover-stability.sh <binary> [tag]
+#
+# Run it twice — once on the build under test and once on a control — and
+# compare. A run that reports zero unstable positions means nothing on its own
+# unless the control run reports some; see the "which way it cannot fail" family
+# in docs/LESSONS.md.
+#
+# Requires: Xvfb, xdotool, ImageMagick (import), python3 with Pillow, and
+# python-xlib for the cursor sampling (the cursor half is skipped without it).
+#
+# Detaches nothing: run it under `systemd-run --user --collect` if your caller
+# reaps process groups, exactly as the other two guards document.
+set -u
+
+BIN="${1:?usage: hover-stability.sh <binary> [tag]}"
+TAG="${2:-run}"
+DISPLAY_NUM="${MDV_DISPLAY:-95}"
+STEP=1
+SETTLE="${MDV_SETTLE:-1.5}"
+FRAMES="${MDV_FRAMES:-12}"
+OUT="${MDV_OUT:-/tmp/mdv-hover-$TAG}"
+
+rm -rf "$OUT"; mkdir -p "$OUT/shots"
+FIXTURE="$OUT/fixture"; mkdir -p "$FIXTURE"
+# Enough files that the explorer itself scrolls: its vertical scrollbar is the
+# one that sits on the explorer/document boundary.
+for i in $(seq 1 40); do
+    f="$FIXTURE/a-deliberately-long-file-name-$i.md"
+    printf '# Document %s\n\n' "$i" > "$f"
+    for j in $(seq 1 60); do
+        echo "Line $j, long enough that the document scrolls and gets a scrollbar." >> "$f"
+    done
+done
+
+pkill -f "Xvfb :$DISPLAY_NUM " 2>/dev/null
+rm -f "/tmp/.X$DISPLAY_NUM-lock" "/tmp/.X11-unix/X$DISPLAY_NUM"
+Xvfb ":$DISPLAY_NUM" -screen 0 1400x900x24 >/dev/null 2>&1 &
+XVFB_PID=$!
+for _ in $(seq 1 40); do DISPLAY=":$DISPLAY_NUM" xdpyinfo >/dev/null 2>&1 && break; sleep 0.25; done
+DISPLAY=":$DISPLAY_NUM" xdpyinfo >/dev/null 2>&1 || { echo "Xvfb :$DISPLAY_NUM did not come up"; exit 1; }
+export DISPLAY=":$DISPLAY_NUM"
+
+env WINIT_UNIX_BACKEND=x11 WAYLAND_DISPLAY= \
+    XDG_DATA_HOME="$OUT/data" XDG_CONFIG_HOME="$OUT/config" \
+    setsid "$BIN" --foreground "$FIXTURE/a-deliberately-long-file-name-1.md" \
+    >"$OUT/app.log" 2>&1 &
+APP_PID=$!
+for _ in $(seq 1 60); do
+    WID=$(xdotool search --name "Markdown Viewer" 2>/dev/null | head -1)
+    [ -n "${WID:-}" ] && break
+    sleep 0.5
+done
+if [ -z "${WID:-}" ]; then
+    echo "FAIL: no window appeared"; tail -5 "$OUT/app.log"
+    kill "$APP_PID" "$XVFB_PID" 2>/dev/null; exit 1
+fi
+sleep 3
+
+shot()  { import -window "$WID" "$OUT/shots/$1.png" 2>/dev/null; }
+hold()  { xdotool mousemove --sync "$1" "$2"; }
+
+# Narrow the centre pane by widening the explorer, which is the condition the
+# report names. The divider starts near x=213 at this window size.
+hold 213 400; sleep 0.4
+xdotool mousedown 1; sleep 0.3
+for x in $(seq 220 15 430); do xdotool mousemove --sync "$x" 400; sleep 0.05; done
+sleep 0.4; xdotool mouseup 1; sleep 2
+hold 700 400; sleep 1.5
+
+: > "$OUT/cursor.txt"
+for x in $(seq 405 "$STEP" 440); do
+    hold "$x" 400
+    sleep "$SETTLE"
+    for f in $(seq -w 1 "$FRAMES"); do
+        shot "x${x}_f${f}"
+        printf '%s %s ' "$x" \
+            "$(python3 "$(dirname "$0")/hover-cursor-hash.py" ":$DISPLAY_NUM" 2>/dev/null | awk '{print $1}')" \
+            >> "$OUT/cursor.txt"
+        sleep 0.15
+    done
+    echo >> "$OUT/cursor.txt"
+done
+
+kill -TERM "$APP_PID" 2>/dev/null; sleep 1; kill "$XVFB_PID" 2>/dev/null
+
+python3 - "$OUT" "$TAG" <<'PY'
+from PIL import Image
+import hashlib, glob, re, sys, os
+out, tag = sys.argv[1], sys.argv[2]
+BOX = (400, 140, 470, 700)   # the divider column and the scrollbar beside it
+by_x = {}
+for p in glob.glob(f"{out}/shots/x*_f*.png"):
+    m = re.match(r".*/x(\d+)_f(\d+)\.png", p)
+    by_x.setdefault(int(m.group(1)), []).append(
+        hashlib.sha1(Image.open(p).convert("RGB").crop(BOX).tobytes()).hexdigest()[:8])
+pixel = {x: len(set(v)) for x, v in by_x.items() if len(set(v)) > 1}
+cursor = {}
+cfile = f"{out}/cursor.txt"
+if os.path.exists(cfile):
+    for line in open(cfile):
+        q = line.split()
+        if len(q) < 4:
+            continue
+        if len(set(q[1::2])) > 1:
+            cursor[int(q[0])] = len(set(q[1::2]))
+print(f"[{tag}] {len(by_x)} positions x {len(next(iter(by_x.values()), []))} frames, pointer held still")
+print(f"[{tag}] pixels unstable at:  {dict(sorted(pixel.items())) or 'none'}")
+print(f"[{tag}] cursor unstable at:  {dict(sorted(cursor.items())) or 'none'}")
+if pixel or cursor:
+    print(f"[{tag}] FAIL: geometry alternates with an unmoving pointer")
+    sys.exit(1)
+print(f"[{tag}] PASS")
+PY

--- a/src/main.rs
+++ b/src/main.rs
@@ -1970,6 +1970,23 @@ impl MarkdownApp {
 
         // Set constant styles once at init (never changes at runtime)
         cc.egui_ctx.style_mut(|style| {
+            // Constant floating-scrollbar geometry (#139).
+            //
+            // egui's floating bar animates its width between `floating_width`
+            // (2) and `bar_width` (10) on hover. A dormant floating bar is
+            // hidden by `dormant_*_opacity: 0.0`, not by being thin, so that
+            // width governs the bar's *interact* rect and nothing visible.
+            // Beside a panel divider the growing and shrinking rect claims and
+            // releases the pointer on alternating frames, and at the one pixel
+            // just outside the resize handle the two never settle.
+            //
+            // Measured on Xvfb with the pointer held still: on `main` exactly
+            // one x out of 36 cycles through four states, in both the painted
+            // pixels and the cursor shape; with the width pinned, zero — and
+            // both builds produce an identical state map across x, so this
+            // removes the oscillation rather than moving it out of view.
+            // `scripts/hover-stability.sh` is that measurement.
+            style.spacing.scroll.floating_width = style.spacing.scroll.bar_width;
             style.url_in_tooltip = true;
             use egui::{FontId, TextStyle};
             style


### PR DESCRIPTION
Fixes #139 with the change **@RichardCao proposed in that issue** — his hypothesis, now confirmed by measurement rather than by argument. He asked that no PR be submitted until there was either a repeatable reproduction or an automated capture showing the alternation with an unmoving pointer. There is now both.

## The mechanism

egui's floating scrollbar animates its width between `floating_width` (2) and `bar_width` (10) on hover. A dormant floating bar is hidden by `dormant_background_opacity: 0.0` / `dormant_handle_opacity: 0.0` — it is **invisible, not thin** — so that width governs the bar's *interact* rect and nothing visible at all. Beside a panel divider the growing and shrinking rect claims and releases the pointer on alternating frames, and at the one pixel just outside the resize handle the two never settle.

That is why the fix has no visual effect on its own and still changes behaviour: both builds render identically, and one of them stops oscillating.

## Measured, both directions

Xvfb, pointer held still, centre pane narrowed by widening the explorer — the condition the report names:

| build | pixels unstable | cursor unstable |
|---|---|---|
| current `main` | `{420: 3}` | `{420: 2}` |
| this branch | none | none |

At x=420 the state cycles `ABBCABBCDBBCDBBC…`; its neighbours are stable across 20 frames. **The window is one pixel wide**, which is why the report reads as intermittent and why an earlier sweep of mine in 14 px steps found nothing — the step was wider than the failure.

Both builds produce an **identical state map** across x (transitions at 405, 408, 419, 420, 438, same hashes), so this removes the oscillation rather than moving it outside the scanned range. That control mattered: pinning the width could have shifted the geometry instead.

## The guard

`scripts/hover-stability.sh`, checked in as a third manual guard beside `scroll-regression.sh` and `visual-regression.sh`. It covers a failure neither can see, and the reason is worth stating: both of those sample *settled* states, which makes them structurally blind to a one-frame artifact (#140) — but an **oscillating** state never settles, so repeated captures at a fixed pointer position do land on different phases. #139 is reachable by capture exactly where #140 is not.

It samples two observables, because the report names two symptoms and both turned out to reproduce at the same pixel: the painted column, and the cursor shape through XFixes. Without `python-xlib` it degrades to the pixel half rather than failing.

**Verified in its checked-in form, both ways** — PASS on this build, FAIL on current `main` at exactly x=420. A guard that has only ever been seen green is not a guard.

## What this does not establish

Recorded in #139 rather than implied here:

- **Why the pointer one pixel outside the handle is involved.** The hot pixel does move with `SIDEBAR_RESIZE_GRAB_RADIUS` (8 → 420, 6 → 421), so the handle boundary is a participant — but I predicted a 2 px shift for a 2-unit radius change and got 1 px, so the handle rect is not simply `E ± r` and I did not chase it further.
- **Why the right-hand boundary never reproduced**, despite a *tighter* gutter (10 vs 12). 51 positions scanned there, zero instability. The asymmetry @RichardCao noticed is real and is not explained by gutter width, nor by the mechanism above.