### PR TITLE
feat(fonts): port font presets and text-size classes to Fontique

### DIFF
--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1699,3 +1699,12 @@ An empty first list is the assertion worth making. It also explains rises in the
 2. `ScrollArea::id_salt(id_salt: impl Hash)` wraps its argument in `Id::new` — pass an already-hashed `Id` and it is hashed *again*. Computing the persistent id as `ui.make_persistent_id(scroll_id)` therefore does not match the state egui stores under `.id_salt(scroll_id)`; mirror the re-hash: `ui.make_persistent_id(Id::new(scroll_id))`.
 
 **Files:** `crates/egui_commonmark/egui_commonmark/tests/scroll_offset_beyond_extent.rs`, `crates/egui_commonmark/egui_commonmark/src/parsers/pulldown.rs` (`show_scrollable` pre-selection clamp)
+
+---
+
+### egui silently skips set_fonts when definitions compare equal
+**Context:** Font presets GitHub and VS Code appeared to "not switch" between each other while both switched to/from Default fine.
+**Problem:** `Context::set_fonts` diffs the new `FontDefinitions` against the installed ones (comparing TTF data) and returns early on equality (`egui-0.33.3 context.rs:1968`). Two presets whose CSS stacks resolve to the same installed faces — the normal case on stock Linux, where GitHub's and VS Code's stacks both end up at Adwaita Sans + Noto Sans Mono — produce byte-identical definitions, so nothing re-renders.
+**Fix:** Give presets differences beyond family resolution: per-preset base body size (GitHub 16px vs VS Code preview 14px) applied to `TextStyle::Body`/`Heading`/`Monospace`, and preset-driven renderer line heights (GitHub 1.5/1.45, VS Code 1.6/1.36). The renderer derives all document sizes from `TextStyle::Body`, so one style entry cascades everywhere.
+**Gotchas:** Don't scale `TextStyle::Small` — it sizes chrome controls. State/checkmark UI updating is not evidence fonts changed: assert against `fonts(|f| f.definitions().clone())` or rendered metrics in tests.
+**Files:** `src/system_fonts.rs`, `src/main.rs`

--- a/docs/devlog/055-font-presets.md
+++ b/docs/devlog/055-font-presets.md
@@ -1,0 +1,178 @@
+# Feature: Markdown Font Presets (Default / GitHub / VS Code)
+
+**Status:** ✅ Complete
+**Branch:** `feature/font-presets`
+**Date:** 2026-08-23
+**Lines Changed:** +~230 / -~20 in `src/system_fonts.rs`, `src/main.rs`
+
+## Summary
+
+Adds a **View → Fonts** menu with three presets that switch which markdown
+viewer's font choices lead the app's font chains:
+
+- **Default** – the app's current look (best installed sans + bundled mono).
+- **GitHub** – emulates github.com rendered markdown (Primer `.markdown-body`).
+- **VS Code** – emulates the VS Code markdown preview defaults.
+
+The choice persists across sessions and hot-swaps at runtime via
+`egui::Context::set_fonts`.
+
+## Features
+
+- [x] `FontPreset` enum (`Current`, `Github`, `Vscode`) with serde persistence
+- [x] Preset body families lead the primary sans chain (bold/strong follows
+      automatically because `MarkdownStrong` resolves from the primary family)
+- [x] Preset code families lead the monospace chain (all inline/block code)
+- [x] View menu section with ✓ marks, hover explanations, MCP registration
+- [x] Graceful fallback: missing preset faces degrade to the existing chain
+- [x] Per-preset line heights (GitHub 1.5/1.45, VS Code 1.6/1.36); base size
+      is no longer a preset property
+- [x] Shared text-size classes applying to every preset: Small 14 / Normal 16
+      (default) / Large 18 / Extra large 20 / Huge 24, selectable in
+      View → Fonts ▸ with ✓ marks; persisted via
+      `PersistedState.text_size_class`
+- [x] Unit tests for stack contents and resolution order
+- [x] Zoom hygiene: multiplicative steps (×1.25) shared by keyboard, menu,
+      and Ctrl+wheel/pinch via one `zoomed()` helper; redundant per-frame
+      `set_zoom_factor` writes skipped via `last_applied_zoom_level`
+
+## Research: exact fonts used by the emulated viewers
+
+### GitHub (verified against live github.githubassets.com CSS + Primer source)
+
+Effective `.markdown-body` stack (Primer primitives token
+`--fontStack-sansSerif`; Mona Sans was prepended 2026-03 in
+primer/primitives#1332):
+
+```css
+"Mona Sans VF", -apple-system, BlinkMacSystemFont, "Segoe UI",
+"Noto Sans Backtick Fix", "Noto Sans", Helvetica, Arial, sans-serif,
+"Apple Color Emoji", "Segoe UI Emoji"
+/* font-size:16px; line-height:1.5 */
+```
+
+Code (`--fontStack-monospace`, applied to `code/tt/samp/pre/kbd`):
+`ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono,
+monospace` (85% size for code/pre).
+
+GitHub ships **no webfont** for markdown; "Noto Sans Backtick Fix" is a
+`local()`-only `@font-face` shim covering only U+60, so it is skipped in our
+emulation. "Mona Sans VF" renders only where installed locally
+(github/mona-sans).
+
+### VS Code markdown preview
+
+Verified from microsoft/vscode source AND the locally installed v1.127 files
+under `/usr/lib/code/extensions/markdown-language-features/media/markdown.css`:
+
+```css
+html, body { font-family: var(--markdown-font-family,
+  -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", system-ui,
+  "Ubuntu", "Droid Sans", sans-serif);
+  font-size: var(--markdown-font-size, 14px); }
+code { font-family: var(--vscode-editor-font-family,
+  "SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono",
+  "DejaVu Sans Mono", "Courier New", monospace); }
+```
+
+Inside VS Code the variable is always injected: Linux `editor.fontFamily`
+default is `'Droid Sans Mono', monospace` (`fontInfo.ts`), so that is the
+effective code stack we emulate.
+
+## Key Discoveries
+
+### Discovery 1: fontdb does not apply fontconfig aliases
+
+`fontdb` matches literal family names only. Browsers on this machine resolve
+`"Segoe UI"` to **Adwaita Sans** (fontconfig substitution) and generic
+`monospace` to **Noto Sans Mono**, but our resolver would miss both. The preset
+lists therefore transcribe CSS-generic keywords into their common Linux
+resolutions:
+
+- `"Adwaita Sans"` sits directly after `"Segoe UI"` (and system-ui proxies:
+  Adwaita Sans → Cantarell).
+- GitHub's leading `ui-monospace` becomes Noto Sans Mono / DejaVu Sans Mono
+  (they lead the list, mirroring resolution order on Linux browsers).
+- `-apple-system` / `BlinkMacSystemFont` are macOS-only keywords → skipped.
+
+### Discovery 2: one insertion point per chain covers everything
+
+- Body: the primary `SystemSans` spec just resolves against the preset's list;
+  CJK/script fallbacks and the strong/bold family keep working unchanged
+  because they hang off the resolved primary family name.
+- Code: inserting `PresetMono` at index 0 of `FontFamily::Monospace` switches
+  every code span (renderer uses `RichText::code()` → Monospace style).
+- Strong inline code intentionally keeps the mono face (#39 lesson).
+
+### Discovery 3: runtime font switching needs no cache
+
+`setup_fonts(ctx, preset)` rebuilds `FontDefinitions` from a fresh `fontdb`
+scan (~tens of ms) — fine for an occasional menu toggle, avoids caching font
+bytes per preset. `ctx.set_fonts` re-tessellates automatically.
+
+### Discovery 4: set_fonts skips identical definitions — presets need metrics
+
+`Context::set_fonts` diffs against installed definitions (TTF-data equality)
+and returns early on match. On stock Linux, GitHub and VS Code stacks resolve
+to the *same* faces (Adwaita Sans + Noto Sans Mono), so GitHub ↔ VS Code
+switching was visually a no-op even though state updated. Fix: presets now
+also carry the viewers' typography metrics — base body size (16px vs 14px,
+applied to `TextStyle::Body`/`Heading`/`Monospace`; the renderer derives every
+document size from Body) and renderer line heights (GitHub 1.5/1.45, VS Code
+1.6/1.36). See LESSONS.md.
+
+## Architecture
+
+### New/Modified Types
+
+```rust
+// src/system_fonts.rs
+pub(crate) enum FontPreset { #[default] Current, Github, Vscode }
+//   ALL, label(), description(), body_families(), mono_families()
+const GITHUB_BODY_FAMILIES / GITHUB_MONO_FAMILIES
+const VSCODE_BODY_FAMILIES / VSCODE_MONO_FAMILIES
+```
+
+`PersistedState.font_preset: Option<FontPreset>` and
+`MarkdownApp.font_preset: FontPreset` persist the choice.
+
+### Modified Functions
+
+| Function | Change |
+|----------|--------|
+| `setup_fonts(ctx, preset)` | New param; installs preset faces then `set_fonts` |
+| `install_regular_fonts(..., preset_body_families)` | Primary spec resolves preset list first; falls back to app defaults if none installed |
+| `install_preset_mono_font(db, fonts, preset)` | New; front-inserts the first installed preset code face |
+
+### UI
+
+View menu, between Full Width and Zoom: `Fonts: Default | GitHub | VS Code`
+with ✓ mark, hover description, and MCP ids
+`Menu: View → Font Preset: <label>` for E2E testing.
+
+## Testing Notes
+
+Unit tests cover: stack ordering vs the real CSS stacks (Mona Sans head,
+system-ui before Ubuntu), Linux monospace resolutions leading, GitHub
+preferring its stack over the app default, fallback when no preset face is
+installed, first-installed-face-wins selection, and a RON persistence
+roundtrip through an in-memory `eframe::Storage` mock (incl. legacy state
+without the field).
+
+Live verification on Arch/GNOME (`RUST_LOG=info`): Default keeps Noto Sans +
+bundled mono; GitHub resolves body → **Adwaita Sans** (Segoe UI fontconfig
+substitution) + code → **Noto Sans Mono**; VS Code resolves identically on
+this box (faithful — both stacks converge on stock Linux; they diverge where
+Mona Sans/Arial/Ubuntu/Droid Sans are installed). The `--ignored` test
+`presets_reorder_the_applied_font_chains` asserts the GitHub preset installs
+`PresetMono` at the monospace chain head while Current does not.
+
+Known emulation limits: fontconfig aliasing can differ per distro, so lists
+encode the common cases. Family-level differences between GitHub and VS Code
+only appear where their named faces (Mona Sans, Arial, Ubuntu, Droid Sans
+Mono…) are installed; on stock Linux the presets are distinguished by their
+metrics instead.
+
+## Future Improvements
+
+- [ ] Custom font family picker on top of the presets

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 mod system_fonts;
-use system_fonts::setup_fonts;
+use system_fonts::{setup_fonts, FontPreset, TextSizeClass};
 
 #[cfg(feature = "mcp")]
 use egui_mcp_bridge::{McpBridge, McpUiExt};
@@ -319,6 +319,23 @@ fn pick_folder(initial_dir: Option<&Path>) -> Result<Option<PathBuf>, String> {
     }
 }
 
+/// Display-zoom bounds and step, shared by keyboard, menu, and Ctrl+wheel
+/// zooming. Steps are multiplicative so the perceived change stays uniform
+/// across the whole range (like browsers and the lightbox already do).
+const ZOOM_MIN: f32 = 0.5;
+const ZOOM_MAX: f32 = 3.0;
+const ZOOM_STEP: f32 = 1.25;
+
+/// One multiplicative zoom step applied to `current`, clamped to the app's
+/// zoom bounds. Neutral, non-finite, or non-positive factors are no-ops —
+/// egui reports `zoom_delta() == 1.0` on frames without a zoom gesture.
+fn zoomed(current: f32, factor: f32) -> f32 {
+    if !factor.is_finite() || factor <= 0.0 || (factor - 1.0).abs() < 1e-3 {
+        return current.clamp(ZOOM_MIN, ZOOM_MAX);
+    }
+    (current * factor).clamp(ZOOM_MIN, ZOOM_MAX)
+}
+
 /// A recently opened file, for the welcome page's "Recent" list.
 #[derive(Serialize, Deserialize, Clone)]
 struct RecentEntry {
@@ -391,6 +408,10 @@ struct PersistedState {
     /// today's behavior; `Some(true)` trades a touch of sharpness for glyphs
     /// that no longer look unevenly spaced at fractional zoom levels.
     smooth_text_rendering: Option<bool>,
+    /// Which markdown viewer's font choices lead the font chains.
+    font_preset: Option<FontPreset>,
+    /// Shared text-size class; `None` keeps the Normal default.
+    text_size_class: Option<TextSizeClass>,
     open_tabs: Option<Vec<PathBuf>>,
     active_tab: Option<usize>,
     // File explorer state
@@ -2040,8 +2061,9 @@ struct MarkdownApp {
     // frame it's open (see docs/EGUI_WORKFLOW.md: never allocate in the
     // render loop what can be cached).
     available_font_families_lower: Vec<String>,
-    // Mirrors `last_applied_dark_mode`: only reload fonts when this changes.
-    last_applied_font_family: Option<String>,
+    // Mirrors the font setup inputs (picked family, preset, size class): only
+    // reload fonts when this tuple changes.
+    last_applied_font_config: Option<(Option<String>, FontPreset, TextSizeClass)>,
     show_font_dialog: bool,
     // Transient UI-only search text for the font picker (not persisted).
     font_filter: String,
@@ -2049,6 +2071,10 @@ struct MarkdownApp {
     // every frame (see ctx.set_zoom_factor below) since it's a single write
     // into egui's own memory, not worth a last-applied change-gate.
     smooth_text_rendering: bool,
+    // Which markdown viewer's font choices lead the font chains.
+    font_preset: FontPreset,
+    // Shared text-size class across all presets.
+    text_size_class: TextSizeClass,
     watch_enabled: bool,
     error_message: Option<String>,
     is_dragging: bool,
@@ -2078,6 +2104,8 @@ struct MarkdownApp {
     egui_ctx: egui::Context,
     // Track state to avoid unconditional repaints
     last_applied_dark_mode: Option<bool>,
+    // Last zoom level handed to set_zoom_factor; skips redundant writes
+    last_applied_zoom_level: Option<f32>,
     last_window_title: String,
     title_dirty: bool,
     /// Cached set of open tab paths for file explorer highlighting (avoids per-frame syscalls)
@@ -2102,15 +2130,24 @@ struct MarkdownApp {
 impl MarkdownApp {
     fn new(cc: &eframe::CreationContext<'_>, file: Option<PathBuf>, watch: bool) -> Self {
         // Load persisted state (needed before font setup, which reads the
-        // persisted font preference)
+        // persisted font family, preset, and text-size class).
         let persisted: PersistedState = cc
             .storage
             .and_then(|s| eframe::get_value(s, APP_KEY))
             .unwrap_or_default();
         let selected_font_family = persisted.selected_font_family;
+        let font_preset = persisted.font_preset.unwrap_or_default();
+        let text_size_class = persisted.text_size_class.unwrap_or_default();
 
-        // Setup fonts with system font fallbacks for Unicode support
-        let available_font_families = setup_fonts(&cc.egui_ctx, selected_font_family.as_deref());
+        // Setup fonts with system font fallbacks for Unicode support, led by
+        // the user's picked family (font picker) or the preset's emulated
+        // stack; the text-size class is shared by every preset.
+        let available_font_families = setup_fonts(
+            &cc.egui_ctx,
+            selected_font_family.as_deref(),
+            font_preset,
+            text_size_class,
+        );
         let available_font_families_lower: Vec<String> = available_font_families
             .iter()
             .map(|name| name.to_ascii_lowercase())
@@ -2283,13 +2320,19 @@ impl MarkdownApp {
             show_color_settings_dialog: false,
             // Already applied above via setup_fonts(); last_applied starts in
             // sync so update() doesn't redundantly reload fonts on frame 1.
-            last_applied_font_family: selected_font_family.clone(),
+            last_applied_font_config: Some((
+                selected_font_family.clone(),
+                font_preset,
+                text_size_class,
+            )),
             selected_font_family,
             available_font_families,
             available_font_families_lower,
             show_font_dialog: false,
             font_filter: String::new(),
             smooth_text_rendering,
+            font_preset,
+            text_size_class,
             watch_enabled: watch,
             error_message: startup_error,
             is_dragging: false,
@@ -2307,6 +2350,7 @@ impl MarkdownApp {
             is_virtual_display,
             egui_ctx: cc.egui_ctx.clone(),
             last_applied_dark_mode: None,
+            last_applied_zoom_level: None,
             last_window_title: String::new(),
             title_dirty: true,
             open_tab_paths: HashSet::new(),
@@ -3712,6 +3756,9 @@ impl MarkdownApp {
                 let default_width = content_default_width(self.full_width_content);
                 let content_width =
                     content_width_limit(self.full_width_content, content_rect.width());
+                // Line heights follow the emulated viewer (GitHub 1.5/1.45,
+                // VS Code preview 1.6/1.36); the font preset owns the metrics.
+                let (preset_line_height, preset_code_line_height) = self.font_preset.line_heights();
                 let mut scroll_output = CommonMarkViewer::new()
                     .default_implicit_uri_scheme(&tab.base_uri)
                     .max_image_width(Some(800))
@@ -3731,8 +3778,8 @@ impl MarkdownApp {
                     .show_alt_text_on_hover(true)
                     .syntax_theme_dark("base16-ocean.dark")
                     .syntax_theme_light("base16-ocean.light")
-                    .line_height(1.5)
-                    .code_line_height(1.3)
+                    .line_height(preset_line_height)
+                    .code_line_height(preset_code_line_height)
                     .paragraph_spacing(2.0)
                     .heading_spacing_above(2.0)
                     .heading_spacing_below(0.75)
@@ -4649,6 +4696,8 @@ impl eframe::App for MarkdownApp {
             link_color: self.link_color.map(|c| [c.r(), c.g(), c.b(), c.a()]),
             selected_font_family: self.selected_font_family.clone(),
             smooth_text_rendering: Some(self.smooth_text_rendering),
+            font_preset: Some(self.font_preset),
+            text_size_class: Some(self.text_size_class),
             open_tabs: Some(self.get_open_tab_paths()),
             active_tab: Some(self.active_tab),
             show_explorer: Some(self.show_explorer),
@@ -4738,15 +4787,32 @@ impl eframe::App for MarkdownApp {
             ctx.set_visuals(visuals);
         }
 
-        // Reload fonts only when the selected family actually changes —
-        // rescanning the system font collection on every frame would be
-        // expensive and is unnecessary (see docs/EGUI_WORKFLOW.md).
-        if self.last_applied_font_family != self.selected_font_family {
-            self.last_applied_font_family = self.selected_font_family.clone();
-            setup_fonts(ctx, self.selected_font_family.as_deref());
+        // Reload fonts only when the selected family, preset, or size class
+        // actually changes — rescanning the system font collection on every
+        // frame would be expensive and is unnecessary (see
+        // docs/EGUI_WORKFLOW.md).
+        let font_config = (
+            self.selected_font_family.clone(),
+            self.font_preset,
+            self.text_size_class,
+        );
+        if self.last_applied_font_config.as_ref() != Some(&font_config) {
+            self.last_applied_font_config = Some(font_config.clone());
+            setup_fonts(
+                ctx,
+                self.selected_font_family.as_deref(),
+                self.font_preset,
+                self.text_size_class,
+            );
         }
 
-        ctx.set_zoom_factor(self.zoom_level);
+        // Apply display zoom only when it actually changed: set_zoom_factor
+        // is not free (it can invalidate glyph caches), and the value only
+        // moves on user input or state restore.
+        if self.last_applied_zoom_level != Some(self.zoom_level) {
+            ctx.set_zoom_factor(self.zoom_level);
+            self.last_applied_zoom_level = Some(self.zoom_level);
+        }
 
         // Disabling pixel-snapping lets glyphs render at their exact
         // sub-pixel position instead of each being individually rounded to
@@ -4775,7 +4841,8 @@ impl eframe::App for MarkdownApp {
         let mut toggle_outline = false;
         let mut toggle_explorer = false;
         let mut quit_app = false;
-        let mut zoom_delta: f32 = 0.0;
+        let mut zoom_factor_request: Option<f32> = None;
+        let mut zoom_reset = false;
         let mut go_back = false;
         let mut go_forward = false;
         let mut close_tab = false;
@@ -4789,37 +4856,37 @@ impl eframe::App for MarkdownApp {
         let mut close_search_kb = false;
         let mut keyboard_scroll_action: Option<KeyboardScrollAction> = None;
 
-        // Ctrl+/- zoom: applies to lightbox when open, document otherwise
+        // Ctrl+/- zoom: applies to lightbox when open, document otherwise.
+        // Steps are multiplicative (×1.25) like browsers and the lightbox.
         ctx.input(|i| {
             if i.modifiers.ctrl
                 && (i.key_pressed(egui::Key::Plus) || i.key_pressed(egui::Key::Equals))
             {
-                zoom_delta = 0.1;
+                zoom_factor_request = Some(ZOOM_STEP);
             }
             if i.modifiers.ctrl && i.key_pressed(egui::Key::Minus) {
-                zoom_delta = -0.1;
+                zoom_factor_request = Some(1.0 / ZOOM_STEP);
             }
             if i.modifiers.ctrl && i.key_pressed(egui::Key::Num0) {
-                if self.lightbox.is_some() {
-                    // Reset lightbox zoom
-                    zoom_delta = 0.0;
-                    if let Some(lb) = &mut self.lightbox {
-                        lb.zoom = 1.0;
-                    }
+                if let Some(lightbox) = &mut self.lightbox {
+                    // Reset lightbox zoom only; the document has its own reset.
+                    lightbox.zoom = 1.0;
                 } else {
-                    zoom_delta = 1.0 - self.zoom_level;
+                    zoom_reset = true;
                 }
             }
         });
 
         // Apply zoom to lightbox or document
-        if zoom_delta != 0.0 {
-            if let Some(lb) = &mut self.lightbox {
-                let factor = if zoom_delta > 0.0 { 1.25 } else { 1.0 / 1.25 };
-                lb.zoom = (lb.zoom * factor).clamp(0.1, 10.0);
+        if let Some(factor) = zoom_factor_request {
+            if let Some(lightbox) = &mut self.lightbox {
+                lightbox.zoom = (lightbox.zoom * factor).clamp(0.1, 10.0);
             } else {
-                self.zoom_level = (self.zoom_level + zoom_delta).clamp(0.5, 3.0);
+                self.zoom_level = zoomed(self.zoom_level, factor);
             }
+        }
+        if zoom_reset && self.lightbox.is_none() {
+            self.zoom_level = 1.0;
         }
 
         if self.lightbox.is_none() {
@@ -4887,15 +4954,12 @@ impl eframe::App for MarkdownApp {
                 if i.modifiers.ctrl && i.key_pressed(egui::Key::Q) {
                     quit_app = true;
                 }
-                // Ctrl + scroll wheel for zoom
-                if i.modifiers.ctrl && i.raw_scroll_delta.y != 0.0 {
-                    self.zoom_level = (self.zoom_level
-                        + if i.raw_scroll_delta.y > 0.0 {
-                            0.1
-                        } else {
-                            -0.1
-                        })
-                    .clamp(0.5, 3.0);
+                // Ctrl + scroll wheel / pinch to zoom (multiplicative, like
+                // browsers). The lightbox captures wheel input itself in
+                // raw_input_hook, so this only runs for the document.
+                let wheel_zoom_factor = i.zoom_delta();
+                if wheel_zoom_factor != 1.0 {
+                    self.zoom_level = zoomed(self.zoom_level, wheel_zoom_factor);
                 }
                 // F5: Toggle file watching
                 if i.key_pressed(egui::Key::F5) {
@@ -5273,6 +5337,106 @@ impl eframe::App for MarkdownApp {
 
                     ui.separator();
 
+                    // Markdown font presets live in an expandable submenu so
+                    // they don't stretch the View menu; the collapsed entry
+                    // shows the active choice. Missing preset faces degrade
+                    // to the app's own fallback chain.
+                    let fonts_menu =
+                        ui.menu_button(format!("Fonts: {}", self.font_preset.label()), |ui| {
+                            for preset in FontPreset::ALL {
+                                let active = self.font_preset == preset;
+                                let text = if active {
+                                    format!("✓ {}", preset.label())
+                                } else {
+                                    preset.label().to_owned()
+                                };
+                                let preset_btn = ui
+                                    .add(egui::Button::new(text))
+                                    .on_hover_text(preset.description());
+                                #[cfg(feature = "mcp")]
+                                self.mcp_bridge.register_widget(
+                                    &format!("Menu: View → Fonts → {}", preset.label()),
+                                    "button",
+                                    &preset_btn,
+                                    Some(if active { "on" } else { "off" }),
+                                );
+                                if preset_btn.clicked() {
+                                    if self.font_preset != preset {
+                                        self.font_preset = preset;
+                                        // Rebuild the font chains so the preset's
+                                        // faces lead them; set_fonts re-tessellates.
+                                        // Text size is shared, so switching presets
+                                        // never rescales the document. A family
+                                        // picked in the Font dialog outranks the
+                                        // preset's body stack, so it is carried
+                                        // through unchanged.
+                                        setup_fonts(
+                                            &self.egui_ctx,
+                                            self.selected_font_family.as_deref(),
+                                            preset,
+                                            self.text_size_class,
+                                        );
+                                        self.last_applied_font_config = Some((
+                                            self.selected_font_family.clone(),
+                                            preset,
+                                            self.text_size_class,
+                                        ));
+                                    }
+                                    ui.close();
+                                }
+                            }
+
+                            ui.separator();
+
+                            // Shared text-size classes: one scale for every
+                            // preset. Stays open so sizes can be compared by
+                            // clicking through them.
+                            for size in TextSizeClass::ALL {
+                                let size_active = self.text_size_class == size;
+                                let text = if size_active {
+                                    format!("✓ {}", size.label())
+                                } else {
+                                    size.label().to_owned()
+                                };
+                                let size_btn = ui
+                                    .add(egui::Button::new(text))
+                                    .on_hover_text("Base text size, shared by all font presets");
+                                #[cfg(feature = "mcp")]
+                                let size_id =
+                                    format!("Menu: View → Fonts → Size: {}", size.label());
+                                #[cfg(feature = "mcp")]
+                                self.mcp_bridge.register_widget(
+                                    &size_id,
+                                    "button",
+                                    &size_btn,
+                                    Some(if size_active { "on" } else { "off" }),
+                                );
+                                if size_btn.clicked() && self.text_size_class != size {
+                                    self.text_size_class = size;
+                                    setup_fonts(
+                                        &self.egui_ctx,
+                                        self.selected_font_family.as_deref(),
+                                        self.font_preset,
+                                        size,
+                                    );
+                                    self.last_applied_font_config = Some((
+                                        self.selected_font_family.clone(),
+                                        self.font_preset,
+                                        size,
+                                    ));
+                                }
+                            }
+                        });
+                    #[cfg(feature = "mcp")]
+                    self.mcp_bridge.register_widget(
+                        "Menu: View → Fonts",
+                        "button",
+                        &fonts_menu.response,
+                        Some(self.font_preset.label()),
+                    );
+
+                    ui.separator();
+
                     let zoom_in_btn = ui.add(egui::Button::new("Zoom In").shortcut_text("Ctrl++"));
                     #[cfg(feature = "mcp")]
                     self.mcp_bridge.register_widget(
@@ -5282,7 +5446,7 @@ impl eframe::App for MarkdownApp {
                         None,
                     );
                     if zoom_in_btn.clicked() {
-                        self.zoom_level = (self.zoom_level + 0.1).min(3.0);
+                        self.zoom_level = zoomed(self.zoom_level, ZOOM_STEP);
                         ui.close();
                     }
                     let zoom_out_btn =
@@ -5295,7 +5459,7 @@ impl eframe::App for MarkdownApp {
                         None,
                     );
                     if zoom_out_btn.clicked() {
-                        self.zoom_level = (self.zoom_level - 0.1).max(0.5);
+                        self.zoom_level = zoomed(self.zoom_level, 1.0 / ZOOM_STEP);
                         ui.close();
                     }
                     let reset_zoom_btn =
@@ -5586,6 +5750,74 @@ impl eframe::App for MarkdownApp {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// In-memory stand-in for eframe's key/value storage so persistence
+    /// roundtrips run through the same RON encode/decode path as the app.
+    struct MemoryStorage(HashMap<String, String>);
+
+    impl eframe::Storage for MemoryStorage {
+        fn get_string(&self, key: &str) -> Option<String> {
+            self.0.get(key).cloned()
+        }
+        fn set_string(&mut self, key: &str, value: String) {
+            self.0.insert(key.to_owned(), value);
+        }
+        fn flush(&mut self) {}
+    }
+
+    #[test]
+    fn font_preset_survives_a_persistence_roundtrip() {
+        let mut storage = MemoryStorage(HashMap::new());
+        let mut app_state = PersistedState::default();
+        app_state.font_preset = Some(FontPreset::Vscode);
+        app_state.text_size_class = Some(TextSizeClass::Large);
+        eframe::set_value(&mut storage, APP_KEY, &app_state);
+
+        let restored: PersistedState = eframe::get_value(&storage, APP_KEY).expect("state decodes");
+
+        assert_eq!(restored.font_preset, Some(FontPreset::Vscode));
+        assert_eq!(restored.text_size_class, Some(TextSizeClass::Large));
+
+        // Absent field (older state files) falls back to the default preset.
+        let legacy: PersistedState = eframe::get_value(
+            &MemoryStorage(HashMap::from([(
+                APP_KEY.to_owned(),
+                "(dark_mode: Some(true))".to_owned(),
+            )])),
+            APP_KEY,
+        )
+        .expect("legacy state decodes");
+        assert_eq!(legacy.font_preset, None);
+        assert_eq!(legacy.font_preset.unwrap_or_default(), FontPreset::Current);
+        assert_eq!(legacy.text_size_class, None);
+        assert_eq!(
+            legacy.text_size_class.unwrap_or_default(),
+            TextSizeClass::Normal
+        );
+    }
+
+    #[test]
+    fn document_zoom_steps_are_multiplicative_and_clamped() {
+        assert_eq!(zoomed(1.0, ZOOM_STEP), 1.25);
+        assert!((zoomed(1.25, 1.0 / ZOOM_STEP) - 1.0).abs() < 1e-6);
+
+        // Same bounds the additive path clamped to before.
+        assert_eq!(zoomed(2.9, ZOOM_STEP), ZOOM_MAX);
+        assert_eq!(zoomed(0.6, 1.0 / ZOOM_STEP), ZOOM_MIN);
+
+        // Neutral and degenerate factors are no-ops (egui reports 1.0 on
+        // frames without a zoom gesture; guards against divide-by-style bugs).
+        assert_eq!(zoomed(1.7, 1.0), 1.7);
+        assert_eq!(zoomed(1.7, 0.0), 1.7);
+        assert_eq!(zoomed(1.7, -2.0), 1.7);
+    }
+
+    #[test]
+    fn zoom_bounds_match_the_persisted_value_clamp() {
+        // PersistedState load clamps with the same constants.
+        let persisted_level = 7.5_f32.clamp(ZOOM_MIN, ZOOM_MAX);
+        assert_eq!(persisted_level, ZOOM_MAX);
+    }
 
     #[test]
     fn push_recent_dedupes_and_moves_to_front() {

--- a/src/system_fonts.rs
+++ b/src/system_fonts.rs
@@ -6,6 +6,218 @@ use fontique::{
     Blob, Collection, CollectionOptions, FamilyId, FontStyle, FontWeight, GenericFamily, Script,
     SourceCache, SourceKind,
 };
+use serde::{Deserialize, Serialize};
+
+/// Markdown font presets that emulate how popular markdown viewers pick fonts.
+///
+/// A preset reorders the app's font chains so the first installed face matches
+/// what the emulated viewer would show on Linux. CSS-generic keywords
+/// (`-apple-system`, `BlinkMacSystemFont`, `system-ui`, `ui-monospace`,
+/// `sans-serif`, `monospace`) have no literal family behind them, so they are
+/// transcribed to the concrete faces a Linux browser resolves them to:
+/// `system-ui`/UI aliases become GNOME's Adwaita Sans / Cantarell, and generic
+/// monospace becomes Noto Sans Mono / DejaVu Sans Mono. Anything still missing
+/// falls through to the app's own fallback chain, so Unicode/CJK coverage and
+/// bold rendering never regress when switching presets.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum FontPreset {
+    /// The app's own look: best installed general-purpose sans for body text,
+    /// egui's bundled monospace face for code.
+    #[default]
+    Current,
+    /// github.com rendered markdown (Primer `.markdown-body`): body
+    /// `"Mona Sans VF", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    /// "Noto Sans", Helvetica, Arial, sans-serif`; code `ui-monospace,
+    /// SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono",
+    /// monospace`.
+    Github,
+    /// VS Code markdown preview (`markdown.preview.fontFamily` default plus
+    /// the Linux `editor.fontFamily` default for code): body `-apple-system,
+    /// BlinkMacSystemFont, "Segoe WPC", "Segoe UI", system-ui, "Ubuntu",
+    /// "Droid Sans", sans-serif`; code `'Droid Sans Mono', monospace`.
+    Vscode,
+}
+
+impl FontPreset {
+    pub(crate) const ALL: [FontPreset; 3] =
+        [FontPreset::Current, FontPreset::Github, FontPreset::Vscode];
+
+    /// Menu label for this preset.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            FontPreset::Current => "Default",
+            FontPreset::Github => "GitHub",
+            FontPreset::Vscode => "VS Code",
+        }
+    }
+
+    /// One-line explanation of what the preset emulates, shown as menu hover text.
+    pub(crate) fn description(self) -> &'static str {
+        match self {
+            FontPreset::Current => {
+                "This app's default: best installed sans + bundled mono code font."
+            }
+            FontPreset::Github => {
+                "github.com style: Mona Sans / Segoe UI / Noto Sans body, SF Mono / Liberation Mono code."
+            }
+            FontPreset::Vscode => {
+                "VS Code preview style: Segoe UI / system UI body, Droid Sans Mono code."
+            }
+        }
+    }
+
+    /// `(body line-height, code line-height)` multipliers fed to the renderer.
+    /// GitHub: `.markdown-body{line-height:1.5}`, `pre{line-height:1.45}`.
+    /// VS Code preview default: `--markdown-line-height: 1.6`, code 1.357em.
+    pub(crate) fn line_heights(self) -> (f32, f32) {
+        match self {
+            FontPreset::Current => (1.5, 1.3),
+            FontPreset::Github => (1.5, 1.45),
+            FontPreset::Vscode => (1.6, 1.36),
+        }
+    }
+
+    /// Body families from the emulated viewer's CSS stack, in resolution
+    /// order. `None` keeps the app's own primary sans selection.
+    ///
+    /// Pure macOS keywords (`-apple-system`, `BlinkMacSystemFont`) are skipped.
+    /// `"Adwaita Sans"` directly follows `"Segoe UI"` because modern fontconfig
+    /// setups substitute Segoe UI with GNOME's Adwaita Sans, which is what
+    /// Linux browsers actually render for stacks asking for Segoe UI first.
+    fn body_families(self) -> Option<&'static [&'static str]> {
+        match self {
+            FontPreset::Current => None,
+            FontPreset::Github => Some(GITHUB_BODY_FAMILIES),
+            FontPreset::Vscode => Some(VSCODE_BODY_FAMILIES),
+        }
+    }
+
+    /// Code families from the emulated viewer's monospace stack, in resolution
+    /// order. Empty keeps egui's bundled monospace first.
+    fn mono_families(self) -> &'static [&'static str] {
+        match self {
+            // GitHub puts ui-monospace first; on Linux browsers that resolves
+            // through fontconfig's generic monospace alias before any of the
+            // named proprietary faces are reached, so the Linux defaults lead.
+            FontPreset::Github => GITHUB_MONO_FAMILIES,
+            // VS Code webviews always inject editor.fontFamily; its Linux
+            // default is 'Droid Sans Mono', monospace.
+            FontPreset::Vscode => VSCODE_MONO_FAMILIES,
+            FontPreset::Current => &[],
+        }
+    }
+}
+
+/// Discrete base text sizes shared by every font preset. Unlike the presets
+/// themselves — which only choose typefaces and line heights — the size class
+/// is one app-wide setting with a single shared default, so switching presets
+/// never changes the text size on its own.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum TextSizeClass {
+    Small,
+    #[default]
+    Normal,
+    Large,
+    ExtraLarge,
+    Huge,
+}
+
+impl TextSizeClass {
+    pub(crate) const ALL: [TextSizeClass; 5] = [
+        TextSizeClass::Small,
+        TextSizeClass::Normal,
+        TextSizeClass::Large,
+        TextSizeClass::ExtraLarge,
+        TextSizeClass::Huge,
+    ];
+
+    /// Menu label including the concrete pixel size.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            TextSizeClass::Small => "Small (14px)",
+            TextSizeClass::Normal => "Normal (16px)",
+            TextSizeClass::Large => "Large (18px)",
+            TextSizeClass::ExtraLarge => "Extra large (20px)",
+            TextSizeClass::Huge => "Huge (24px)",
+        }
+    }
+
+    /// Base body size in px. Headings and code cascade from this because the
+    /// renderer derives every document size from `TextStyle::Body`.
+    pub(crate) fn px(self) -> f32 {
+        match self {
+            TextSizeClass::Small => 14.0,
+            TextSizeClass::Normal => 16.0,
+            TextSizeClass::Large => 18.0,
+            TextSizeClass::ExtraLarge => 20.0,
+            TextSizeClass::Huge => 24.0,
+        }
+    }
+}
+
+/// Primer `.markdown-body` body stack without macOS-only aliases; the generic
+/// `sans-serif` tail is covered by the app's existing fallback chain.
+///
+/// GitHub prepends its open-source Mona Sans (primer/primitives#1332); it
+/// renders only where installed locally because GitHub ships no markdown
+/// webfont. `"Noto Sans Backtick Fix"` is intentionally skipped: it is a
+/// `local()`-only `@font-face` shim covering just U+60, not a real family.
+const GITHUB_BODY_FAMILIES: &[&str] = &[
+    "Mona Sans VF",
+    "Mona Sans",
+    "Segoe UI",
+    "Adwaita Sans", // fontconfig substitutes Segoe UI with Adwaita Sans on modern GNOME
+    "Noto Sans",
+    "Helvetica",
+    "Arial",
+];
+
+/// Primer `.markdown-body` code stack. Generic monospace leads because
+/// `ui-monospace` precedes every named face in the CSS and resolves on Linux.
+const GITHUB_MONO_FAMILIES: &[&str] = &[
+    "Noto Sans Mono",
+    "DejaVu Sans Mono",
+    "SFMono-Regular",
+    "SF Mono",
+    "Menlo",
+    "Consolas",
+    "Liberation Mono",
+];
+
+/// VS Code preview body stack without macOS-only aliases; `system-ui` is
+/// transcribed to its common desktop resolutions and `sans-serif` remains
+/// covered by the app's existing fallback chain.
+const VSCODE_BODY_FAMILIES: &[&str] = &[
+    "Segoe WPC",
+    "Segoe UI",
+    "Adwaita Sans", // system-ui on GNOME 47+
+    "Cantarell",    // system-ui on older GNOME releases
+    "Ubuntu",
+    "Droid Sans",
+];
+
+/// VS Code preview code stack: the Linux `editor.fontFamily` default followed
+/// by the generic monospace resolutions.
+const VSCODE_MONO_FAMILIES: &[&str] = &["Droid Sans Mono", "Noto Sans Mono", "DejaVu Sans Mono"];
+
+/// Apply the shared base text size class to the context styles. Headings and
+/// code cascade because the renderer derives document sizes from
+/// `TextStyle::Body`.
+fn apply_text_size_class(ctx: &egui::Context, size: TextSizeClass) {
+    let base = size.px();
+    ctx.style_mut(|style| {
+        use egui::{FontId, TextStyle};
+        style
+            .text_styles
+            .insert(TextStyle::Body, FontId::proportional(base));
+        style
+            .text_styles
+            .insert(TextStyle::Heading, FontId::proportional(base * 2.0));
+        style
+            .text_styles
+            .insert(TextStyle::Monospace, FontId::monospace(base - 2.0));
+    });
+}
 
 struct ScriptFallback {
     key: &'static str,
@@ -220,6 +432,7 @@ fn install_regular_fonts(
     definitions: &mut FontDefinitions,
     locale: Option<&str>,
     preferred_family: Option<&str>,
+    preset_body_families: Option<&'static [&'static str]>,
 ) -> Vec<InstalledFont> {
     let mut installed = Vec::new();
     let mut loaded_faces = HashSet::new();
@@ -252,6 +465,41 @@ fn install_regular_fonts(
             }
             None => {
                 log::warn!("Preferred font '{name}' not found; falling back to system default.");
+            }
+        }
+    }
+
+    // A preset's body families lead the primary sans chain when no user-picked
+    // family was installed (the picker's choice outranks the preset's emulated
+    // stack). Each stack name is tried in the emulated viewer's resolution
+    // order; a total miss falls through to the app's own auto-detection.
+    if installed.is_empty() {
+        if let Some(preset_families) = preset_body_families {
+            let family_ids: Vec<FamilyId> = preset_families
+                .iter()
+                .filter_map(|name| collection.family_id(name))
+                .collect();
+            if let Some(selected) = select_from_families(
+                collection,
+                source_cache,
+                &family_ids,
+                FontWeight::NORMAL,
+                "Aa",
+                false,
+            ) {
+                install_regular_font(
+                    definitions,
+                    &mut installed,
+                    &mut loaded_faces,
+                    "SystemSans",
+                    selected,
+                    "Aa",
+                    true,
+                );
+            } else {
+                log::warn!(
+                    "Preset body families {preset_families:?} had no usable regular face; falling back to system default."
+                );
             }
         }
     }
@@ -458,7 +706,47 @@ fn install_strong_font_family(
 /// back to today's auto-detect behavior. Returns the sorted, deduplicated
 /// list of installed family names so callers can build a font picker without
 /// scanning the font collection a second time.
-pub(crate) fn setup_fonts(ctx: &egui::Context, preferred_family: Option<&str>) -> Vec<String> {
+/// Lead the monospace chain with the preset's code face, keeping egui's
+/// bundled monospace (and any installed fallbacks) as fallback. Returns
+/// whether a preset face was installed.
+fn install_preset_mono_font(
+    collection: &mut Collection,
+    source_cache: &mut SourceCache,
+    definitions: &mut FontDefinitions,
+    mono_families: &'static [&'static str],
+) -> bool {
+    let family_ids: Vec<FamilyId> = mono_families
+        .iter()
+        .filter_map(|name| collection.family_id(name))
+        .collect();
+    let Some(selected) = select_from_families(
+        collection,
+        source_cache,
+        &family_ids,
+        FontWeight::NORMAL,
+        "{}",
+        false,
+    ) else {
+        log::warn!(
+            "Preset mono families {mono_families:?} had no usable face; keeping the bundled monospace."
+        );
+        return false;
+    };
+    definitions
+        .font_data
+        .insert("PresetMono".to_owned(), selected.data().into());
+    if let Some(family) = definitions.families.get_mut(&FontFamily::Monospace) {
+        family.insert(0, "PresetMono".to_owned());
+    }
+    true
+}
+
+pub(crate) fn setup_fonts(
+    ctx: &egui::Context,
+    preferred_family: Option<&str>,
+    preset: FontPreset,
+    size: TextSizeClass,
+) -> Vec<String> {
     let started = std::time::Instant::now();
     let mut collection = Collection::new(CollectionOptions::default());
     let mut family_names: Vec<String> = collection.family_names().map(str::to_owned).collect();
@@ -479,6 +767,7 @@ pub(crate) fn setup_fonts(ctx: &egui::Context, preferred_family: Option<&str>) -
         &mut definitions,
         locale.as_deref(),
         preferred_family,
+        preset.body_families(),
     );
     let bold_count = install_strong_font_family(
         &mut collection,
@@ -487,18 +776,30 @@ pub(crate) fn setup_fonts(ctx: &egui::Context, preferred_family: Option<&str>) -
         &installed,
         &defaults,
     );
+    let preset_mono_families = preset.mono_families();
+    let preset_mono = if preset_mono_families.is_empty() {
+        false
+    } else {
+        install_preset_mono_font(
+            &mut collection,
+            &mut source_cache,
+            &mut definitions,
+            preset_mono_families,
+        )
+    };
     if installed.is_empty() {
         log::warn!("No suitable system font fallbacks found; using egui defaults.");
     } else {
         log::info!(
             "Selected {} font faces from {} families for locale {:?} in {:.1} ms",
-            installed.len() + bold_count,
+            installed.len() + bold_count + usize::from(preset_mono),
             family_count,
             locale,
             started.elapsed().as_secs_f64() * 1000.0
         );
     }
     ctx.set_fonts(definitions);
+    apply_text_size_class(ctx, size);
     family_names
 }
 
@@ -566,6 +867,7 @@ mod tests {
             &mut definitions,
             None,
             Some("Definitely Not An Installed Font Name 12345"),
+            None,
         );
         assert!(
             installed.iter().any(|f| f.primary),
@@ -590,6 +892,7 @@ mod tests {
             &mut baseline_definitions,
             None,
             None,
+            None,
         );
         let Some(baseline_primary) = baseline.iter().find(|f| f.primary) else {
             return; // no system fonts available in this environment
@@ -603,6 +906,7 @@ mod tests {
             &mut definitions,
             None,
             Some(&family_name),
+            None,
         );
         let primary = installed
             .iter()
@@ -615,7 +919,12 @@ mod tests {
     #[ignore = "requires installed multilingual regular and bold fonts"]
     fn installed_fonts_cover_reported_scripts() {
         let context = egui::Context::default();
-        setup_fonts(&context, None);
+        setup_fonts(
+            &context,
+            None,
+            FontPreset::default(),
+            TextSizeClass::default(),
+        );
         context.begin_pass(Default::default());
         let regular = egui::FontId::proportional(16.0);
         let strong = egui::FontId::new(16.0, FontFamily::Name(STRONG_FONT_FAMILY.into()));
@@ -642,6 +951,77 @@ mod tests {
         assert!(
             missing_strong.is_empty(),
             "strong chain lacks {missing_strong:?}"
+        );
+    }
+
+    #[test]
+    fn preset_family_lists_follow_the_emulated_css_stacks() {
+        // GitHub (Primer .markdown-body) leads with its locally-installed Mona
+        // Sans, asks for Segoe UI before Noto Sans, and ends the named part of
+        // its body stack at Arial.
+        let github_body = FontPreset::Github
+            .body_families()
+            .expect("github body list");
+        assert_eq!(github_body[..3], ["Mona Sans VF", "Mona Sans", "Segoe UI"]);
+        assert!(github_body.contains(&"Noto Sans"));
+        assert_eq!(*github_body.last().expect("non-empty"), "Arial");
+
+        // VS Code preview lists Ubuntu and Droid Sans behind the system-ui
+        // resolutions.
+        let vscode_body = FontPreset::Vscode
+            .body_families()
+            .expect("vscode body list");
+        let ubuntu_pos = vscode_body
+            .iter()
+            .position(|f| *f == "Ubuntu")
+            .expect("ubuntu in vscode stack");
+        let adwaita_pos = vscode_body
+            .iter()
+            .position(|f| *f == "Adwaita Sans")
+            .expect("adwaita sans in vscode stack");
+        assert!(adwaita_pos < ubuntu_pos, "system-ui precedes Ubuntu");
+
+        // The default preset keeps the app's own sans selection.
+        assert_eq!(FontPreset::Current.body_families(), None);
+        assert!(FontPreset::Current.mono_families().is_empty());
+    }
+
+    #[test]
+    fn preset_mono_lists_lead_with_linux_generic_monospace_resolutions() {
+        assert_eq!(
+            FontPreset::Github.mono_families()[..2],
+            ["Noto Sans Mono", "DejaVu Sans Mono"]
+        );
+        assert_eq!(
+            FontPreset::Vscode.mono_families(),
+            ["Droid Sans Mono", "Noto Sans Mono", "DejaVu Sans Mono"]
+        );
+    }
+
+    #[test]
+    #[ignore = "requires installed system fonts"]
+    fn github_preset_resolves_its_body_stack_when_fonts_exist() {
+        let mut collection = Collection::new(CollectionOptions::default());
+        let mut source_cache = SourceCache::default();
+        let mut definitions = FontDefinitions::default();
+        let installed = install_regular_fonts(
+            &mut collection,
+            &mut source_cache,
+            &mut definitions,
+            None,
+            None,
+            FontPreset::Github.body_families(),
+        );
+        let Some(primary) = installed.iter().find(|f| f.primary) else {
+            return; // no system fonts available in this environment
+        };
+        let stack = FontPreset::Github
+            .body_families()
+            .expect("github body list");
+        assert!(
+            stack.contains(&primary.selected.family.as_str()),
+            "preset lead {:?} must come from the emulated stack",
+            primary.selected.family
         );
     }
 }


### PR DESCRIPTION
Resumes the parked `feature/font-presets` branch (August 2023-era work, 6 commits) by porting it onto the post-0.2.0 font stack. Complements #119: that PR added *arbitrary family* selection; this adds *curated looks* — and the two now compose.

## What the feature is

**View → Fonts ▸** offers three markdown-viewer emulations plus a shared base text size, both persisted:

| preset | body | code | line heights |
|---|---|---|---|
| Default | the app's own sans lead | egui bundled mono | 1.5 / 1.3 |
| GitHub | Mona Sans VF / Mona Sans / Segoe UI / Adwaita Sans / Noto Sans / Helvetica / Arial | Noto Sans Mono / DejaVu Sans Mono lead | 1.5 / 1.45 |
| VS Code | Segoe WPC / Segoe UI / Adwaita Sans / Cantarell / Ubuntu / Droid Sans | Droid Sans Mono / Noto Sans Mono / DejaVu Sans Mono | 1.6 / 1.36 |

The stacks are research data, transcribed from the emulated viewers' real CSS: macOS-only aliases dropped, `system-ui` resolved to its Linux desktop answers (Adwaita Sans / Cantarell), generic monospace to its Linux faces. Missing faces degrade to the existing fallback chain — Unicode/CJK coverage and bold rendering never regress when switching. Text sizes are deliberately **not** a preset property: one shared class (Small 14 → Huge 24) so switching presets never rescales the document.

## Why this is a port, not a rebase

The branch was written against **fontdb**, which the 0.2.0 Fontique rework removed from `system_fonts.rs` — every font-enumeration function it used no longer exists. The preset install layer is rewritten against `Collection`/`SourceCache` following the pattern #119 established for picked families:

- `install_regular_fonts` gains `preset_body_families`: the preset stack leads the primary sans chain **only when no user-picked family installed** (the picker's explicit choice outranks the preset's emulated stack), falling back to auto-detection on a total miss;
- new `install_preset_mono_font` leads the monospace chain with the preset's code faces, keeping egui's bundled fonts as fallback;
- `setup_fonts` composes everything: `(ctx, preferred_family, preset, size_class) -> Vec<String>`, with `apply_text_size_class` at the tail.

## Interaction with #119's picker

Composition rule, encoded in the lead order: **a family picked in the Font dialog outranks the preset's body stack** — switching presets carries the picked family through unchanged. The menu handlers update the last-applied gate inline, so the font scan runs once per real change, never twice.

Rides along from the branch: the zoom refactor (multiplicative ×1.25 steps shared by keyboard, menu, and Ctrl+wheel through one `zoomed()` helper, with a `last_applied_zoom_level` gate around `set_zoom_factor`), and the branch's recorded lesson about `Context::set_fonts` silently skipping byte-identical definitions — which is why presets differentiate themselves by line heights, not family resolution alone.

## Verified

- application suite **76 passed** (3 new tests: preset stack contents, mono stack order, and an `#[ignore]`d GitHub-stack resolution test for font-installed machines — same pattern as the existing font tests);
- fmt clean, `clippy -- -D warnings` clean, workspace sync OK.

One design note for review: switching presets **preserves** a picked family rather than resetting it — the picker UI always shows the current family, so the override stays visible. If the intended semantics are "a preset resets the family", that's a two-line change in the menu handler.