### PR TITLE
fix(list): place markers from the item text's first-line layout (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to markdown-viewer will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **List markers sit on the optical centre of their item text (#196).** Text after a bullet or a number hung a little low: measured in the renderer harness, the dot's centre sat 6.18 px above the text baseline where the lowercase optical centre is 4.50 px up — about 1.7 px high. The cause was not the one the code assumed. The marker box resolved its line-height multiplier against `text_style_height` (the font's natural ≈1.2× height, so a 27.6 px box where the text's line box is 24 px), and the marker centred itself at `box bottom − raw/2`, a compensation tuned for a box offset rather than derived from text metrics — the boxes were 6 px apart at every edge, so nothing bottom-aligned. The direct fix made both markers worse, because shortening the box destroys the compensation while leaving the offset in place. egui anchors a wrapping label's galley at the cursor's top edge and sizes its first row from the cursor's height at label time, so a marker position computed before the item text exists is wrong by construction. The renderer now reserves the marker's slot in `start_item` and paints it immediately before the item's first text is laid out, reading the baseline from a reference galley laid out exactly as the label will be: the dot centres on `baseline − x-height/2` from the `x` glyph's own metrics, the ordered number keeps its baseline alignment through its own glyph metrics, and task checkboxes, inline images and wrapped first lines are handled because the position is computed after everything sharing the line has been allocated. Items whose first content is not text fall back to flushes at item start and item end. The vendored renderer moves to 0.28.2 with the same fix, and a painted-geometry test pins the marker to within a pixel of the optical centre across body sizes, pixel and multiplier line heights, checkboxes and wrapped items.
+
 ## [0.2.1] - 2026-09-10
 
 A short follow-up to 0.2.0: one link-handling feature, one silent failure made visible, and the viewport slicer's range selection made permanently observable.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -239,7 +239,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1233,7 +1233,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend_extended"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_extended"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "egui",
  "egui_commonmark_backend_extended",
@@ -1736,7 +1736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2531,7 +2531,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5116,7 +5116,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5534,7 +5534,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5717,7 +5717,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6378,7 +6378,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7072,7 +7072,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ egui = { version = "0.33", features = ["accesskit"] }
 # egui-mcp-bridge = { path = "/home/ahmet/dev/mcp/egui-mcp/crates/egui-mcp-bridge", optional = true }
 
 # Markdown rendering with syntax highlighting (fork with typography support)
-egui_commonmark_extended = { version = "0.28.1", features = [
+egui_commonmark_extended = { version = "0.28.2", features = [
     "better_syntax_highlighting",
     "svg",
     "svg_text",
@@ -92,5 +92,5 @@ lto = "thin"
 codegen-units = 4
 
 [patch.crates-io]
-egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark", version = "0.28.1" }
-egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend", version = "0.28.1" }
+egui_commonmark_extended = { path = "crates/egui_commonmark/egui_commonmark", version = "0.28.2" }
+egui_commonmark_backend_extended = { path = "crates/egui_commonmark/egui_commonmark_backend", version = "0.28.2" }

--- a/crates/egui_commonmark/CHANGELOG.md
+++ b/crates/egui_commonmark/CHANGELOG.md
@@ -1,5 +1,10 @@
 # egui_commonmark changelog
 
+## Unreleased
+
+### Fixed
+- List markers sit on the item text's lowercase optical centre. The dot was ~1.7 px high at a 16 px body with a 1.5× line height, and the ordered marker's alignment was a coincidence of two compensating errors: the marker box resolved its line-height multiplier against `text_style_height` (the font's natural ≈1.2× height, so 27.6 px where the text's line box is 24 px), and the marker centred itself at its own box's `bottom − raw/2` — a tuned compensation for a box offset, not a derivation from text metrics. egui anchors a wrapping label's galley at the cursor's top edge and sizes its first row from the cursor's height at label time, so no marker position computed before the item text exists can be exact. `start_item` now reserves the marker's slot and paints it right before the item's first text is laid out, deriving the baseline from a reference galley laid out exactly as the label will be; the dot centres on `baseline − x-height/2` from the `x` glyph's own metrics, and the ordered number stays baseline-aligned via its own glyph metrics. Items whose first content is not text (task checkboxes, code blocks, nested lists) are covered by flush points at item start, item end and nested-item start. The immediate `bullet_point`/`bullet_point_hollow`/`number_point` entries keep their signatures for the proc-macro path, which has no render state to defer with.
+
 ## 0.28.0
 
 ### Added

--- a/crates/egui_commonmark/Cargo.lock
+++ b/crates/egui_commonmark/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend_extended"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "data-url",
  "egui",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_extended"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "document-features",
  "eframe",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_macros_extended"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "document-features",
  "egui",

--- a/crates/egui_commonmark/Cargo.toml
+++ b/crates/egui_commonmark/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.89"
-version = "0.28.1"
+version = "0.28.2"
 repository = "https://github.com/aydiler/md-viewer"
 
 [workspace.dependencies]
@@ -21,8 +21,8 @@ egui = { version = "0.33", default-features = false }
 
 # Runtime lookup for recognized GitHub/gemoji shortcode names.
 emojis = "0.9.0"
-egui_commonmark_backend_extended = { version = "0.28.1", path = "egui_commonmark_backend", default-features = false }
-egui_commonmark_macros_extended = { version = "0.28.1", path = "egui_commonmark_macros", default-features = false }
+egui_commonmark_backend_extended = { version = "0.28.2", path = "egui_commonmark_backend", default-features = false }
+egui_commonmark_macros_extended = { version = "0.28.2", path = "egui_commonmark_macros", default-features = false }
 
 # To add features to documentation
 document-features = { version = "0.2" }

--- a/crates/egui_commonmark/egui_commonmark/src/lib.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/lib.rs
@@ -82,6 +82,9 @@
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 
 use egui::{self, Id};
+use egui_commonmark_backend_extended::elements::{
+    paint_list_marker, reserve_list_marker, ListMarkerKind, ListMarkerSlot,
+};
 
 #[cfg(feature = "svg")]
 mod mime_svg_loader;
@@ -597,6 +600,9 @@ pub(crate) struct ListLevel {
 pub(crate) struct List {
     items: Vec<ListLevel>,
     has_list_begun: bool,
+    /// Marker slots reserved by `start_item` but not painted yet, waiting for
+    /// the item's first line to be laid out.
+    pending_markers: Vec<(ListMarkerSlot, ListMarkerKind)>,
 }
 
 impl List {
@@ -621,6 +627,10 @@ impl List {
     }
 
     pub fn start_item(&mut self, ui: &mut egui::Ui, options: &CommonMarkOptions) {
+        // A nested list starts a new item before the outer item has painted any
+        // text; flush the outer marker here so it stays on its own row.
+        self.flush_pending_markers(ui, None);
+
         // To ensure that newlines are only inserted within the list and not before it
         if self.has_list_begun {
             newline(ui);
@@ -632,27 +642,53 @@ impl List {
         if let Some(item) = self.items.last_mut() {
             ui.label(" ".repeat((len - 1) * options.indentation_spaces));
 
-            // Match the marker box to the item text's line-height so the marker
-            // bottom-aligns with (and vertically centres on) the text.
-            let body_h = ui.text_style_height(&egui::TextStyle::Body);
-            let row_height = options
-                .typography
-                .resolve_line_height(body_h)
-                .unwrap_or(body_h);
+            // The marker's box must match the item text's line box, and the
+            // text's line height is resolved against the font size. Resolving
+            // against `text_style_height` (the font's natural ≈1.2× height)
+            // makes the box 27.6 px where the text's line box is 24 px at a
+            // 16 px body with a 1.5× line height — that mismatch is what pushed
+            // this line's glyphs down (issue #196).
+            let row_height = crate::parsers::pulldown::body_line_height(ui, options);
 
-            if let Some(number) = &mut item.current_number {
-                number_point(ui, &number.to_string(), row_height);
+            let slot = reserve_list_marker(ui, row_height);
+            let kind = if let Some(number) = &mut item.current_number {
+                let kind = ListMarkerKind::Number(number.to_string());
                 *number += 1;
+                kind
             } else if len > 1 {
-                bullet_point_hollow(ui, row_height);
+                ListMarkerKind::BulletHollow
             } else {
-                bullet_point(ui, row_height);
-            }
+                ListMarkerKind::Bullet
+            };
+
+            // The marker cannot be painted yet. egui anchors a wrapping label's
+            // galley at the cursor's top edge and sizes its first row from the
+            // cursor's height at label time, so anything that still joins this
+            // line — the task checkbox, inline images, the text itself — moves
+            // the text relative to this slot. Paint once the item's first text
+            // is about to be laid out (`flush_pending_markers`); items whose
+            // first content is not text are covered by the fallbacks.
+            self.pending_markers.push((slot, kind));
         } else {
             unreachable!();
         }
 
         ui.add_space(4.0);
+    }
+
+    /// Paint every reserved list marker that is still outstanding.
+    ///
+    /// `format` is the text format of the label the markers are being aligned
+    /// with; `None` falls back to the body style. Must be called right before
+    /// that label is laid out, with no widget in between, so the cursor egui
+    /// reads here is the cursor the label will read.
+    pub fn flush_pending_markers(&mut self, ui: &mut egui::Ui, format: Option<egui::TextFormat>) {
+        if self.pending_markers.is_empty() {
+            return;
+        }
+        for (slot, kind) in self.pending_markers.drain(..) {
+            paint_list_marker(ui, &slot, &kind, format.as_ref());
+        }
     }
 
     pub fn end_level(&mut self, ui: &mut egui::Ui, insert_newline: bool) {

--- a/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
+++ b/crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs
@@ -615,7 +615,7 @@ fn wrapped_text_height(ui: &Ui, text: &str, column_width: f32, line_height: f32)
     line_height * galley.rows.len().max(1) as f32
 }
 
-fn body_line_height(ui: &Ui, options: &CommonMarkOptions) -> f32 {
+pub(crate) fn body_line_height(ui: &Ui, options: &CommonMarkOptions) -> f32 {
     let font = egui::TextStyle::Body.resolve(ui.style());
     let natural = ui
         .text_style_height(&egui::TextStyle::Body)
@@ -2763,6 +2763,19 @@ impl CommonMarkViewerInternal {
         } else if self.is_table {
             ui.add(egui::Label::new(rich_text).wrap());
         } else {
+            // The item's first text decides where its deferred marker paints:
+            // mirror exactly the job `ui.label` is about to build (same format,
+            // same valign) so the marker's reference galley matches the real
+            // layout, and flush with no widget in between.
+            let mut job = egui::text::LayoutJob::default();
+            rich_text.clone().append_to(
+                &mut job,
+                ui.style(),
+                egui::FontSelection::Default,
+                ui.text_valign(),
+            );
+            let format = job.sections.first().map(|section| section.format.clone());
+            self.list.flush_pending_markers(ui, format);
             ui.label(rich_text);
         }
     }
@@ -3155,7 +3168,13 @@ impl CommonMarkViewerInternal {
                     self.list = List::default();
                 }
             }
-            pulldown_cmark::TagEnd::Item => {}
+            pulldown_cmark::TagEnd::Item => {
+                // The item is over without ever painting text — a code block,
+                // nested list or math block came first, say — so align its
+                // deferred marker with whatever line the content produced
+                // rather than leaving the reserved slot empty.
+                self.list.flush_pending_markers(ui, None);
+            }
             pulldown_cmark::TagEnd::FootnoteDefinition => {
                 self.line.should_start_newline = true;
                 self.line.should_end_newline = true;

--- a/crates/egui_commonmark/egui_commonmark/tests/list_marker_alignment.rs
+++ b/crates/egui_commonmark/egui_commonmark/tests/list_marker_alignment.rs
@@ -1,0 +1,240 @@
+//! Regression tests for list-marker vertical alignment (#196).
+//!
+//! Markers used to be placed from their own allocated box (`bottom - raw/2`),
+//! a compensation tuned at one set of font metrics. The measured result was a
+//! bullet dot ~1.7 px above the item text's lowercase optical centre at a 16 px
+//! body with a 1.5× line height. The fix derives the position from the item
+//! text's own first-line layout, so every test here pins painted geometry:
+//! the dot's centre must land within a pixel of `baseline − x-height/2`,
+//! computed from the first item-text glyph's own metrics (never a constant).
+
+use std::sync::Arc;
+
+use egui::{Context, Pos2, Shape, TextStyle};
+use egui_commonmark_extended::{CommonMarkCache, CommonMarkViewer};
+
+struct PaintedText {
+    text: String,
+    pos: Pos2,
+    galley: Arc<egui::Galley>,
+}
+
+struct PaintedDot {
+    centre: Pos2,
+}
+
+fn collect(shape: &Shape, texts: &mut Vec<PaintedText>, dots: &mut Vec<PaintedDot>) {
+    match shape {
+        Shape::Text(t) => texts.push(PaintedText {
+            text: t.galley.job.text.clone(),
+            pos: t.pos,
+            galley: t.galley.clone(),
+        }),
+        Shape::Circle(c) => dots.push(PaintedDot { centre: c.center }),
+        Shape::Vec(shapes) => {
+            for shape in shapes {
+                collect(shape, texts, dots);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// How the item text's line box is configured for a render.
+enum LineBox {
+    /// `CommonMarkViewer::line_height(multiplier)`
+    Multiplier(f32),
+    /// `CommonMarkViewer::line_height_px(pixels)`
+    Pixels(f32),
+}
+
+struct Render {
+    texts: Vec<PaintedText>,
+    dots: Vec<PaintedDot>,
+}
+
+fn render(markdown: &str, width: f32, body_size: f32, line_box: LineBox) -> Render {
+    let ctx = Context::default();
+    let mut style = (*ctx.style()).clone();
+    style
+        .text_styles
+        .insert(TextStyle::Body, egui::FontId::proportional(body_size));
+    ctx.set_style(style);
+
+    let mut cache = CommonMarkCache::default();
+    let mut out = Render {
+        texts: Vec::new(),
+        dots: Vec::new(),
+    };
+
+    // Two passes so font/layout caches settle; only final-pass geometry counts.
+    for pass in 0..2 {
+        out.texts.clear();
+        out.dots.clear();
+        let full = ctx.run(Default::default(), |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                ui.set_max_width(width);
+                let viewer = CommonMarkViewer::new();
+                let viewer = viewer
+                    .default_width(Some(width as usize))
+                    .table_max_width(Some(width as usize));
+                let viewer = match line_box {
+                    LineBox::Multiplier(m) => viewer.line_height(m),
+                    LineBox::Pixels(px) => viewer.line_height_px(px),
+                };
+                viewer.show(ui, &mut cache, markdown);
+            });
+        });
+        if pass == 1 {
+            for clipped in full.shapes {
+                collect(&clipped.shape, &mut out.texts, &mut out.dots);
+            }
+        }
+    }
+    out
+}
+
+/// The painted baseline of a text shape's first row.
+fn first_row_baseline(text: &PaintedText) -> f32 {
+    let row = text.galley.rows.first().expect("galleys are never empty");
+    let glyph = row.glyphs.first().expect("rows have glyphs");
+    text.pos.y + row.pos.y + glyph.pos.y
+}
+
+fn find_text<'a>(render: &'a Render, prefix: &str) -> &'a PaintedText {
+    render
+        .texts
+        .iter()
+        .find(|t| t.text.starts_with(prefix))
+        .unwrap_or_else(|| panic!("no painted text starting with {prefix:?}"))
+}
+
+/// Lowercase optical centre of an item text whose first glyph is an `x`:
+/// baseline minus half the glyph's own x-height. All item texts in these
+/// documents deliberately start with `x` so the metric comes from the painted
+/// shape itself rather than a constant.
+fn optical_centre_y(text: &PaintedText) -> f32 {
+    let row = text.galley.rows.first().expect("galleys are never empty");
+    let glyph = row.glyphs.first().expect("rows have glyphs");
+    let baseline = text.pos.y + row.pos.y + glyph.pos.y;
+    baseline - glyph.uv_rect.size.y / 2.0
+}
+
+#[track_caller]
+fn assert_dot_on_optical_centre(render: &Render, item_prefix: &str) {
+    let text = find_text(render, item_prefix);
+    let expected = optical_centre_y(text);
+    let dot = render
+        .dots
+        .iter()
+        .min_by(|a, b| {
+            (a.centre.y - expected)
+                .abs()
+                .total_cmp(&(b.centre.y - expected).abs())
+        })
+        .expect("the bullet paints a circle");
+    let error = (dot.centre.y - expected).abs();
+    assert!(
+        error <= 1.0,
+        "dot centre {:.2} vs lowercase optical centre {:.2} ({error:.2} px off, tolerance 1.0 px)",
+        dot.centre.y,
+        expected
+    );
+}
+
+/// Baseline-aligned ordered markers, not centre-aligned: a digit centred on
+/// the x-height midpoint would sink its baseline visibly below the text's.
+#[track_caller]
+fn assert_number_baseline_aligned(render: &Render, number: &str, item_prefix: &str) {
+    let number = find_text(render, number);
+    let item = find_text(render, item_prefix);
+    let error = (first_row_baseline(number) - first_row_baseline(item)).abs();
+    assert!(
+        error <= 1.0,
+        "number baseline {:.2} vs item text baseline {:.2} ({error:.2} px off, tolerance 1.0 px)",
+        first_row_baseline(number),
+        first_row_baseline(item)
+    );
+}
+
+#[test]
+fn bullet_dot_sits_on_lowercase_optical_centre() {
+    let render = render(
+        "Absatz.\n\n- xenial text\n",
+        600.0,
+        16.0,
+        LineBox::Multiplier(1.5),
+    );
+    assert_dot_on_optical_centre(&render, "xenial");
+}
+
+#[test]
+fn bullet_dot_matches_optical_centre_at_other_sizes_and_line_boxes() {
+    for (size, line_box) in [
+        (12.0, LineBox::Multiplier(1.5)),
+        (20.0, LineBox::Multiplier(1.5)),
+        (16.0, LineBox::Pixels(28.0)),
+        (16.0, LineBox::Pixels(20.0)),
+    ] {
+        let render = render("- xenial text\n", 600.0, size, line_box.clone());
+        assert_dot_on_optical_centre(&render, "xenial");
+    }
+}
+
+#[test]
+fn ordered_number_stays_baseline_aligned_with_item_text() {
+    let render = render(
+        "Absatz.\n\n1. xenon text\n",
+        600.0,
+        16.0,
+        LineBox::Multiplier(1.5),
+    );
+    assert_number_baseline_aligned(&render, "1.", "xenon");
+}
+
+#[test]
+fn bullet_aligns_after_a_task_checkbox() {
+    // The checkbox joins the line between the marker slot and the text, so the
+    // marker may only be positioned once the text is about to be laid out.
+    let render = render(
+        "Absatz.\n\n- [ ] xenial task\n",
+        600.0,
+        16.0,
+        LineBox::Multiplier(1.5),
+    );
+    assert_dot_on_optical_centre(&render, "xenial");
+}
+
+#[test]
+fn bullet_aligns_to_first_line_of_wrapped_item_text() {
+    // Narrow enough that the item text wraps; the marker belongs on row one.
+    let render = render(
+        "- xenial text that certainly wraps somewhere\n",
+        160.0,
+        16.0,
+        LineBox::Multiplier(1.5),
+    );
+    let text = find_text(&render, "xenial");
+    assert!(text.galley.rows.len() > 1, "expected the item text to wrap");
+    assert_dot_on_optical_centre(&render, "xenial");
+}
+
+#[test]
+fn hollow_bullet_of_nested_lists_aligns_the_same_way() {
+    let render = render(
+        "Absatz.\n\n- - xenial nested\n",
+        600.0,
+        16.0,
+        LineBox::Multiplier(1.5),
+    );
+    assert_dot_on_optical_centre(&render, "xenial");
+}
+
+impl Clone for LineBox {
+    fn clone(&self) -> Self {
+        match self {
+            LineBox::Multiplier(m) => LineBox::Multiplier(*m),
+            LineBox::Pixels(px) => LineBox::Pixels(*px),
+        }
+    }
+}

--- a/crates/egui_commonmark/egui_commonmark_backend/src/elements.rs
+++ b/crates/egui_commonmark/egui_commonmark_backend/src/elements.rs
@@ -53,60 +53,173 @@ pub fn newline(ui: &mut Ui) {
     ui.label("\n");
 }
 
-pub fn bullet_point(ui: &mut Ui, row_height: f32) {
-    // The list row is `Align::BOTTOM` and as tall as the item text, which carries
-    // the 1.5× accessibility line-height. Size the marker box to that same
-    // row_height so it bottom-aligns identically to the text; keep the dot radius
-    // tied to the raw glyph height so the marker size is unchanged. Without this,
-    // the marker box was only the raw font height and its centre sat above the
-    // text's optical centre (marker high, text low).
+/// One reserved list-marker slot. `List::start_item` reserves these before any
+/// item text exists; the slot is painted later, once the item's first line is
+/// about to be laid out (see [`paint_list_marker`]).
+#[derive(Debug, Clone)]
+pub struct ListMarkerSlot {
+    /// Horizontal centre for a bullet dot.
+    pub centre_x: f32,
+    /// Right edge an ordered marker's text aligns to.
+    pub right_x: f32,
+    /// The body style's natural painted height; the dot radius is `raw / 6`.
+    pub raw: f32,
+    /// The height the marker's box reserved. Doubles as the line-height hint
+    /// when a marker is painted without a text format.
+    pub box_height: f32,
+}
+
+/// Which glyph or shape paints into a reserved [`ListMarkerSlot`].
+#[derive(Debug, Clone)]
+pub enum ListMarkerKind {
+    Bullet,
+    BulletHollow,
+    Number(String),
+}
+
+/// Reserve the horizontal slot for a list marker without painting anything.
+///
+/// The reserved box is as tall as the item text's line box so the row grows to
+/// the same height either way; the vertical position is decided at paint time.
+pub fn reserve_list_marker(ui: &mut Ui, row_height: f32) -> ListMarkerSlot {
     let raw = height_body(ui);
+    let height = row_height.max(raw);
     let (rect, _) = ui.allocate_exact_size(
-        egui::vec2(width_body_space(ui) * 4.0, row_height.max(raw)),
+        egui::vec2(width_body_space(ui) * 4.0, height),
         Sense::hover(),
     );
-    ui.painter().circle_filled(
-        marker_center(rect, raw),
-        raw / 6.0,
-        ui.visuals().strong_text_color(),
-    );
+    ListMarkerSlot {
+        centre_x: rect.center().x,
+        right_x: rect.right(),
+        raw,
+        box_height: height,
+    }
+}
+
+/// Paint a reserved marker so it lands on the item text's first line.
+///
+/// `format` is the text format the item text will be laid out with — taken from
+/// the label's job immediately before `ui.label` runs. `None` falls back to the
+/// body style with the marker's own reserved line box.
+///
+/// The marker's centre is the text's lowercase optical centre: the baseline of
+/// a reference `x` glyph (laid out under the same conditions egui will lay out
+/// the item text) minus half the glyph's x-height. That derivation has to live
+/// at paint time: egui anchors a wrapping label's galley at the cursor's top
+/// edge and gives the first row the cursor's current height as a minimum
+/// (`Label::layout_in_ui`), so every widget sharing the marker's line — task
+/// checkboxes, inline images — moves the text, and the marker must move with it.
+pub fn paint_list_marker(
+    ui: &Ui,
+    slot: &ListMarkerSlot,
+    kind: &ListMarkerKind,
+    format: Option<&egui::TextFormat>,
+) {
+    let (baseline_y, x_height) = first_line_baseline(ui, slot, format);
+    let optical_centre_y = baseline_y - x_height / 2.0;
+    let color = ui.visuals().strong_text_color();
+    match kind {
+        ListMarkerKind::Bullet => {
+            ui.painter().circle_filled(
+                egui::pos2(slot.centre_x, optical_centre_y),
+                slot.raw / 6.0,
+                color,
+            );
+        }
+        ListMarkerKind::BulletHollow => {
+            ui.painter().circle(
+                egui::pos2(slot.centre_x, optical_centre_y),
+                slot.raw / 6.0,
+                egui::Color32::TRANSPARENT,
+                egui::Stroke::new(0.6_f32, color),
+            );
+        }
+        ListMarkerKind::Number(number) => {
+            // Ordered markers are glyphs, so they read as aligned when their
+            // baseline matches the item text's baseline; anchoring their box
+            // centre on the lowercase optical centre would sink them below it.
+            let numbered = format!("{number}.");
+            let font = format
+                .map(|f| f.font_id.clone())
+                .unwrap_or_else(|| TextStyle::Body.resolve(ui.style()));
+            let galley = ui.painter().layout_no_wrap(numbered, font, color);
+            let Some(row) = galley.rows.first() else {
+                return;
+            };
+            let Some(glyph) = row.glyphs.first() else {
+                return;
+            };
+            let baseline_offset = row.pos.y + glyph.pos.y;
+            let pos = egui::pos2(slot.right_x - galley.size().x, baseline_y - baseline_offset);
+            ui.painter().add(epaint::TextShape::new(pos, galley, color));
+        }
+    }
+}
+
+/// Where the item text's first line will paint its baseline, and how tall a
+/// lowercase `x` is under that format, both in ui coordinates.
+///
+/// The reference galley reproduces what `Label::layout_in_ui` does to the job
+/// it lays out on a wrapping horizontal row: `first_row_min_height` from the
+/// cursor's current height, `valign` from the layout, and the format's own
+/// line height. The row box that drives glyph placement is
+/// `max(cursor height, line height)` — so this must run after every widget
+/// sharing the marker's line has been allocated, right before the text's own
+/// label.
+fn first_line_baseline(
+    ui: &Ui,
+    slot: &ListMarkerSlot,
+    format: Option<&egui::TextFormat>,
+) -> (f32, f32) {
+    let cursor_top = ui.cursor().top();
+    let mut format = format.cloned().unwrap_or_else(|| egui::TextFormat {
+        font_id: TextStyle::Body.resolve(ui.style()),
+        line_height: Some(slot.box_height),
+        ..egui::TextFormat::default()
+    });
+    format.valign = ui.text_valign();
+    let job = egui::text::LayoutJob {
+        text: "x".to_owned(),
+        sections: vec![egui::text::LayoutSection {
+            leading_space: 0.0,
+            byte_range: 0..1,
+            format,
+        }],
+        first_row_min_height: ui.cursor().height(),
+        halign: egui::Align::LEFT,
+        justify: false,
+        wrap: egui::text::TextWrapping::default(),
+        ..egui::text::LayoutJob::default()
+    };
+    let galley = ui.fonts_mut(|fonts| fonts.layout_job(job));
+    let row = galley.rows.first().expect("galleys are never empty");
+    let glyph = row
+        .glyphs
+        .first()
+        .expect("a one-character job lays out one glyph");
+    let baseline_offset = row.pos.y + glyph.pos.y;
+    (cursor_top + baseline_offset, glyph.uv_rect.size.y)
+}
+
+/// Reserve and immediately paint a bullet marker.
+///
+/// The code generated by `egui_commonmark_macros` has no render state to defer
+/// a paint with, so it cannot wait for the item text's layout. Positioning from
+/// the live cursor is still exact whenever the item text directly follows the
+/// marker on the same line.
+pub fn bullet_point(ui: &mut Ui, row_height: f32) {
+    let slot = reserve_list_marker(ui, row_height);
+    paint_list_marker(ui, &slot, &ListMarkerKind::Bullet, None);
 }
 
 pub fn bullet_point_hollow(ui: &mut Ui, row_height: f32) {
-    let raw = height_body(ui);
-    let (rect, _) = ui.allocate_exact_size(
-        egui::vec2(width_body_space(ui) * 4.0, row_height.max(raw)),
-        Sense::hover(),
-    );
-    ui.painter().circle(
-        marker_center(rect, raw),
-        raw / 6.0,
-        egui::Color32::TRANSPARENT,
-        egui::Stroke::new(0.6_f32, ui.visuals().strong_text_color()),
-    );
+    let slot = reserve_list_marker(ui, row_height);
+    paint_list_marker(ui, &slot, &ListMarkerKind::BulletHollow, None);
 }
 
 pub fn number_point(ui: &mut Ui, number: &str, row_height: f32) {
-    let raw = height_body(ui);
-    let (rect, _) = ui.allocate_exact_size(
-        egui::vec2(width_body_space(ui) * 4.0, row_height.max(raw)),
-        Sense::hover(),
-    );
-    ui.painter().text(
-        egui::pos2(rect.right(), marker_center(rect, raw).y),
-        egui::Align2::RIGHT_CENTER,
-        format!("{number}."),
-        TextStyle::Body.resolve(ui.style()),
-        ui.visuals().strong_text_color(),
-    );
-}
-
-/// Vertical centre for a list marker inside a `row_height`-tall, bottom-aligned box.
-/// egui lays a `line_height`-boosted galley with the glyph near the bottom of the
-/// line box (extra leading above), so the text's optical centre is one raw
-/// half-height up from the row bottom — match the marker to that, not the box centre.
-fn marker_center(rect: egui::Rect, raw: f32) -> egui::Pos2 {
-    egui::pos2(rect.center().x, rect.bottom() - raw / 2.0)
+    let slot = reserve_list_marker(ui, row_height);
+    paint_list_marker(ui, &slot, &ListMarkerKind::Number(number.to_owned()), None);
 }
 
 #[inline]

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1671,3 +1671,20 @@ comm -13 /tmp/main.txt /tmp/a.txt   # added by the branch
 An empty first list is the assertion worth making. It also explains rises in the *ignored* count without alarm — #119's two new `system_fonts` tests are skipped for want of installed fonts, exactly like the existing CJK one.
 
 **Files:** N/A (verification discipline)
+
+### On a wrapping row, nothing about a label's position is knowable before the label runs
+**Context:** #196 — list markers sat ~1.7 px above the item text's lowercase optical centre. The marker code centred itself on its own allocated box (`bottom − raw/2`), which the comment described as bottom-alignment compensation. Measurement showed the marker box and the text galley shared neither top nor bottom edge — they were 6.00 px apart at *every* edge, so the compensation was compensating for a box offset, not aligning anything.
+
+**Root cause, in egui's layout:** on `Layout::left_to_right(Align::BOTTOM).with_main_wrap(true)`, `ui.label` does not use the row's bottom alignment at all. `Label::layout_in_ui` has a special path for wrapping horizontal layouts: it lays the text as a full-width galley anchored at `pos2(max_rect.left, cursor.top)`, and sets `first_row_min_height = cursor.height()` **at label time**. Inside the galley, glyphs are then pushed to the bottom of the row box (`valign` factor × the row height minus the format's line height). Two consequences:
+
+1. Every widget allocated earlier on the line — the marker's own box, a task checkbox, an inline image — inflates `cursor.height()` and pushes the text down. The marker's oversized box (line height resolved against `text_style_height` ≈1.2× size instead of the font size: 27.6 px vs 24 px) was itself what moved the text.
+2. A marker position computed at slot-reservation time is wrong by construction. `Rect::bottom()` of an allocation says nothing about where a later label will paint.
+
+**Fix:** reserve the slot in `start_item`, paint later. The renderer flushes deferred markers immediately before the item's first `ui.label`, and the position comes from a *reference galley*: a one-character `"x"` job laid out with the label's own `TextFormat` (taken from the job `append_to` builds, `valign` overridden to `ui.text_valign()`) and the same `first_row_min_height` the label will see. egui performs its own arithmetic on the reference; the code only reads back `glyph.pos.y` (baseline) and `glyph.uv_rect.size.y` (x-height) and centres the dot on `baseline − x_height/2`. Delegating the math beats re-deriving it: the formula (`font_impl_ascent + valign × (row_height − glyph.line_height) + ½(font_height − font_impl_height)`, plus pixel rounding) has inputs that are not all public.
+
+**Corollaries:**
+- Compensations can cancel to near-zero and read as "aligned": the ordered marker landed 0.18 px from the text baseline through *two* stacked errors (oversized box + `RIGHT_CENTER` re-centring). A coincidence at today's metrics is not a derivation; the acceptance test has to pin the mechanism's quantity (dot centre vs x-glyph optical centre), not today's residuals.
+- Flush points for deferred paints need every path the renderer can take between slot and first text: nested `start_item`, non-text-first content (code block, math, buffered link/image text via `TagEnd::Item`), and the text path itself. The reference-galley fallback with `None` keeps those markers painted, if with a stale cursor.
+- `misc.rs` already documented the `text_style_height` vs font-size distinction for inline math ("formulas ~1 px low"); the marker path is the second instance. When a renderer constant reads like a fudge factor, grep the lessons before tuning it again.
+
+**Files:** `crates/egui_commonmark/egui_commonmark_backend/src/elements.rs` (`reserve_list_marker`, `paint_list_marker`, `first_line_baseline`), `crates/egui_commonmark/egui_commonmark/src/lib.rs` (`List::start_item`, `flush_pending_markers`), `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs` (`emit_text` flush, `TagEnd::Item` fallback), `crates/egui_commonmark/egui_commonmark/tests/list_marker_alignment.rs`


### PR DESCRIPTION
Fixes #196.

## What was wrong, as measured

The issue's report reproduced exactly in the renderer harness (16 px body, `line_height(1.5)`): the bullet dot's centre sat 6.18 px above the text baseline where the lowercase optical centre is 4.50 px up — **1.68 px high**. But neither of the two placements the code performs is derived from text metrics:

| quantity | value | what it should be |
|---|---|---|
| marker box height | `1.5 × text_style_height` = 27.56 px | `1.5 × font size` = 24.00 px (`misc.rs` already documents this exact distinction for inline math) |
| marker centre | `own box bottom − raw/2` | an offset compensation, tuned when #046 landed |

The marker box and the text galley shared **neither** edge — 6.00 px apart at top *and* bottom — so the box never bottom-aligned with anything, and `bottom − raw/2` was compensating for that box offset rather than deriving the position.

## Why the direct fix made both markers worse

Reproduced in the issue and confirmed here: correcting the multiplier shortens the box, which destroys the compensation `bottom − raw/2` was providing, while the underlying offset stays. Ordered markers went 0.18 → 4.59 px off; the dot 6.18 → 10.59 px. The two errors were cancelling; removing one exposed the other.

## The mechanic the issue's option 2 missed

egui's `Label::layout_in_ui` has a special path for wrapping horizontal rows (our list row layout): it does **not** use the row's bottom alignment. It lays the text as a full-width galley anchored at `(max_rect.left, cursor.top)` and sets `first_row_min_height = cursor.height()` **at label time** — so every widget allocated earlier on the line (the marker's own box, a task checkbox, an inline image) moves the text, and glyphs are then pushed toward the bottom of the resulting row box (`valign` × (row height − line height)).

Consequence: **a marker position computed before the item text exists is wrong by construction.** That is the issue's option 1, and this implements it — with one addition that removes the need to re-derive egui's arithmetic (`font_impl_ascent + valign × (row_height − glyph.line_height) + ½(font_height − font_impl_height)`, then pixel rounding — not all inputs public).

## The fix

- `List::start_item` **reserves** the marker slot (allocation geometry unchanged) and records it; painting is deferred.
- The renderer **flushes** deferred markers immediately before the item's first `ui.label`, taking the label's own `TextFormat` from the job `append_to` builds. The vertical position comes from a **reference galley**: a one-character `"x"` job laid out with that format and `first_row_min_height = cursor.height()` — exactly what `Label` will do. egui performs its own arithmetic; the code reads back `glyph.pos.y` (baseline) and `glyph.uv_rect.size.y` (x-height) and centres the dot on `baseline − x_height/2`.
- The ordered number is **baseline**-aligned through its own laid-out galley — a digit centred on the x-height midpoint would sink visibly below the text baseline. (Today's 0.18 px ordered agreement was the two errors cancelling; the mechanism is now pinned instead of the residual.)
- Fallback flushes cover non-text-first items (code block, math, buffered link/image text): nested `start_item` and `TagEnd::Item`.
- `bullet_point` / `bullet_point_hollow` / `number_point` keep their signatures for the `egui_commonmark_macros` generated code, which has no render state to defer with — they now position from the live cursor via the same reference galley.

## Verified

The acceptance criterion from the issue is pinned as painted geometry: the dot's centre within a pixel of the item text's `x`-glyph optical centre, computed from the painted shapes (never a constant). Residual error after the fix: **0.00 px** — the reference galley's baseline matches the real text's painted glyph exactly.

`tests/list_marker_alignment.rs` covers: the issue's config, other body sizes (12/20 px), pixel line heights (20/28 px), task checkboxes (the widget between slot and text), wrapped item text (marker on row one), nested hollow bullets, and ordered-number baseline alignment.

```
fork workspace (default):            165 passed
fork viewer crate (CI feature set):  136 passed
app workspace:                        67 passed
check-workspace-sync.sh:              synchronized at renderer 0.28.2
```

The vendored fork moves to **0.28.2** (must publish before the next md-viewer tag, per the release runbook lesson).